### PR TITLE
Proto decode shall not panic

### DIFF
--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -85,45 +85,6 @@ impl TryFrom<models::PolicySet> for api::PolicySet {
     }
 }
 
-#[expect(clippy::use_self, reason = "readability")]
-impl From<&api::ValidationMode> for models::ValidationMode {
-    fn from(v: &api::ValidationMode) -> Self {
-        match v {
-            api::ValidationMode::Strict => models::ValidationMode::Strict,
-            #[cfg(feature = "permissive-validate")]
-            api::ValidationMode::Permissive => models::ValidationMode::Permissive,
-            #[cfg(feature = "partial-validate")]
-            api::ValidationMode::Partial => models::ValidationMode::Partial,
-        }
-    }
-}
-
-/// Error when a protobuf message specifies a [`ValidationMode`](api::ValidationMode)
-/// that requires a feature not enabled in this build
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-pub struct ValidationModeError(String);
-
-#[expect(clippy::use_self, reason = "readability")]
-impl TryFrom<&models::ValidationMode> for api::ValidationMode {
-    type Error = ValidationModeError;
-    fn try_from(v: &models::ValidationMode) -> Result<Self, Self::Error> {
-        match v {
-            models::ValidationMode::Strict => Ok(api::ValidationMode::Strict),
-            #[cfg(feature = "permissive-validate")]
-            models::ValidationMode::Permissive => Ok(api::ValidationMode::Permissive),
-            #[cfg(not(feature = "permissive-validate"))]
-            models::ValidationMode::Permissive => Err(
-                ValidationModeError("protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build".to_string())),
-            #[cfg(feature = "partial-validate")]
-            models::ValidationMode::Partial => Ok(api::ValidationMode::Partial),
-            #[cfg(not(feature = "partial-validate"))]
-            models::ValidationMode::Partial => Err(
-                ValidationModeError("protobuf specifies partial validation, but `partial-validate` feature not enabled in this build".to_string())),
-        }
-    }
-}
-
 /// Macro that implements `traits::Protobuf` for cases where `From<>` and `TryFrom<>`
 /// conversions exist between the api type `$api` and the protobuf model type `$model`
 macro_rules! standard_protobuf_impl {
@@ -398,16 +359,6 @@ mod test {
             let _ = crate::Request::decode(*input);
             let _ = crate::PolicySet::decode(*input);
         }
-    }
-
-    #[test]
-    fn validation_mode_strict_roundtrip() {
-        use crate::proto::models;
-        let strict = crate::ValidationMode::Strict;
-        let proto = models::ValidationMode::from(&strict);
-        assert_matches!(proto, models::ValidationMode::Strict);
-        let back = crate::ValidationMode::try_from(&proto).unwrap();
-        assert_matches!(back, crate::ValidationMode::Strict);
     }
 
     #[test]

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -15,11 +15,11 @@
  */
 
 use super::super::api;
-use super::{ast::ProtoToAstError, models, traits};
+use super::{ast::ProtobufConversionError, models, traits};
 
 /// Macro that implements `From<A>` and `TryFrom<B>` for types where
 /// one conversion direction is infallible, the other is not. This is typically the case where
-/// the API type converts to  protobuf models without failing, but converting the protobuf model
+/// the API type converts to protobuf models without failing, but converting the protobuf model
 /// to the API type requires additional checks.
 macro_rules! fallible_conversions {
     ( $A:ty, $A_expr:expr, $B:ty ) => {
@@ -30,7 +30,7 @@ macro_rules! fallible_conversions {
         }
 
         impl TryFrom<$B> for $A {
-            type Error = ProtoToAstError;
+            type Error = ProtobufConversionError;
             fn try_from(v: $B) -> Result<$A, Self::Error> {
                 Ok($A_expr(v.try_into()?))
             }
@@ -58,7 +58,7 @@ impl From<&api::Template> for models::TemplateBody {
 }
 
 impl TryFrom<models::TemplateBody> for api::Template {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
         Ok(Self::from_ast(v.try_into()?))
     }
@@ -77,10 +77,11 @@ impl From<&api::PolicySet> for models::PolicySet {
 }
 
 impl TryFrom<models::PolicySet> for api::PolicySet {
-    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
         let ast: cedar_policy_core::ast::PolicySet = v.try_into()?;
-        Ok(Self::from_ast(ast)?)
+        Self::from_ast(ast)
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}")))
     }
 }
 
@@ -112,11 +113,13 @@ impl TryFrom<&models::ValidationMode> for api::ValidationMode {
             #[cfg(feature = "permissive-validate")]
             models::ValidationMode::Permissive => Ok(api::ValidationMode::Permissive),
             #[cfg(not(feature = "permissive-validate"))]
-            models::ValidationMode::Permissive => Err(ValidationModeError("protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build".to_string())),
+            models::ValidationMode::Permissive => Err(
+                ValidationModeError("protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build".to_string())),
             #[cfg(feature = "partial-validate")]
             models::ValidationMode::Partial => Ok(api::ValidationMode::Partial),
             #[cfg(not(feature = "partial-validate"))]
-            models::ValidationMode::Partial => Err(ValidationModeError("protobuf specifies partial validation, but `partial-validate` feature not enabled in this build".to_string())),
+            models::ValidationMode::Partial => Err(
+                ValidationModeError("protobuf specifies partial validation, but `partial-validate` feature not enabled in this build".to_string())),
         }
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -15,12 +15,13 @@
  */
 
 use super::super::api;
-use super::{models, traits};
+use super::{ast::ProtoToAstError, models, traits};
 
-/// Macro that implements From<> both ways for cases where the `A` type is a
-/// simple wrapper around a different type `C` which already has From<>
-/// conversions both ways with `B`
-macro_rules! standard_conversions {
+/// Macro that implements `From<A>` and `TryFrom<B>` for types where
+/// one conversion direction is infallible, the other is not. This is typically the case where
+/// the API type converts to  protobuf models without failing, but converting the protobuf model
+/// to the API type requires additional checks.
+macro_rules! fallible_conversions {
     ( $A:ty, $A_expr:expr, $B:ty ) => {
         impl From<&$A> for $B {
             fn from(v: &$A) -> $B {
@@ -28,24 +29,25 @@ macro_rules! standard_conversions {
             }
         }
 
-        impl From<$B> for $A {
-            fn from(v: $B) -> $A {
-                $A_expr(v.into())
+        impl TryFrom<$B> for $A {
+            type Error = ProtoToAstError;
+            fn try_from(v: $B) -> Result<$A, Self::Error> {
+                Ok($A_expr(v.try_into()?))
             }
         }
     };
 }
 
-// standard conversions
+// fallible conversions (encode infallible, decode fallible)
 
-standard_conversions!(api::Entity, api::Entity, models::Entity);
-standard_conversions!(api::EntityUid, api::EntityUid, models::EntityUid);
-standard_conversions!(api::Entities, api::Entities, models::Entities);
-standard_conversions!(api::Schema, api::Schema, models::Schema);
-standard_conversions!(api::EntityTypeName, api::EntityTypeName, models::Name);
-standard_conversions!(api::EntityNamespace, api::EntityNamespace, models::Name);
-standard_conversions!(api::Expression, api::Expression, models::Expr);
-standard_conversions!(api::Request, api::Request, models::Request);
+fallible_conversions!(api::Entity, api::Entity, models::Entity);
+fallible_conversions!(api::EntityUid, api::EntityUid, models::EntityUid);
+fallible_conversions!(api::Entities, api::Entities, models::Entities);
+fallible_conversions!(api::Schema, api::Schema, models::Schema);
+fallible_conversions!(api::EntityTypeName, api::EntityTypeName, models::Name);
+fallible_conversions!(api::EntityNamespace, api::EntityNamespace, models::Name);
+fallible_conversions!(api::Expression, api::Expression, models::Expr);
+fallible_conversions!(api::Request, api::Request, models::Request);
 
 // nonstandard conversions
 
@@ -55,9 +57,10 @@ impl From<&api::Template> for models::TemplateBody {
     }
 }
 
-impl From<models::TemplateBody> for api::Template {
-    fn from(v: models::TemplateBody) -> Self {
-        Self::from_ast(v.into())
+impl TryFrom<models::TemplateBody> for api::Template {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
+        Ok(Self::from_ast(v.try_into()?))
     }
 }
 
@@ -74,13 +77,10 @@ impl From<&api::PolicySet> for models::PolicySet {
 }
 
 impl TryFrom<models::PolicySet> for api::PolicySet {
-    type Error = api::PolicySetError;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
-        #[expect(clippy::expect_used, reason = "experimental feature")]
-        Self::from_ast(
-            v.try_into()
-                .expect("proto-encoded policy set should be a valid policy set"),
-        )
+        let ast: cedar_policy_core::ast::PolicySet = v.try_into()?;
+        Ok(Self::from_ast(ast)?)
     }
 }
 
@@ -97,33 +97,40 @@ impl From<&api::ValidationMode> for models::ValidationMode {
     }
 }
 
+/// Error when a protobuf message specifies a [`ValidationMode`](api::ValidationMode)
+/// that requires a feature not enabled in this build
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+pub struct ValidationModeError(String);
+
 #[expect(clippy::use_self, reason = "readability")]
-impl From<&models::ValidationMode> for api::ValidationMode {
-    fn from(v: &models::ValidationMode) -> Self {
+impl TryFrom<&models::ValidationMode> for api::ValidationMode {
+    type Error = ValidationModeError;
+    fn try_from(v: &models::ValidationMode) -> Result<Self, Self::Error> {
         match v {
-            models::ValidationMode::Strict => api::ValidationMode::Strict,
+            models::ValidationMode::Strict => Ok(api::ValidationMode::Strict),
             #[cfg(feature = "permissive-validate")]
-            models::ValidationMode::Permissive => api::ValidationMode::Permissive,
+            models::ValidationMode::Permissive => Ok(api::ValidationMode::Permissive),
             #[cfg(not(feature = "permissive-validate"))]
-            models::ValidationMode::Permissive => panic!("Protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build"),
+            models::ValidationMode::Permissive => Err(ValidationModeError("protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build".to_string())),
             #[cfg(feature = "partial-validate")]
-            models::ValidationMode::Partial => api::ValidationMode::Partial,
+            models::ValidationMode::Partial => Ok(api::ValidationMode::Partial),
             #[cfg(not(feature = "partial-validate"))]
-            models::ValidationMode::Partial => panic!("Protobuf specifies partial validation, but `partial-validate` feature not enabled in this build"),
+            models::ValidationMode::Partial => Err(ValidationModeError("protobuf specifies partial validation, but `partial-validate` feature not enabled in this build".to_string())),
         }
     }
 }
 
-/// Macro that implements `traits::Protobuf` for cases where From<> conversions
-/// exist both ways between the api type `$api` and the protobuf model type `$model`
+/// Macro that implements `traits::Protobuf` for cases where From<> and TryFrom<>
+/// conversions exist between the api type `$api` and the protobuf model type `$model`
 macro_rules! standard_protobuf_impl {
     ( $api:ty, $model:ty ) => {
         impl traits::Protobuf for $api {
             fn encode(&self) -> Vec<u8> {
                 traits::encode_to_vec::<$model>(self)
             }
-            fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
-                traits::decode::<$model, _>(buf)
+            fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+                traits::try_decode::<$model, _, _>(buf)
             }
         }
     };
@@ -146,10 +153,8 @@ impl traits::Protobuf for api::PolicySet {
     fn encode(&self) -> Vec<u8> {
         traits::encode_to_vec::<models::PolicySet>(self)
     }
-    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
-        #[expect(clippy::expect_used, reason = "experimental feature")]
-        Ok(traits::try_decode::<models::PolicySet, _, Self>(buf)?
-            .expect("protobuf-encoded policy set should be a valid policy set"))
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+        traits::try_decode::<models::PolicySet, _, Self>(buf)
     }
 }
 
@@ -357,5 +362,38 @@ mod test {
             permit(principal == ?principal, action, resource);
             "#,
         );
+    }
+
+    /// Decoding arbitrary bytes must never panic — it should return `Err`.
+    #[test]
+    fn decode_random_bytes_does_not_panic() {
+        use crate::proto::traits::Protobuf;
+
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"\x00",
+            b"\xff\xff\xff\xff",
+            b"not a protobuf",
+            &[0u8; 1024],
+            &{
+                let mut v = Vec::new();
+                for i in 0u8..=255 {
+                    v.push(i);
+                }
+                v
+            },
+        ];
+
+        for input in inputs {
+            let _ = crate::Entity::decode(*input);
+            let _ = crate::Entities::decode(*input);
+            let _ = crate::Schema::decode(*input);
+            let _ = crate::EntityTypeName::decode(*input);
+            let _ = crate::EntityNamespace::decode(*input);
+            let _ = crate::Template::decode(*input);
+            let _ = crate::Expression::decode(*input);
+            let _ = crate::Request::decode(*input);
+            let _ = crate::PolicySet::decode(*input);
+        }
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -163,9 +163,9 @@ impl traits::Protobuf for api::PolicySet {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, str::FromStr};
-
+    use cool_asserts::assert_matches;
     use prost::Message as _;
+    use std::{collections::HashMap, str::FromStr};
 
     /// Performs a series of conversions: API -> Protobuf model -> Protobuf bytes -> Protobuf model -> API.
     /// Checks that the input API policy set is equal to the converted policy set.
@@ -398,5 +398,39 @@ mod test {
             let _ = crate::Request::decode(*input);
             let _ = crate::PolicySet::decode(*input);
         }
+    }
+
+    #[test]
+    fn validation_mode_strict_roundtrip() {
+        use crate::proto::models;
+        let strict = crate::ValidationMode::Strict;
+        let proto = models::ValidationMode::from(&strict);
+        assert_matches!(proto, models::ValidationMode::Strict);
+        let back = crate::ValidationMode::try_from(&proto).unwrap();
+        assert_matches!(back, crate::ValidationMode::Strict);
+    }
+
+    #[test]
+    fn decode_conversion_error_path() {
+        use crate::proto::traits::Protobuf;
+        // An Entity with a uid whose type name is empty string triggers
+        // ProtobufConversionError, exercising the DecodeError::Conversion path.
+        let model = crate::proto::models::Entity {
+            uid: Some(crate::proto::models::EntityUid {
+                ty: Some(crate::proto::models::Name {
+                    id: String::new(), // invalid: empty identifier
+                    path: vec![],
+                }),
+                eid: "x".to_string(),
+            }),
+            attrs: Default::default(),
+            ancestors: vec![],
+            tags: Default::default(),
+        };
+        let buf = prost::Message::encode_to_vec(&model);
+        assert_matches!(
+            crate::Entity::decode(&buf[..]),
+            Err(crate::proto::traits::DecodeError::Conversion(_))
+        );
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -124,7 +124,7 @@ impl TryFrom<&models::ValidationMode> for api::ValidationMode {
     }
 }
 
-/// Macro that implements `traits::Protobuf` for cases where From<> and TryFrom<>
+/// Macro that implements `traits::Protobuf` for cases where `From<>` and `TryFrom<>`
 /// conversions exist between the api type `$api` and the protobuf model type `$model`
 macro_rules! standard_protobuf_impl {
     ( $api:ty, $model:ty ) => {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -811,6 +811,7 @@ impl From<&ast::Context> for models::Expr {
 #[cfg(test)]
 mod test {
     use super::*;
+    use cool_asserts::assert_matches;
 
     #[test]
     fn name_and_slot_roundtrip() {
@@ -1054,5 +1055,317 @@ mod test {
         assert_eq!(request.principal().uid(), request_rt.principal().uid());
         assert_eq!(request.action().uid(), request_rt.action().uid());
         assert_eq!(request.resource().uid(), request_rt.resource().uid());
+    }
+
+    #[test]
+    fn name_try_from_invalid_basename() {
+        let bad = models::Name {
+            id: "".to_string(),
+            path: vec![],
+        };
+        assert_matches!(
+            ast::InternalName::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("invalid basename")
+        );
+    }
+
+    #[test]
+    fn name_try_from_invalid_path_component() {
+        let bad = models::Name {
+            id: "A".to_string(),
+            path: vec!["".to_string()],
+        };
+        assert_matches!(
+            ast::InternalName::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("invalid path component")
+        );
+    }
+
+    #[test]
+    fn test_when_missing_ty() {
+        // models missing type field don't convert
+        let bad = models::EntityUid {
+            ty: None,
+            eid: "foo".to_string(),
+        };
+        assert_matches!(
+            ast::EntityUID::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "ty"
+        );
+        let bad = models::EntityUid {
+            ty: None,
+            eid: "foo".to_string(),
+        };
+        assert_matches!(
+            ast::EntityUIDEntry::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "ty"
+        );
+    }
+
+    #[test]
+    fn entity_try_from_missing_uid() {
+        let bad = models::Entity {
+            uid: None,
+            attrs: Default::default(),
+            ancestors: vec![],
+            tags: Default::default(),
+        };
+        assert_matches!(
+            ast::Entity::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "uid"
+        );
+    }
+
+    #[test]
+    fn test_when_missing_expr_kind() {
+        // Entity with invalid attr expr
+        let bad = models::Entity {
+            uid: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "A".to_string(),
+                    path: vec![],
+                }),
+                eid: "x".to_string(),
+            }),
+            attrs: [("k".to_string(), models::Expr { expr_kind: None })]
+                .into_iter()
+                .collect(),
+            ancestors: vec![],
+            tags: Default::default(),
+        };
+        assert_matches!(
+            ast::Entity::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "expr_kind"
+        );
+
+        // Entity with invalid tag expr
+        let bad = models::Entity {
+            uid: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "A".to_string(),
+                    path: vec![],
+                }),
+                eid: "x".to_string(),
+            }),
+            attrs: Default::default(),
+            ancestors: vec![],
+            tags: [("t".to_string(), models::Expr { expr_kind: None })]
+                .into_iter()
+                .collect(),
+        };
+        assert_matches!(
+            ast::Entity::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "expr_kind"
+        );
+
+        // Bare Expr missing expr_kind
+        assert_matches!(
+            ast::Expr::try_from(models::Expr { expr_kind: None }),
+            Err(ProtobufConversionError::MissingField(f)) if f == "expr_kind"
+        );
+    }
+
+    #[test]
+    fn expr_try_from_missing_required_fields() {
+        // The models in each test case are missing a field, the field name is the string in the test case
+        let cases: Vec<(models::Expr, &str)> = vec![
+            (models::Expr { expr_kind: None }, "expr_kind"),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::If(Box::new(models::expr::If {
+                        test_expr: None,
+                        then_expr: None,
+                        else_expr: None,
+                    }))),
+                },
+                "test_expr",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::And(Box::new(models::expr::And {
+                        left: None,
+                        right: None,
+                    }))),
+                },
+                "left",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::Or(Box::new(models::expr::Or {
+                        left: None,
+                        right: None,
+                    }))),
+                },
+                "left",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::UApp(Box::new(
+                        models::expr::UnaryApp {
+                            op: models::expr::unary_app::Op::Not.into(),
+                            expr: None,
+                        },
+                    ))),
+                },
+                "expr",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::BApp(Box::new(
+                        models::expr::BinaryApp {
+                            op: models::expr::binary_app::Op::Eq.into(),
+                            left: None,
+                            right: None,
+                        },
+                    ))),
+                },
+                "left",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::ExtApp(
+                        models::expr::ExtensionFunctionApp {
+                            fn_name: None,
+                            args: vec![],
+                        },
+                    )),
+                },
+                "fn_name",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::GetAttr(Box::new(
+                        models::expr::GetAttr {
+                            expr: None,
+                            attr: "a".to_string(),
+                        },
+                    ))),
+                },
+                "expr",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::HasAttr(Box::new(
+                        models::expr::HasAttr {
+                            expr: None,
+                            attr: "a".to_string(),
+                        },
+                    ))),
+                },
+                "expr",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::Like(Box::new(models::expr::Like {
+                        expr: None,
+                        pattern: vec![],
+                    }))),
+                },
+                "expr",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::Is(Box::new(models::expr::Is {
+                        expr: None,
+                        entity_type: None,
+                    }))),
+                },
+                "expr",
+            ),
+        ];
+
+        for (bad, expected_field) in cases {
+            assert_matches!(
+                ast::Expr::try_from(bad),
+                Err(ProtobufConversionError::MissingField(f)) if f == expected_field
+            );
+        }
+    }
+
+    #[test]
+    fn expr_try_from_invalid_enum_values() {
+        let cases: Vec<(models::Expr, &str)> = vec![
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::Var(999)),
+                },
+                "invalid var",
+            ),
+            (
+                models::Expr {
+                    expr_kind: Some(models::expr::ExprKind::Slot(999)),
+                },
+                "invalid slot",
+            ),
+        ];
+
+        for (bad, expected_msg) in cases {
+            assert_matches!(
+                ast::Expr::try_from(bad),
+                Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains(expected_msg)
+            );
+        }
+    }
+
+    #[test]
+    fn literal_try_from_missing_lit() {
+        assert_matches!(
+            ast::Literal::try_from(models::expr::Literal { lit: None }),
+            Err(ProtobufConversionError::MissingField(f)) if f == "lit"
+        );
+    }
+
+    #[test]
+    fn pattern_elem_try_from_missing_data() {
+        assert_matches!(
+            ast::PatternElem::try_from(models::expr::like::PatternElem { data: None }),
+            Err(ProtobufConversionError::MissingField(f)) if f == "data"
+        );
+    }
+
+    #[test]
+    fn pattern_elem_try_from_empty_char() {
+        let bad = models::expr::like::PatternElem {
+            data: Some(models::expr::like::pattern_elem::Data::C(String::new())),
+        };
+        assert_matches!(
+            ast::PatternElem::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("empty char")
+        );
+    }
+
+    #[test]
+    fn request_try_from_missing_principal() {
+        let bad = models::Request {
+            principal: None,
+            action: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "Action".to_string(),
+                    path: vec![],
+                }),
+                eid: "a".to_string(),
+            }),
+            resource: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "R".to_string(),
+                    path: vec![],
+                }),
+                eid: "r".to_string(),
+            }),
+            context: Default::default(),
+        };
+        assert_matches!(
+            ast::Request::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "principal"
+        );
+    }
+
+    #[test]
+    fn context_try_from_missing_expr_kind() {
+        let bad = models::Expr { expr_kind: None };
+        assert_matches!(
+            ast::Context::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "expr_kind"
+        );
     }
 }

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -23,32 +23,38 @@ use cedar_policy_core::{
 use smol_str::ToSmolStr;
 use std::{collections::HashSet, sync::Arc};
 
-/// Error converting a protobuf model type into an AST type.
+/// Error converting a protobuf model type into a Cedar type.
 ///
 /// This indicates the protobuf message was well-formed at the wire level but
 /// contained semantically invalid data (e.g. missing required fields, invalid
 /// identifiers, unsupported features).
 #[derive(Debug, thiserror::Error)]
-#[error("error converting protobuf to AST: {0}")]
-pub struct ProtoToAstError(pub(crate) String);
+pub enum ProtobufConversionError {
+    /// A required protobuf field was absent
+    #[error("missing required field `{0}`")]
+    MissingField(String),
+    /// A field was present but its value was semantically invalid
+    #[error("{0}")]
+    InvalidValue(String),
+}
 
-impl ProtoToAstError {
+impl ProtobufConversionError {
     pub(crate) fn missing(field: &str) -> Self {
-        Self(format!("missing required field: `{field}`"))
+        Self::MissingField(field.to_string())
     }
 }
 
 impl TryFrom<models::Name> for ast::InternalName {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Name) -> Result<Self, Self::Error> {
         let basename = ast::Id::from_normalized_str(&v.id)
-            .map_err(|e| ProtoToAstError(format!("invalid basename `{}`: {e}", v.id)))?;
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid basename `{}`: {e}", v.id)))?;
         let path = v
             .path
             .into_iter()
             .map(|id| {
                 ast::Id::from_normalized_str(&id)
-                    .map_err(|e| ProtoToAstError(format!("invalid path component `{id}`: {e}")))
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid path component `{id}`: {e}")))
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(ast::InternalName::new(basename, path, None))
@@ -56,15 +62,15 @@ impl TryFrom<models::Name> for ast::InternalName {
 }
 
 impl TryFrom<models::Name> for ast::Name {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Name) -> Result<Self, Self::Error> {
         ast::Name::try_from(ast::InternalName::try_from(v)?)
-            .map_err(|e| ProtoToAstError(format!("invalid name: {e}")))
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid name: {e}")))
     }
 }
 
 impl TryFrom<models::Name> for ast::EntityType {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Name) -> Result<Self, Self::Error> {
         Ok(ast::EntityType::from(ast::Name::try_from(v)?))
     }
@@ -95,10 +101,10 @@ impl From<&ast::EntityType> for models::Name {
 }
 
 impl TryFrom<models::EntityUid> for ast::EntityUID {
-    type Error = ProtoToAstError;
-    fn try_from(v: models::EntityUid) -> Result<Self, ProtoToAstError> {
+    type Error = ProtobufConversionError;
+    fn try_from(v: models::EntityUid) -> Result<Self, ProtobufConversionError> {
         Ok(Self::from_components(
-            ast::EntityType::try_from(v.ty.ok_or_else(|| ProtoToAstError::missing("ty"))?)?,
+            ast::EntityType::try_from(v.ty.ok_or_else(|| ProtobufConversionError::missing("ty"))?)?,
             ast::Eid::new(v.eid),
             None,
         ))
@@ -115,7 +121,7 @@ impl From<&ast::EntityUID> for models::EntityUid {
 }
 
 impl TryFrom<models::EntityUid> for ast::EntityUIDEntry {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::EntityUid) -> Result<Self, Self::Error> {
         Ok(ast::EntityUIDEntry::known(
             ast::EntityUID::try_from(v)?,
@@ -139,7 +145,7 @@ impl From<&ast::EntityUIDEntry> for models::EntityUid {
 }
 
 impl TryFrom<models::Entity> for ast::Entity {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Entity) -> Result<Self, Self::Error> {
         let eval = RestrictedEvaluator::new(Extensions::none());
 
@@ -149,14 +155,14 @@ impl TryFrom<models::Entity> for ast::Entity {
             .map(|(key, value)| {
                 let expr = ast::Expr::try_from(value)?;
                 let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
-                    ProtoToAstError(format!("invalid restricted expr in attr `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!("invalid restricted expr in attr `{key}`: {e}"))
                 })?;
                 let pval = eval.partial_interpret(restricted).map_err(|e| {
-                    ProtoToAstError(format!("error interpreting attr `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!("error interpreting attr `{key}`: {e}"))
                 })?;
                 Ok((key.into(), pval))
             })
-            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
         let ancestors = v
             .ancestors
@@ -170,17 +176,17 @@ impl TryFrom<models::Entity> for ast::Entity {
             .map(|(key, value)| {
                 let expr = ast::Expr::try_from(value)?;
                 let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
-                    ProtoToAstError(format!("invalid restricted expr in tag `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!("invalid restricted expr in tag `{key}`: {e}"))
                 })?;
                 let pval = eval
                     .partial_interpret(restricted)
-                    .map_err(|e| ProtoToAstError(format!("error interpreting tag `{key}`: {e}")))?;
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("error interpreting tag `{key}`: {e}")))?;
                 Ok((key.into(), pval))
             })
-            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
         Ok(Self::new_with_attr_partial_value(
-            ast::EntityUID::try_from(v.uid.ok_or_else(|| ProtoToAstError::missing("uid"))?)?,
+            ast::EntityUID::try_from(v.uid.ok_or_else(|| ProtobufConversionError::missing("uid"))?)?,
             attrs,
             HashSet::new(),
             ancestors,
@@ -223,37 +229,37 @@ impl From<&Arc<ast::Entity>> for models::Entity {
 }
 
 impl TryFrom<models::Expr> for ast::Expr {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Expr) -> Result<Self, Self::Error> {
         let kind = v
             .expr_kind
-            .ok_or_else(|| ProtoToAstError::missing("expr_kind"))?;
+            .ok_or_else(|| ProtobufConversionError::missing("expr_kind"))?;
 
         match kind {
             models::expr::ExprKind::Lit(lit) => Ok(ast::Expr::val(ast::Literal::try_from(lit)?)),
 
             models::expr::ExprKind::Var(var) => {
                 let pvar = models::expr::Var::try_from(var)
-                    .map_err(|e| ProtoToAstError(format!("invalid var: {e}")))?;
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid var: {e}")))?;
                 Ok(ast::Expr::var(ast::Var::from(pvar)))
             }
 
             models::expr::ExprKind::Slot(slot) => {
                 let pslot = models::SlotId::try_from(slot)
-                    .map_err(|e| ProtoToAstError(format!("invalid slot: {e}")))?;
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid slot: {e}")))?;
                 Ok(ast::Expr::slot(ast::SlotId::from(pslot)))
             }
 
             models::expr::ExprKind::If(msg) => {
                 let test_expr = *msg
                     .test_expr
-                    .ok_or_else(|| ProtoToAstError::missing("test_expr"))?;
+                    .ok_or_else(|| ProtobufConversionError::missing("test_expr"))?;
                 let then_expr = *msg
                     .then_expr
-                    .ok_or_else(|| ProtoToAstError::missing("then_expr"))?;
+                    .ok_or_else(|| ProtobufConversionError::missing("then_expr"))?;
                 let else_expr = *msg
                     .else_expr
-                    .ok_or_else(|| ProtoToAstError::missing("else_expr"))?;
+                    .ok_or_else(|| ProtobufConversionError::missing("else_expr"))?;
                 Ok(ast::Expr::ite(
                     ast::Expr::try_from(test_expr)?,
                     ast::Expr::try_from(then_expr)?,
@@ -262,8 +268,8 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::And(msg) => {
-                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::and(
                     ast::Expr::try_from(left)?,
                     ast::Expr::try_from(right)?,
@@ -271,8 +277,8 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Or(msg) => {
-                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::or(
                     ast::Expr::try_from(left)?,
                     ast::Expr::try_from(right)?,
@@ -280,9 +286,9 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::UApp(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 let puop = models::expr::unary_app::Op::try_from(msg.op)
-                    .map_err(|e| ProtoToAstError(format!("invalid unary op: {e}")))?;
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid unary op: {e}")))?;
                 Ok(ast::Expr::unary_app(
                     ast::UnaryOp::from(puop),
                     ast::Expr::try_from(arg)?,
@@ -291,9 +297,9 @@ impl TryFrom<models::Expr> for ast::Expr {
 
             models::expr::ExprKind::BApp(msg) => {
                 let pbop = models::expr::binary_app::Op::try_from(msg.op)
-                    .map_err(|e| ProtoToAstError(format!("invalid binary op: {e}")))?;
-                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid binary op: {e}")))?;
+                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::binary_app(
                     ast::BinaryOp::from(pbop),
                     ast::Expr::try_from(left)?,
@@ -304,7 +310,7 @@ impl TryFrom<models::Expr> for ast::Expr {
             models::expr::ExprKind::ExtApp(msg) => Ok(ast::Expr::call_extension_fn(
                 ast::Name::try_from(
                     msg.fn_name
-                        .ok_or_else(|| ProtoToAstError::missing("fn_name"))?,
+                        .ok_or_else(|| ProtobufConversionError::missing("fn_name"))?,
                 )?,
                 msg.args
                     .into_iter()
@@ -313,7 +319,7 @@ impl TryFrom<models::Expr> for ast::Expr {
             )),
 
             models::expr::ExprKind::GetAttr(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::get_attr(
                     ast::Expr::try_from(arg)?,
                     msg.attr.into(),
@@ -321,7 +327,7 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::HasAttr(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::has_attr(
                     ast::Expr::try_from(arg)?,
                     msg.attr.into(),
@@ -329,7 +335,7 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Like(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::like(
                     ast::Expr::try_from(arg)?,
                     msg.pattern
@@ -340,12 +346,12 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Is(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::is_entity_type(
                     ast::Expr::try_from(arg)?,
                     ast::EntityType::try_from(
                         msg.entity_type
-                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                            .ok_or_else(|| ProtobufConversionError::missing("entity_type"))?,
                     )?,
                 ))
             }
@@ -362,9 +368,9 @@ impl TryFrom<models::Expr> for ast::Expr {
                     .items
                     .into_iter()
                     .map(|(key, value)| Ok((key.into(), ast::Expr::try_from(value)?)))
-                    .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+                    .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
                 ast::Expr::record(items)
-                    .map_err(|e| ProtoToAstError(format!("invalid record: {e}")))
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid record: {e}")))
             }
         }
     }
@@ -514,9 +520,9 @@ impl From<&ast::Var> for models::expr::Var {
 }
 
 impl TryFrom<models::expr::Literal> for ast::Literal {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::expr::Literal) -> Result<Self, Self::Error> {
-        match v.lit.ok_or_else(|| ProtoToAstError::missing("lit"))? {
+        match v.lit.ok_or_else(|| ProtobufConversionError::missing("lit"))? {
             models::expr::literal::Lit::B(b) => Ok(ast::Literal::Bool(b)),
             models::expr::literal::Lit::I(l) => Ok(ast::Literal::Long(l)),
             models::expr::literal::Lit::S(s) => Ok(ast::Literal::String(s.into())),
@@ -630,17 +636,17 @@ impl From<&ast::BinaryOp> for models::expr::binary_app::Op {
 }
 
 impl TryFrom<models::expr::like::PatternElem> for ast::PatternElem {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::expr::like::PatternElem) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
+        match v.data.ok_or_else(|| ProtobufConversionError::missing("data"))? {
             models::expr::like::pattern_elem::Data::C(c) => {
                 Ok(ast::PatternElem::Char(c.chars().next().ok_or_else(
-                    || ProtoToAstError("empty char in pattern element".to_string()),
+                    || ProtobufConversionError::InvalidValue("empty char in pattern element".to_string()),
                 )?))
             }
             models::expr::like::pattern_elem::Data::Wildcard(unit) => {
                 match models::expr::like::pattern_elem::Wildcard::try_from(unit)
-                    .map_err(|e| ProtoToAstError(format!("invalid wildcard: {e}")))?
+                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid wildcard: {e}")))?
                 {
                     models::expr::like::pattern_elem::Wildcard::Unit => {
                         Ok(ast::PatternElem::Wildcard)
@@ -667,19 +673,19 @@ impl From<&ast::PatternElem> for models::expr::like::PatternElem {
 }
 
 impl TryFrom<models::Request> for ast::Request {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Request) -> Result<Self, Self::Error> {
         Ok(ast::Request::new_unchecked(
             ast::EntityUIDEntry::try_from(
                 v.principal
-                    .ok_or_else(|| ProtoToAstError::missing("principal"))?,
+                    .ok_or_else(|| ProtobufConversionError::missing("principal"))?,
             )?,
             ast::EntityUIDEntry::try_from(
-                v.action.ok_or_else(|| ProtoToAstError::missing("action"))?,
+                v.action.ok_or_else(|| ProtobufConversionError::missing("action"))?,
             )?,
             ast::EntityUIDEntry::try_from(
                 v.resource
-                    .ok_or_else(|| ProtoToAstError::missing("resource"))?,
+                    .ok_or_else(|| ProtobufConversionError::missing("resource"))?,
             )?,
             Some(
                 ast::Context::from_pairs(
@@ -688,16 +694,16 @@ impl TryFrom<models::Request> for ast::Request {
                         .map(|(k, v)| {
                             let expr = ast::Expr::try_from(v)?;
                             let restricted = ast::RestrictedExpr::new(expr).map_err(|e| {
-                                ProtoToAstError(format!(
+                                ProtobufConversionError::InvalidValue(format!(
                                     "invalid restricted expr in context key `{k}`: {e}"
                                 ))
                             })?;
                             Ok((k.to_smolstr(), restricted))
                         })
-                        .collect::<Result<Vec<_>, ProtoToAstError>>()?,
+                        .collect::<Result<Vec<_>, ProtobufConversionError>>()?,
                     Extensions::all_available(),
                 )
-                .map_err(|e| ProtoToAstError(format!("invalid context: {e}")))?,
+                .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid context: {e}")))?,
             ),
         ))
     }
@@ -730,13 +736,13 @@ impl From<&ast::Request> for models::Request {
 }
 
 impl TryFrom<models::Expr> for ast::Context {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Expr) -> Result<Self, Self::Error> {
         let expr = ast::Expr::try_from(v)?;
         let restricted = ast::BorrowedRestrictedExpr::new(&expr)
-            .map_err(|e| ProtoToAstError(format!("invalid restricted expr in context: {e}")))?;
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid restricted expr in context: {e}")))?;
         ast::Context::from_expr(restricted, Extensions::none())
-            .map_err(|e| ProtoToAstError(format!("invalid context: {e}")))
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid context: {e}")))
     }
 }
 

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -47,14 +47,18 @@ impl ProtobufConversionError {
 impl TryFrom<models::Name> for ast::InternalName {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Name) -> Result<Self, Self::Error> {
-        let basename = ast::Id::from_normalized_str(&v.id)
-            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid basename `{}`: {e}", v.id)))?;
+        let basename = ast::Id::from_normalized_str(&v.id).map_err(|e| {
+            ProtobufConversionError::InvalidValue(format!("invalid basename `{}`: {e}", v.id))
+        })?;
         let path = v
             .path
             .into_iter()
             .map(|id| {
-                ast::Id::from_normalized_str(&id)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid path component `{id}`: {e}")))
+                ast::Id::from_normalized_str(&id).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!(
+                        "invalid path component `{id}`: {e}"
+                    ))
+                })
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(ast::InternalName::new(basename, path, None))
@@ -155,10 +159,14 @@ impl TryFrom<models::Entity> for ast::Entity {
             .map(|(key, value)| {
                 let expr = ast::Expr::try_from(value)?;
                 let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
-                    ProtobufConversionError::InvalidValue(format!("invalid restricted expr in attr `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!(
+                        "invalid restricted expr in attr `{key}`: {e}"
+                    ))
                 })?;
                 let pval = eval.partial_interpret(restricted).map_err(|e| {
-                    ProtobufConversionError::InvalidValue(format!("error interpreting attr `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!(
+                        "error interpreting attr `{key}`: {e}"
+                    ))
                 })?;
                 Ok((key.into(), pval))
             })
@@ -176,17 +184,24 @@ impl TryFrom<models::Entity> for ast::Entity {
             .map(|(key, value)| {
                 let expr = ast::Expr::try_from(value)?;
                 let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
-                    ProtobufConversionError::InvalidValue(format!("invalid restricted expr in tag `{key}`: {e}"))
+                    ProtobufConversionError::InvalidValue(format!(
+                        "invalid restricted expr in tag `{key}`: {e}"
+                    ))
                 })?;
-                let pval = eval
-                    .partial_interpret(restricted)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("error interpreting tag `{key}`: {e}")))?;
+                let pval = eval.partial_interpret(restricted).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!(
+                        "error interpreting tag `{key}`: {e}"
+                    ))
+                })?;
                 Ok((key.into(), pval))
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
         Ok(Self::new_with_attr_partial_value(
-            ast::EntityUID::try_from(v.uid.ok_or_else(|| ProtobufConversionError::missing("uid"))?)?,
+            ast::EntityUID::try_from(
+                v.uid
+                    .ok_or_else(|| ProtobufConversionError::missing("uid"))?,
+            )?,
             attrs,
             HashSet::new(),
             ancestors,
@@ -239,14 +254,16 @@ impl TryFrom<models::Expr> for ast::Expr {
             models::expr::ExprKind::Lit(lit) => Ok(ast::Expr::val(ast::Literal::try_from(lit)?)),
 
             models::expr::ExprKind::Var(var) => {
-                let pvar = models::expr::Var::try_from(var)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid var: {e}")))?;
+                let pvar = models::expr::Var::try_from(var).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid var: {e}"))
+                })?;
                 Ok(ast::Expr::var(ast::Var::from(pvar)))
             }
 
             models::expr::ExprKind::Slot(slot) => {
-                let pslot = models::SlotId::try_from(slot)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid slot: {e}")))?;
+                let pslot = models::SlotId::try_from(slot).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid slot: {e}"))
+                })?;
                 Ok(ast::Expr::slot(ast::SlotId::from(pslot)))
             }
 
@@ -268,8 +285,12 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::And(msg) => {
-                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
+                let left = *msg
+                    .left
+                    .ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg
+                    .right
+                    .ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::and(
                     ast::Expr::try_from(left)?,
                     ast::Expr::try_from(right)?,
@@ -277,8 +298,12 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Or(msg) => {
-                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
+                let left = *msg
+                    .left
+                    .ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg
+                    .right
+                    .ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::or(
                     ast::Expr::try_from(left)?,
                     ast::Expr::try_from(right)?,
@@ -286,9 +311,12 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::UApp(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
-                let puop = models::expr::unary_app::Op::try_from(msg.op)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid unary op: {e}")))?;
+                let arg = *msg
+                    .expr
+                    .ok_or_else(|| ProtobufConversionError::missing("expr"))?;
+                let puop = models::expr::unary_app::Op::try_from(msg.op).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid unary op: {e}"))
+                })?;
                 Ok(ast::Expr::unary_app(
                     ast::UnaryOp::from(puop),
                     ast::Expr::try_from(arg)?,
@@ -296,10 +324,15 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::BApp(msg) => {
-                let pbop = models::expr::binary_app::Op::try_from(msg.op)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid binary op: {e}")))?;
-                let left = *msg.left.ok_or_else(|| ProtobufConversionError::missing("left"))?;
-                let right = *msg.right.ok_or_else(|| ProtobufConversionError::missing("right"))?;
+                let pbop = models::expr::binary_app::Op::try_from(msg.op).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid binary op: {e}"))
+                })?;
+                let left = *msg
+                    .left
+                    .ok_or_else(|| ProtobufConversionError::missing("left"))?;
+                let right = *msg
+                    .right
+                    .ok_or_else(|| ProtobufConversionError::missing("right"))?;
                 Ok(ast::Expr::binary_app(
                     ast::BinaryOp::from(pbop),
                     ast::Expr::try_from(left)?,
@@ -319,7 +352,9 @@ impl TryFrom<models::Expr> for ast::Expr {
             )),
 
             models::expr::ExprKind::GetAttr(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
+                let arg = *msg
+                    .expr
+                    .ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::get_attr(
                     ast::Expr::try_from(arg)?,
                     msg.attr.into(),
@@ -327,7 +362,9 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::HasAttr(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
+                let arg = *msg
+                    .expr
+                    .ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::has_attr(
                     ast::Expr::try_from(arg)?,
                     msg.attr.into(),
@@ -335,7 +372,9 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Like(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
+                let arg = *msg
+                    .expr
+                    .ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::like(
                     ast::Expr::try_from(arg)?,
                     msg.pattern
@@ -346,7 +385,9 @@ impl TryFrom<models::Expr> for ast::Expr {
             }
 
             models::expr::ExprKind::Is(msg) => {
-                let arg = *msg.expr.ok_or_else(|| ProtobufConversionError::missing("expr"))?;
+                let arg = *msg
+                    .expr
+                    .ok_or_else(|| ProtobufConversionError::missing("expr"))?;
                 Ok(ast::Expr::is_entity_type(
                     ast::Expr::try_from(arg)?,
                     ast::EntityType::try_from(
@@ -369,8 +410,9 @@ impl TryFrom<models::Expr> for ast::Expr {
                     .into_iter()
                     .map(|(key, value)| Ok((key.into(), ast::Expr::try_from(value)?)))
                     .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
-                ast::Expr::record(items)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid record: {e}")))
+                ast::Expr::record(items).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid record: {e}"))
+                })
             }
         }
     }
@@ -522,7 +564,10 @@ impl From<&ast::Var> for models::expr::Var {
 impl TryFrom<models::expr::Literal> for ast::Literal {
     type Error = ProtobufConversionError;
     fn try_from(v: models::expr::Literal) -> Result<Self, Self::Error> {
-        match v.lit.ok_or_else(|| ProtobufConversionError::missing("lit"))? {
+        match v
+            .lit
+            .ok_or_else(|| ProtobufConversionError::missing("lit"))?
+        {
             models::expr::literal::Lit::B(b) => Ok(ast::Literal::Bool(b)),
             models::expr::literal::Lit::I(l) => Ok(ast::Literal::Long(l)),
             models::expr::literal::Lit::S(s) => Ok(ast::Literal::String(s.into())),
@@ -638,16 +683,21 @@ impl From<&ast::BinaryOp> for models::expr::binary_app::Op {
 impl TryFrom<models::expr::like::PatternElem> for ast::PatternElem {
     type Error = ProtobufConversionError;
     fn try_from(v: models::expr::like::PatternElem) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtobufConversionError::missing("data"))? {
-            models::expr::like::pattern_elem::Data::C(c) => {
-                Ok(ast::PatternElem::Char(c.chars().next().ok_or_else(
-                    || ProtobufConversionError::InvalidValue("empty char in pattern element".to_string()),
-                )?))
-            }
+        match v
+            .data
+            .ok_or_else(|| ProtobufConversionError::missing("data"))?
+        {
+            models::expr::like::pattern_elem::Data::C(c) => Ok(ast::PatternElem::Char(
+                c.chars().next().ok_or_else(|| {
+                    ProtobufConversionError::InvalidValue(
+                        "empty char in pattern element".to_string(),
+                    )
+                })?,
+            )),
             models::expr::like::pattern_elem::Data::Wildcard(unit) => {
-                match models::expr::like::pattern_elem::Wildcard::try_from(unit)
-                    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid wildcard: {e}")))?
-                {
+                match models::expr::like::pattern_elem::Wildcard::try_from(unit).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid wildcard: {e}"))
+                })? {
                     models::expr::like::pattern_elem::Wildcard::Unit => {
                         Ok(ast::PatternElem::Wildcard)
                     }
@@ -681,7 +731,8 @@ impl TryFrom<models::Request> for ast::Request {
                     .ok_or_else(|| ProtobufConversionError::missing("principal"))?,
             )?,
             ast::EntityUIDEntry::try_from(
-                v.action.ok_or_else(|| ProtobufConversionError::missing("action"))?,
+                v.action
+                    .ok_or_else(|| ProtobufConversionError::missing("action"))?,
             )?,
             ast::EntityUIDEntry::try_from(
                 v.resource
@@ -703,7 +754,9 @@ impl TryFrom<models::Request> for ast::Request {
                         .collect::<Result<Vec<_>, ProtobufConversionError>>()?,
                     Extensions::all_available(),
                 )
-                .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid context: {e}")))?,
+                .map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid context: {e}"))
+                })?,
             ),
         ))
     }
@@ -739,8 +792,11 @@ impl TryFrom<models::Expr> for ast::Context {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Expr) -> Result<Self, Self::Error> {
         let expr = ast::Expr::try_from(v)?;
-        let restricted = ast::BorrowedRestrictedExpr::new(&expr)
-            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid restricted expr in context: {e}")))?;
+        let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
+            ProtobufConversionError::InvalidValue(format!(
+                "invalid restricted expr in context: {e}"
+            ))
+        })?;
         ast::Context::from_expr(restricted, Extensions::none())
             .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid context: {e}")))
     }

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -243,6 +243,7 @@ impl From<&Arc<ast::Entity>> for models::Entity {
     }
 }
 
+#[expect(clippy::too_many_lines, reason = "models::ExprKind has many variants")]
 impl TryFrom<models::Expr> for ast::Expr {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Expr) -> Result<Self, Self::Error> {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -23,30 +23,50 @@ use cedar_policy_core::{
 use smol_str::ToSmolStr;
 use std::{collections::HashSet, sync::Arc};
 
-#[expect(clippy::fallible_impl_from, reason = "experimental feature")]
-impl From<models::Name> for ast::InternalName {
-    #[expect(clippy::unwrap_used, reason = "experimental feature")]
-    fn from(v: models::Name) -> Self {
-        let basename = ast::Id::from_normalized_str(&v.id).unwrap();
+/// Error converting a protobuf model type into an AST type.
+///
+/// This indicates the protobuf message was well-formed at the wire level but
+/// contained semantically invalid data (e.g. missing required fields, invalid
+/// identifiers, unsupported features).
+#[derive(Debug, thiserror::Error)]
+#[error("error converting protobuf to AST: {0}")]
+pub struct ProtoToAstError(pub(crate) String);
+
+impl ProtoToAstError {
+    pub(crate) fn missing(field: &str) -> Self {
+        Self(format!("missing required field: `{field}`"))
+    }
+}
+
+impl TryFrom<models::Name> for ast::InternalName {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Name) -> Result<Self, Self::Error> {
+        let basename = ast::Id::from_normalized_str(&v.id)
+            .map_err(|e| ProtoToAstError(format!("invalid basename `{}`: {e}", v.id)))?;
         let path = v
             .path
             .into_iter()
-            .map(|id| ast::Id::from_normalized_str(&id).unwrap());
-        ast::InternalName::new(basename, path, None)
+            .map(|id| {
+                ast::Id::from_normalized_str(&id)
+                    .map_err(|e| ProtoToAstError(format!("invalid path component `{id}`: {e}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ast::InternalName::new(basename, path, None))
     }
 }
 
-#[expect(clippy::fallible_impl_from, reason = "experimental feature")]
-impl From<models::Name> for ast::Name {
-    #[expect(clippy::unwrap_used, reason = "experimental feature")]
-    fn from(v: models::Name) -> Self {
-        ast::Name::try_from(ast::InternalName::from(v)).unwrap()
+impl TryFrom<models::Name> for ast::Name {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Name) -> Result<Self, Self::Error> {
+        ast::Name::try_from(ast::InternalName::try_from(v)?)
+            .map_err(|e| ProtoToAstError(format!("invalid name: {e}")))
     }
 }
 
-impl From<models::Name> for ast::EntityType {
-    fn from(v: models::Name) -> Self {
-        ast::EntityType::from(ast::Name::from(v))
+impl TryFrom<models::Name> for ast::EntityType {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Name) -> Result<Self, Self::Error> {
+        Ok(ast::EntityType::from(ast::Name::try_from(v)?))
     }
 }
 
@@ -74,14 +94,14 @@ impl From<&ast::EntityType> for models::Name {
     }
 }
 
-impl From<models::EntityUid> for ast::EntityUID {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::EntityUid) -> Self {
-        Self::from_components(
-            ast::EntityType::from(v.ty.expect("ty field should exist")),
+impl TryFrom<models::EntityUid> for ast::EntityUID {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::EntityUid) -> Result<Self, ProtoToAstError> {
+        Ok(Self::from_components(
+            ast::EntityType::try_from(v.ty.ok_or_else(|| ProtoToAstError::missing("ty"))?)?,
             ast::Eid::new(v.eid),
             None,
-        )
+        ))
     }
 }
 
@@ -94,9 +114,13 @@ impl From<&ast::EntityUID> for models::EntityUid {
     }
 }
 
-impl From<models::EntityUid> for ast::EntityUIDEntry {
-    fn from(v: models::EntityUid) -> Self {
-        ast::EntityUIDEntry::known(ast::EntityUID::from(v), None)
+impl TryFrom<models::EntityUid> for ast::EntityUIDEntry {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::EntityUid) -> Result<Self, Self::Error> {
+        Ok(ast::EntityUIDEntry::known(
+            ast::EntityUID::try_from(v)?,
+            None,
+        ))
     }
 }
 
@@ -114,41 +138,54 @@ impl From<&ast::EntityUIDEntry> for models::EntityUid {
     }
 }
 
-impl From<models::Entity> for ast::Entity {
-    #[expect(
-        clippy::expect_used,
-        clippy::unwrap_used,
-        reason = "experimental feature"
-    )]
-    fn from(v: models::Entity) -> Self {
+impl TryFrom<models::Entity> for ast::Entity {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Entity) -> Result<Self, Self::Error> {
         let eval = RestrictedEvaluator::new(Extensions::none());
 
-        let attrs = v.attrs.into_iter().map(|(key, value)| {
-            let expr = ast::Expr::from(value);
-            let pval = eval
-                .partial_interpret(ast::BorrowedRestrictedExpr::new(&expr).unwrap())
-                .expect("interpret on RestrictedExpr");
-            (key.into(), pval)
-        });
+        let attrs = v
+            .attrs
+            .into_iter()
+            .map(|(key, value)| {
+                let expr = ast::Expr::try_from(value)?;
+                let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
+                    ProtoToAstError(format!("invalid restricted expr in attr `{key}`: {e}"))
+                })?;
+                let pval = eval.partial_interpret(restricted).map_err(|e| {
+                    ProtoToAstError(format!("error interpreting attr `{key}`: {e}"))
+                })?;
+                Ok((key.into(), pval))
+            })
+            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
 
-        let ancestors: HashSet<ast::EntityUID> =
-            v.ancestors.into_iter().map(ast::EntityUID::from).collect();
+        let ancestors = v
+            .ancestors
+            .into_iter()
+            .map(ast::EntityUID::try_from)
+            .collect::<Result<HashSet<_>, _>>()?;
 
-        let tags = v.tags.into_iter().map(|(key, value)| {
-            let expr = ast::Expr::from(value);
-            let pval = eval
-                .partial_interpret(ast::BorrowedRestrictedExpr::new(&expr).expect("RestrictedExpr"))
-                .expect("interpret on RestrictedExpr");
-            (key.into(), pval)
-        });
+        let tags = v
+            .tags
+            .into_iter()
+            .map(|(key, value)| {
+                let expr = ast::Expr::try_from(value)?;
+                let restricted = ast::BorrowedRestrictedExpr::new(&expr).map_err(|e| {
+                    ProtoToAstError(format!("invalid restricted expr in tag `{key}`: {e}"))
+                })?;
+                let pval = eval
+                    .partial_interpret(restricted)
+                    .map_err(|e| ProtoToAstError(format!("error interpreting tag `{key}`: {e}")))?;
+                Ok((key.into(), pval))
+            })
+            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
 
-        Self::new_with_attr_partial_value(
-            ast::EntityUID::from(v.uid.expect("uid field should exist")),
+        Ok(Self::new_with_attr_partial_value(
+            ast::EntityUID::try_from(v.uid.ok_or_else(|| ProtoToAstError::missing("uid"))?)?,
             attrs,
             HashSet::new(),
             ancestors,
             tags,
-        )
+        ))
     }
 }
 
@@ -185,110 +222,150 @@ impl From<&Arc<ast::Entity>> for models::Entity {
     }
 }
 
-impl From<models::Expr> for ast::Expr {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::Expr) -> Self {
-        let kind = v.expr_kind.expect("expr_kind field should exist");
+impl TryFrom<models::Expr> for ast::Expr {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Expr) -> Result<Self, Self::Error> {
+        let kind = v
+            .expr_kind
+            .ok_or_else(|| ProtoToAstError::missing("expr_kind"))?;
 
         match kind {
-            models::expr::ExprKind::Lit(lit) => ast::Expr::val(ast::Literal::from(lit)),
+            models::expr::ExprKind::Lit(lit) => Ok(ast::Expr::val(ast::Literal::try_from(lit)?)),
 
             models::expr::ExprKind::Var(var) => {
-                let pvar = models::expr::Var::try_from(var).expect("decode should succeed");
-                ast::Expr::var(ast::Var::from(pvar))
+                let pvar = models::expr::Var::try_from(var)
+                    .map_err(|e| ProtoToAstError(format!("invalid var: {e}")))?;
+                Ok(ast::Expr::var(ast::Var::from(pvar)))
             }
 
             models::expr::ExprKind::Slot(slot) => {
-                let pslot = models::SlotId::try_from(slot).expect("decode should succeed");
-                ast::Expr::slot(ast::SlotId::from(pslot))
+                let pslot = models::SlotId::try_from(slot)
+                    .map_err(|e| ProtoToAstError(format!("invalid slot: {e}")))?;
+                Ok(ast::Expr::slot(ast::SlotId::from(pslot)))
             }
 
             models::expr::ExprKind::If(msg) => {
-                let test_expr = *msg.test_expr.expect("test_expr field should exist");
-                let then_expr = *msg.then_expr.expect("then_expr field should exist");
-                let else_expr = *msg.else_expr.expect("else_expr field should exist");
-                ast::Expr::ite(
-                    ast::Expr::from(test_expr),
-                    ast::Expr::from(then_expr),
-                    ast::Expr::from(else_expr),
-                )
+                let test_expr = *msg
+                    .test_expr
+                    .ok_or_else(|| ProtoToAstError::missing("test_expr"))?;
+                let then_expr = *msg
+                    .then_expr
+                    .ok_or_else(|| ProtoToAstError::missing("then_expr"))?;
+                let else_expr = *msg
+                    .else_expr
+                    .ok_or_else(|| ProtoToAstError::missing("else_expr"))?;
+                Ok(ast::Expr::ite(
+                    ast::Expr::try_from(test_expr)?,
+                    ast::Expr::try_from(then_expr)?,
+                    ast::Expr::try_from(else_expr)?,
+                ))
             }
 
             models::expr::ExprKind::And(msg) => {
-                let left = *msg.left.expect("left field should exist");
-                let right = *msg.right.expect("right field should exist");
-                ast::Expr::and(ast::Expr::from(left), ast::Expr::from(right))
+                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                Ok(ast::Expr::and(
+                    ast::Expr::try_from(left)?,
+                    ast::Expr::try_from(right)?,
+                ))
             }
 
             models::expr::ExprKind::Or(msg) => {
-                let left = *msg.left.expect("left field should exist");
-                let right = *msg.right.expect("right field should exist");
-                ast::Expr::or(ast::Expr::from(left), ast::Expr::from(right))
+                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                Ok(ast::Expr::or(
+                    ast::Expr::try_from(left)?,
+                    ast::Expr::try_from(right)?,
+                ))
             }
 
             models::expr::ExprKind::UApp(msg) => {
-                let arg = *msg.expr.expect("expr field should exist");
-                let puop =
-                    models::expr::unary_app::Op::try_from(msg.op).expect("decode should succeed");
-                ast::Expr::unary_app(ast::UnaryOp::from(puop), ast::Expr::from(arg))
+                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                let puop = models::expr::unary_app::Op::try_from(msg.op)
+                    .map_err(|e| ProtoToAstError(format!("invalid unary op: {e}")))?;
+                Ok(ast::Expr::unary_app(
+                    ast::UnaryOp::from(puop),
+                    ast::Expr::try_from(arg)?,
+                ))
             }
 
             models::expr::ExprKind::BApp(msg) => {
-                let pbop =
-                    models::expr::binary_app::Op::try_from(msg.op).expect("decode should succeed");
-                let left = *msg.left.expect("left field should exist");
-                let right = *msg.right.expect("right field should exist");
-                ast::Expr::binary_app(
+                let pbop = models::expr::binary_app::Op::try_from(msg.op)
+                    .map_err(|e| ProtoToAstError(format!("invalid binary op: {e}")))?;
+                let left = *msg.left.ok_or_else(|| ProtoToAstError::missing("left"))?;
+                let right = *msg.right.ok_or_else(|| ProtoToAstError::missing("right"))?;
+                Ok(ast::Expr::binary_app(
                     ast::BinaryOp::from(pbop),
-                    ast::Expr::from(left),
-                    ast::Expr::from(right),
-                )
+                    ast::Expr::try_from(left)?,
+                    ast::Expr::try_from(right)?,
+                ))
             }
 
-            models::expr::ExprKind::ExtApp(msg) => ast::Expr::call_extension_fn(
-                ast::Name::from(msg.fn_name.expect("fn_name field should exist")),
-                msg.args.into_iter().map(ast::Expr::from).collect(),
-            ),
+            models::expr::ExprKind::ExtApp(msg) => Ok(ast::Expr::call_extension_fn(
+                ast::Name::try_from(
+                    msg.fn_name
+                        .ok_or_else(|| ProtoToAstError::missing("fn_name"))?,
+                )?,
+                msg.args
+                    .into_iter()
+                    .map(ast::Expr::try_from)
+                    .collect::<Result<_, _>>()?,
+            )),
 
             models::expr::ExprKind::GetAttr(msg) => {
-                let arg = *msg.expr.expect("expr field should exist");
-                ast::Expr::get_attr(ast::Expr::from(arg), msg.attr.into())
+                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                Ok(ast::Expr::get_attr(
+                    ast::Expr::try_from(arg)?,
+                    msg.attr.into(),
+                ))
             }
 
             models::expr::ExprKind::HasAttr(msg) => {
-                let arg = *msg.expr.expect("expr field should exist");
-                ast::Expr::has_attr(ast::Expr::from(arg), msg.attr.into())
+                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                Ok(ast::Expr::has_attr(
+                    ast::Expr::try_from(arg)?,
+                    msg.attr.into(),
+                ))
             }
 
             models::expr::ExprKind::Like(msg) => {
-                let arg = *msg.expr.expect("expr field should exist");
-                ast::Expr::like(
-                    ast::Expr::from(arg),
+                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                Ok(ast::Expr::like(
+                    ast::Expr::try_from(arg)?,
                     msg.pattern
                         .into_iter()
-                        .map(ast::PatternElem::from)
-                        .collect(),
-                )
+                        .map(ast::PatternElem::try_from)
+                        .collect::<Result<_, _>>()?,
+                ))
             }
 
             models::expr::ExprKind::Is(msg) => {
-                let arg = *msg.expr.expect("expr field should exist");
-                ast::Expr::is_entity_type(
-                    ast::Expr::from(arg),
-                    ast::EntityType::from(msg.entity_type.expect("entity_type field should exist")),
-                )
+                let arg = *msg.expr.ok_or_else(|| ProtoToAstError::missing("expr"))?;
+                Ok(ast::Expr::is_entity_type(
+                    ast::Expr::try_from(arg)?,
+                    ast::EntityType::try_from(
+                        msg.entity_type
+                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                    )?,
+                ))
             }
 
-            models::expr::ExprKind::Set(msg) => {
-                ast::Expr::set(msg.elements.into_iter().map(ast::Expr::from))
-            }
-
-            models::expr::ExprKind::Record(msg) => ast::Expr::record(
-                msg.items
+            models::expr::ExprKind::Set(msg) => Ok(ast::Expr::set(
+                msg.elements
                     .into_iter()
-                    .map(|(key, value)| (key.into(), ast::Expr::from(value))),
-            )
-            .expect("Expr should be valid"),
+                    .map(ast::Expr::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+
+            models::expr::ExprKind::Record(msg) => {
+                let items = msg
+                    .items
+                    .into_iter()
+                    .map(|(key, value)| Ok((key.into(), ast::Expr::try_from(value)?)))
+                    .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+                ast::Expr::record(items)
+                    .map_err(|e| ProtoToAstError(format!("invalid record: {e}")))
+            }
         }
     }
 }
@@ -436,15 +513,15 @@ impl From<&ast::Var> for models::expr::Var {
     }
 }
 
-impl From<models::expr::Literal> for ast::Literal {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::expr::Literal) -> Self {
-        match v.lit.expect("lit field should exist") {
-            models::expr::literal::Lit::B(b) => ast::Literal::Bool(b),
-            models::expr::literal::Lit::I(l) => ast::Literal::Long(l),
-            models::expr::literal::Lit::S(s) => ast::Literal::String(s.into()),
+impl TryFrom<models::expr::Literal> for ast::Literal {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::expr::Literal) -> Result<Self, Self::Error> {
+        match v.lit.ok_or_else(|| ProtoToAstError::missing("lit"))? {
+            models::expr::literal::Lit::B(b) => Ok(ast::Literal::Bool(b)),
+            models::expr::literal::Lit::I(l) => Ok(ast::Literal::Long(l)),
+            models::expr::literal::Lit::S(s) => Ok(ast::Literal::String(s.into())),
             models::expr::literal::Lit::Euid(e) => {
-                ast::Literal::EntityUID(ast::EntityUID::from(e).into())
+                Ok(ast::Literal::EntityUID(ast::EntityUID::try_from(e)?.into()))
             }
         }
     }
@@ -552,19 +629,22 @@ impl From<&ast::BinaryOp> for models::expr::binary_app::Op {
     }
 }
 
-impl From<models::expr::like::PatternElem> for ast::PatternElem {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::expr::like::PatternElem) -> Self {
-        match v.data.expect("data field should exist") {
+impl TryFrom<models::expr::like::PatternElem> for ast::PatternElem {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::expr::like::PatternElem) -> Result<Self, Self::Error> {
+        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
             models::expr::like::pattern_elem::Data::C(c) => {
-                ast::PatternElem::Char(c.chars().next().expect("c is non-empty"))
+                Ok(ast::PatternElem::Char(c.chars().next().ok_or_else(
+                    || ProtoToAstError("empty char in pattern element".to_string()),
+                )?))
             }
-
             models::expr::like::pattern_elem::Data::Wildcard(unit) => {
                 match models::expr::like::pattern_elem::Wildcard::try_from(unit)
-                    .expect("decode should succeed")
+                    .map_err(|e| ProtoToAstError(format!("invalid wildcard: {e}")))?
                 {
-                    models::expr::like::pattern_elem::Wildcard::Unit => ast::PatternElem::Wildcard,
+                    models::expr::like::pattern_elem::Wildcard::Unit => {
+                        Ok(ast::PatternElem::Wildcard)
+                    }
                 }
             }
         }
@@ -586,27 +666,40 @@ impl From<&ast::PatternElem> for models::expr::like::PatternElem {
     }
 }
 
-impl From<models::Request> for ast::Request {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::Request) -> Self {
-        ast::Request::new_unchecked(
-            ast::EntityUIDEntry::from(v.principal.expect("principal.as_ref()")),
-            ast::EntityUIDEntry::from(v.action.expect("action.as_ref()")),
-            ast::EntityUIDEntry::from(v.resource.expect("resource.as_ref()")),
+impl TryFrom<models::Request> for ast::Request {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Request) -> Result<Self, Self::Error> {
+        Ok(ast::Request::new_unchecked(
+            ast::EntityUIDEntry::try_from(
+                v.principal
+                    .ok_or_else(|| ProtoToAstError::missing("principal"))?,
+            )?,
+            ast::EntityUIDEntry::try_from(
+                v.action.ok_or_else(|| ProtoToAstError::missing("action"))?,
+            )?,
+            ast::EntityUIDEntry::try_from(
+                v.resource
+                    .ok_or_else(|| ProtoToAstError::missing("resource"))?,
+            )?,
             Some(
                 ast::Context::from_pairs(
-                    v.context.into_iter().map(|(k, v)| {
-                        (
-                            k.to_smolstr(),
-                            ast::RestrictedExpr::new(ast::Expr::from(v))
-                                .expect("encoded context should be a valid RestrictedExpr"),
-                        )
-                    }),
+                    v.context
+                        .into_iter()
+                        .map(|(k, v)| {
+                            let expr = ast::Expr::try_from(v)?;
+                            let restricted = ast::RestrictedExpr::new(expr).map_err(|e| {
+                                ProtoToAstError(format!(
+                                    "invalid restricted expr in context key `{k}`: {e}"
+                                ))
+                            })?;
+                            Ok((k.to_smolstr(), restricted))
+                        })
+                        .collect::<Result<Vec<_>, ProtoToAstError>>()?,
                     Extensions::all_available(),
                 )
-                .expect("encoded context should be valid"),
+                .map_err(|e| ProtoToAstError(format!("invalid context: {e}")))?,
             ),
-        )
+        ))
     }
 }
 
@@ -636,15 +729,14 @@ impl From<&ast::Request> for models::Request {
     }
 }
 
-impl From<models::Expr> for ast::Context {
-    fn from(v: models::Expr) -> Self {
-        #[expect(clippy::expect_used, reason = "experimental feature")]
-        ast::Context::from_expr(
-            ast::BorrowedRestrictedExpr::new(&ast::Expr::from(v))
-                .expect("encoded context should be valid restricted expr"),
-            Extensions::none(),
-        )
-        .expect("encoded context should be valid")
+impl TryFrom<models::Expr> for ast::Context {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Expr) -> Result<Self, Self::Error> {
+        let expr = ast::Expr::try_from(v)?;
+        let restricted = ast::BorrowedRestrictedExpr::new(&expr)
+            .map_err(|e| ProtoToAstError(format!("invalid restricted expr in context: {e}")))?;
+        ast::Context::from_expr(restricted, Extensions::none())
+            .map_err(|e| ProtoToAstError(format!("invalid context: {e}")))
     }
 }
 
@@ -661,7 +753,10 @@ mod test {
     #[test]
     fn name_and_slot_roundtrip() {
         let orig_name = ast::Name::from_normalized_str("B::C::D").unwrap();
-        assert_eq!(orig_name, ast::Name::from(models::Name::from(&orig_name)));
+        assert_eq!(
+            orig_name,
+            ast::Name::try_from(models::Name::from(&orig_name)).unwrap()
+        );
 
         let orig_slot1 = ast::SlotId::principal();
         assert_eq!(
@@ -682,21 +777,30 @@ mod test {
         let ety_specified = ast::EntityType::from(name);
         assert_eq!(
             ety_specified,
-            ast::EntityType::from(models::Name::from(&ety_specified))
+            ast::EntityType::try_from(models::Name::from(&ety_specified)).unwrap()
         );
 
         let euid1 = ast::EntityUID::with_eid_and_type("A", "foo").unwrap();
-        assert_eq!(euid1, ast::EntityUID::from(models::EntityUid::from(&euid1)));
+        assert_eq!(
+            euid1,
+            ast::EntityUID::try_from(models::EntityUid::from(&euid1)).unwrap()
+        );
 
         let euid2 = ast::EntityUID::from_normalized_str("Foo::Action::\"view\"").unwrap();
-        assert_eq!(euid2, ast::EntityUID::from(models::EntityUid::from(&euid2)));
+        assert_eq!(
+            euid2,
+            ast::EntityUID::try_from(models::EntityUid::from(&euid2)).unwrap()
+        );
 
         let euid3 = ast::EntityUID::from_components(
             ast::EntityType::from_normalized_str("A").unwrap(),
             ast::Eid::new("\0\n \' \"+-$^!"),
             None,
         );
-        assert_eq!(euid3, ast::EntityUID::from(models::EntityUid::from(&euid3)));
+        assert_eq!(
+            euid3,
+            ast::EntityUID::try_from(models::EntityUid::from(&euid3)).unwrap()
+        );
 
         let attrs = (1..=7).map(|id| (format!("{id}").into(), ast::RestrictedExpr::val(true)));
         let parent = ast::EntityUID::with_eid_and_type("Folder", "shared").unwrap();
@@ -709,8 +813,13 @@ mod test {
             Extensions::none(),
         )
         .unwrap();
-        assert_eq!(entity, ast::Entity::from(models::Entity::from(&entity)));
-        assert!(ast::Entity::from(models::Entity::from(&entity)).is_child_of(&parent));
+        assert_eq!(
+            entity,
+            ast::Entity::try_from(models::Entity::from(&entity)).unwrap()
+        );
+        assert!(ast::Entity::try_from(models::Entity::from(&entity))
+            .unwrap()
+            .is_child_of(&parent));
     }
 
     #[test]
@@ -728,54 +837,57 @@ mod test {
             Extensions::none(),
         )
         .unwrap();
-        assert_eq!(entity, ast::Entity::from(models::Entity::from(&entity)));
+        assert_eq!(
+            entity,
+            ast::Entity::try_from(models::Entity::from(&entity)).unwrap()
+        );
     }
 
     #[test]
     fn expr_roundtrip() {
         let e1 = ast::Expr::val(33);
-        assert_eq!(e1, ast::Expr::from(models::Expr::from(&e1)));
+        assert_eq!(e1, ast::Expr::try_from(models::Expr::from(&e1)).unwrap());
         let e2 = ast::Expr::val("hello");
-        assert_eq!(e2, ast::Expr::from(models::Expr::from(&e2)));
+        assert_eq!(e2, ast::Expr::try_from(models::Expr::from(&e2)).unwrap());
         let e3 = ast::Expr::val(ast::EntityUID::with_eid_and_type("A", "foo").unwrap());
-        assert_eq!(e3, ast::Expr::from(models::Expr::from(&e3)));
+        assert_eq!(e3, ast::Expr::try_from(models::Expr::from(&e3)).unwrap());
         let e4 = ast::Expr::var(ast::Var::Principal);
-        assert_eq!(e4, ast::Expr::from(models::Expr::from(&e4)));
+        assert_eq!(e4, ast::Expr::try_from(models::Expr::from(&e4)).unwrap());
         let e4 = ast::Expr::var(ast::Var::Action);
-        assert_eq!(e4, ast::Expr::from(models::Expr::from(&e4)));
+        assert_eq!(e4, ast::Expr::try_from(models::Expr::from(&e4)).unwrap());
         let e4 = ast::Expr::var(ast::Var::Resource);
-        assert_eq!(e4, ast::Expr::from(models::Expr::from(&e4)));
+        assert_eq!(e4, ast::Expr::try_from(models::Expr::from(&e4)).unwrap());
         let e4 = ast::Expr::var(ast::Var::Context);
-        assert_eq!(e4, ast::Expr::from(models::Expr::from(&e4)));
+        assert_eq!(e4, ast::Expr::try_from(models::Expr::from(&e4)).unwrap());
         let e5 = ast::Expr::ite(
             ast::Expr::val(true),
             ast::Expr::val(88),
             ast::Expr::val(-100),
         );
-        assert_eq!(e5, ast::Expr::from(models::Expr::from(&e5)));
+        assert_eq!(e5, ast::Expr::try_from(models::Expr::from(&e5)).unwrap());
         let e6 = ast::Expr::not(ast::Expr::val(false));
-        assert_eq!(e6, ast::Expr::from(models::Expr::from(&e6)));
+        assert_eq!(e6, ast::Expr::try_from(models::Expr::from(&e6)).unwrap());
         let e7 = ast::Expr::get_attr(
             ast::Expr::val(ast::EntityUID::with_eid_and_type("A", "foo").unwrap()),
             "some_attr".into(),
         );
-        assert_eq!(e7, ast::Expr::from(models::Expr::from(&e7)));
+        assert_eq!(e7, ast::Expr::try_from(models::Expr::from(&e7)).unwrap());
         let e8 = ast::Expr::has_attr(
             ast::Expr::val(ast::EntityUID::with_eid_and_type("A", "foo").unwrap()),
             "some_attr".into(),
         );
-        assert_eq!(e8, ast::Expr::from(models::Expr::from(&e8)));
+        assert_eq!(e8, ast::Expr::try_from(models::Expr::from(&e8)).unwrap());
         let e9 = ast::Expr::is_entity_type(
             ast::Expr::val(ast::EntityUID::with_eid_and_type("A", "foo").unwrap()),
             "Type".parse().unwrap(),
         );
-        assert_eq!(e9, ast::Expr::from(models::Expr::from(&e9)));
+        assert_eq!(e9, ast::Expr::try_from(models::Expr::from(&e9)).unwrap());
         let e10 = ast::Expr::slot(ast::SlotId::principal());
-        assert_eq!(e10, ast::Expr::from(models::Expr::from(&e10)));
+        assert_eq!(e10, ast::Expr::try_from(models::Expr::from(&e10)).unwrap());
         let e11 = ast::Expr::slot(ast::SlotId::resource());
-        assert_eq!(e11, ast::Expr::from(models::Expr::from(&e11)));
+        assert_eq!(e11, ast::Expr::try_from(models::Expr::from(&e11)).unwrap());
         let e12 = ast::Expr::and(ast::Expr::val(false), ast::Expr::not(ast::Expr::val(true)));
-        assert_eq!(e12, ast::Expr::from(models::Expr::from(&e12)));
+        assert_eq!(e12, ast::Expr::try_from(models::Expr::from(&e12)).unwrap());
         let e13 = ast::Expr::or(
             ast::Expr::ite(
                 ast::Expr::get_attr(ast::Expr::var(ast::Var::Context), "a".into()),
@@ -784,20 +896,20 @@ mod test {
             ),
             ast::Expr::greater(ast::Expr::val(33), ast::Expr::val(-33)),
         );
-        assert_eq!(e13, ast::Expr::from(models::Expr::from(&e13)));
+        assert_eq!(e13, ast::Expr::try_from(models::Expr::from(&e13)).unwrap());
         let e14 = ast::Expr::contains(
             ast::Expr::set([ast::Expr::val("beans"), ast::Expr::val("carrots")]),
             ast::Expr::val("peas"),
         );
-        assert_eq!(e14, ast::Expr::from(models::Expr::from(&e14)));
+        assert_eq!(e14, ast::Expr::try_from(models::Expr::from(&e14)).unwrap());
         let e: ast::Expr = r#"ip("0.0.0.0").isInRange(ip("0.0.0.0"))"#.parse().unwrap();
-        assert_eq!(e, ast::Expr::from(models::Expr::from(&e)));
+        assert_eq!(e, ast::Expr::try_from(models::Expr::from(&e)).unwrap());
         let e: ast::Expr = r#"principal.foo like "bar*""#.parse().unwrap();
-        assert_eq!(e, ast::Expr::from(models::Expr::from(&e)));
+        assert_eq!(e, ast::Expr::try_from(models::Expr::from(&e)).unwrap());
         let e: ast::Expr = r#"principal.foo.isEmpty()"#.parse().unwrap();
-        assert_eq!(e, ast::Expr::from(models::Expr::from(&e)));
+        assert_eq!(e, ast::Expr::try_from(models::Expr::from(&e)).unwrap());
         let e: ast::Expr = r#"- principal.foo"#.parse().unwrap();
-        assert_eq!(e, ast::Expr::from(models::Expr::from(&e)));
+        assert_eq!(e, ast::Expr::try_from(models::Expr::from(&e)).unwrap());
     }
 
     #[test]
@@ -805,44 +917,44 @@ mod test {
         let bool_literal_f = ast::Literal::from(false);
         assert_eq!(
             bool_literal_f,
-            ast::Literal::from(models::expr::Literal::from(&bool_literal_f))
+            ast::Literal::try_from(models::expr::Literal::from(&bool_literal_f)).unwrap()
         );
 
         let bool_literal_t = ast::Literal::from(true);
         assert_eq!(
             bool_literal_t,
-            ast::Literal::from(models::expr::Literal::from(&bool_literal_t))
+            ast::Literal::try_from(models::expr::Literal::from(&bool_literal_t)).unwrap()
         );
 
         let long_literal0 = ast::Literal::from(0);
         assert_eq!(
             long_literal0,
-            ast::Literal::from(models::expr::Literal::from(&long_literal0))
+            ast::Literal::try_from(models::expr::Literal::from(&long_literal0)).unwrap()
         );
 
         let long_literal1 = ast::Literal::from(1);
         assert_eq!(
             long_literal1,
-            ast::Literal::from(models::expr::Literal::from(&long_literal1))
+            ast::Literal::try_from(models::expr::Literal::from(&long_literal1)).unwrap()
         );
 
         let str_literal0 = ast::Literal::from("");
         assert_eq!(
             str_literal0,
-            ast::Literal::from(models::expr::Literal::from(&str_literal0))
+            ast::Literal::try_from(models::expr::Literal::from(&str_literal0)).unwrap()
         );
 
         let str_literal1 = ast::Literal::from("foo");
         assert_eq!(
             str_literal1,
-            ast::Literal::from(models::expr::Literal::from(&str_literal1))
+            ast::Literal::try_from(models::expr::Literal::from(&str_literal1)).unwrap()
         );
 
         let euid_literal =
             ast::Literal::from(ast::EntityUID::with_eid_and_type("A", "foo").unwrap());
         assert_eq!(
             euid_literal,
-            ast::Literal::from(models::expr::Literal::from(&euid_literal))
+            ast::Literal::try_from(models::expr::Literal::from(&euid_literal)).unwrap()
         );
     }
 
@@ -872,8 +984,11 @@ mod test {
             },
             Some(context.clone()),
         );
-        let request_rt = ast::Request::from(models::Request::from(&request));
-        assert_eq!(context, ast::Context::from(models::Expr::from(&context)));
+        let request_rt = ast::Request::try_from(models::Request::from(&request)).unwrap();
+        assert_eq!(
+            context,
+            ast::Context::try_from(models::Expr::from(&context)).unwrap()
+        );
         assert_eq!(request.principal().uid(), request_rt.principal().uid());
         assert_eq!(request.action().uid(), request_rt.action().uid());
         assert_eq!(request.resource().uid(), request_rt.resource().uid());

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -16,12 +16,12 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
-use super::ast::ProtoToAstError;
+use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::{ast, entities, extensions};
 
 impl TryFrom<models::Entities> for entities::Entities {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
 
     fn try_from(v: models::Entities) -> Result<Self, Self::Error> {
         let entities: Vec<ast::Entity> = v
@@ -40,7 +40,7 @@ impl TryFrom<models::Entities> for entities::Entities {
             entities::TCComputation::AssumeAlreadyComputed,
             extensions::Extensions::all_available(),
         )
-        .map_err(|e| ProtoToAstError(format!("invalid entities: {e}")))
+        .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid entities: {e}")))
     }
 }
 

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -16,13 +16,19 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
+use super::ast::ProtoToAstError;
 use super::models;
 use cedar_policy_core::{ast, entities, extensions};
 
-impl From<models::Entities> for entities::Entities {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::Entities) -> Self {
-        let entities: Vec<ast::Entity> = v.entities.into_iter().map(ast::Entity::from).collect();
+impl TryFrom<models::Entities> for entities::Entities {
+    type Error = ProtoToAstError;
+
+    fn try_from(v: models::Entities) -> Result<Self, Self::Error> {
+        let entities: Vec<ast::Entity> = v
+            .entities
+            .into_iter()
+            .map(ast::Entity::try_from)
+            .collect::<Result<_, _>>()?;
 
         // REVIEW (before stabilization): does `AssumeAlreadyComputed` make
         // sense here? It will be the case for protobufs produced from our
@@ -34,7 +40,7 @@ impl From<models::Entities> for entities::Entities {
             entities::TCComputation::AssumeAlreadyComputed,
             extensions::Extensions::all_available(),
         )
-        .expect("protobuf entities should be valid")
+        .map_err(|e| ProtoToAstError(format!("invalid entities: {e}")))
     }
 }
 
@@ -65,7 +71,7 @@ mod test {
         let entities1 = entities::Entities::new();
         assert_deep_eq!(
             entities1,
-            entities::Entities::from(models::Entities::from(&entities1))
+            entities::Entities::try_from(models::Entities::from(&entities1)).unwrap()
         );
 
         // Single Element Test
@@ -94,7 +100,7 @@ mod test {
             .unwrap();
         assert_deep_eq!(
             entities2,
-            entities::Entities::from(models::Entities::from(&entities2))
+            entities::Entities::try_from(models::Entities::from(&entities2)).unwrap()
         );
 
         // Two Element Test
@@ -120,7 +126,7 @@ mod test {
             .unwrap();
         assert_deep_eq!(
             entities3,
-            entities::Entities::from(models::Entities::from(&entities3))
+            entities::Entities::try_from(models::Entities::from(&entities3)).unwrap()
         );
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -16,13 +16,13 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
-use super::ast::ProtoToAstError;
+use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::{ast, FromNormalizedStr};
 use std::collections::HashMap;
 
 impl TryFrom<models::Policy> for ast::LiteralPolicy {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Policy) -> Result<Self, Self::Error> {
         let mut values: ast::SlotEnv = HashMap::new();
         if let Some(principal_euid) = v.principal_euid {
@@ -46,7 +46,7 @@ impl TryFrom<models::Policy> for ast::LiteralPolicy {
                 ast::PolicyID::from_string(
                     v.link_id
                         .as_ref()
-                        .ok_or_else(|| ProtoToAstError::missing("link_id"))?,
+                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?,
                 ),
                 values,
             ))
@@ -99,17 +99,17 @@ impl From<&ast::Policy> for models::Policy {
 }
 
 impl TryFrom<models::TemplateBody> for ast::Template {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
         Ok(ast::Template::from(ast::TemplateBody::try_from(v)?))
     }
 }
 
 impl TryFrom<models::TemplateBody> for ast::TemplateBody {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
         let effect = models::Effect::try_from(v.effect)
-            .map_err(|e| ProtoToAstError(format!("invalid effect: {e}")))?;
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid effect: {e}")))?;
         Ok(ast::TemplateBody::new(
             ast::PolicyID::from_string(v.id),
             None,
@@ -127,22 +127,24 @@ impl TryFrom<models::TemplateBody> for ast::TemplateBody {
                             )
                         })
                         .map_err(|e| {
-                            ProtoToAstError(format!("invalid annotation key `{key}`: {e}"))
+                            ProtobufConversionError::InvalidValue(format!(
+                                "invalid annotation key `{key}`: {e}"
+                            ))
                         })
                 })
                 .collect::<Result<_, _>>()?,
             ast::Effect::from(effect),
             ast::PrincipalConstraint::try_from(
                 v.principal_constraint
-                    .ok_or_else(|| ProtoToAstError::missing("principal_constraint"))?,
+                    .ok_or_else(|| ProtobufConversionError::missing("principal_constraint"))?,
             )?,
             ast::ActionConstraint::try_from(
                 v.action_constraint
-                    .ok_or_else(|| ProtoToAstError::missing("action_constraint"))?,
+                    .ok_or_else(|| ProtobufConversionError::missing("action_constraint"))?,
             )?,
             ast::ResourceConstraint::try_from(
                 v.resource_constraint
-                    .ok_or_else(|| ProtoToAstError::missing("resource_constraint"))?,
+                    .ok_or_else(|| ProtobufConversionError::missing("resource_constraint"))?,
             )?,
             v.non_scope_constraints
                 .map(ast::Expr::try_from)
@@ -181,7 +183,7 @@ impl From<&ast::Template> for models::TemplateBody {
 }
 
 impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalConstraint {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
         Ok(Self::new(ast::PrincipalOrResourceConstraint::try_from(v)?))
     }
@@ -194,7 +196,7 @@ impl From<&ast::PrincipalConstraint> for models::PrincipalOrResourceConstraint {
 }
 
 impl TryFrom<models::PrincipalOrResourceConstraint> for ast::ResourceConstraint {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
         Ok(Self::new(ast::PrincipalOrResourceConstraint::try_from(v)?))
     }
@@ -207,13 +209,18 @@ impl From<&ast::ResourceConstraint> for models::PrincipalOrResourceConstraint {
 }
 
 impl TryFrom<models::EntityReference> for ast::EntityReference {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::EntityReference) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
+        match v
+            .data
+            .ok_or_else(|| ProtobufConversionError::missing("data"))?
+        {
             models::entity_reference::Data::Slot(slot) => {
-                match models::entity_reference::Slot::try_from(slot)
-                    .map_err(|e| ProtoToAstError(format!("invalid entity reference slot: {e}")))?
-                {
+                match models::entity_reference::Slot::try_from(slot).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!(
+                        "invalid entity reference slot: {e}"
+                    ))
+                })? {
                     models::entity_reference::Slot::Unit => Ok(ast::EntityReference::Slot(None)),
                 }
             }
@@ -242,12 +249,19 @@ impl From<&ast::EntityReference> for models::EntityReference {
 }
 
 impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalOrResourceConstraint {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
+        match v
+            .data
+            .ok_or_else(|| ProtobufConversionError::missing("data"))?
+        {
             models::principal_or_resource_constraint::Data::Any(unit) => {
                 match models::principal_or_resource_constraint::Any::try_from(unit).map_err(
-                    |e| ProtoToAstError(format!("invalid principal/resource constraint: {e}")),
+                    |e| {
+                        ProtobufConversionError::InvalidValue(format!(
+                            "invalid principal/resource constraint: {e}"
+                        ))
+                    },
                 )? {
                     models::principal_or_resource_constraint::Any::Unit => {
                         Ok(ast::PrincipalOrResourceConstraint::Any)
@@ -256,19 +270,21 @@ impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalOrResource
             }
             models::principal_or_resource_constraint::Data::In(msg) => Ok(
                 ast::PrincipalOrResourceConstraint::In(ast::EntityReference::try_from(
-                    msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                    msg.er
+                        .ok_or_else(|| ProtobufConversionError::missing("er"))?,
                 )?),
             ),
             models::principal_or_resource_constraint::Data::Eq(msg) => Ok(
                 ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::try_from(
-                    msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                    msg.er
+                        .ok_or_else(|| ProtobufConversionError::missing("er"))?,
                 )?),
             ),
             models::principal_or_resource_constraint::Data::Is(msg) => {
                 Ok(ast::PrincipalOrResourceConstraint::Is(
                     ast::EntityType::try_from(
                         msg.entity_type
-                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                            .ok_or_else(|| ProtobufConversionError::missing("entity_type"))?,
                     )?
                     .into(),
                 ))
@@ -277,11 +293,12 @@ impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalOrResource
                 Ok(ast::PrincipalOrResourceConstraint::IsIn(
                     ast::EntityType::try_from(
                         msg.entity_type
-                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                            .ok_or_else(|| ProtobufConversionError::missing("entity_type"))?,
                     )?
                     .into(),
                     ast::EntityReference::try_from(
-                        msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                        msg.er
+                            .ok_or_else(|| ProtobufConversionError::missing("er"))?,
                     )?,
                 ))
             }
@@ -331,13 +348,16 @@ impl From<&ast::PrincipalOrResourceConstraint> for models::PrincipalOrResourceCo
 }
 
 impl TryFrom<models::ActionConstraint> for ast::ActionConstraint {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::ActionConstraint) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
+        match v
+            .data
+            .ok_or_else(|| ProtobufConversionError::missing("data"))?
+        {
             models::action_constraint::Data::Any(unit) => {
-                match models::action_constraint::Any::try_from(unit)
-                    .map_err(|e| ProtoToAstError(format!("invalid action constraint: {e}")))?
-                {
+                match models::action_constraint::Any::try_from(unit).map_err(|e| {
+                    ProtobufConversionError::InvalidValue(format!("invalid action constraint: {e}"))
+                })? {
                     models::action_constraint::Any::Unit => Ok(ast::ActionConstraint::Any),
                 }
             }
@@ -345,11 +365,12 @@ impl TryFrom<models::ActionConstraint> for ast::ActionConstraint {
                 msg.euids
                     .into_iter()
                     .map(|value| Ok(ast::EntityUID::try_from(value)?.into()))
-                    .collect::<Result<_, ProtoToAstError>>()?,
+                    .collect::<Result<_, ProtobufConversionError>>()?,
             )),
             models::action_constraint::Data::Eq(msg) => Ok(ast::ActionConstraint::Eq(
                 ast::EntityUID::try_from(
-                    msg.euid.ok_or_else(|| ProtoToAstError::missing("euid"))?,
+                    msg.euid
+                        .ok_or_else(|| ProtobufConversionError::missing("euid"))?,
                 )?
                 .into(),
             )),
@@ -411,7 +432,7 @@ impl From<&ast::Effect> for models::Effect {
 }
 
 impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
         let templates = v
             .templates
@@ -420,7 +441,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                 let id = ast::PolicyID::from_string(&tb.id);
                 Ok((id, ast::Template::from(ast::TemplateBody::try_from(tb)?)))
             })
-            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
         let links = v
             .links
@@ -431,14 +452,14 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                 let id = if p.is_template_link {
                     p.link_id
                         .as_ref()
-                        .ok_or_else(|| ProtoToAstError::missing("link_id"))?
+                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?
                 } else {
                     &p.template_id
                 };
                 let id = ast::PolicyID::from_string(id);
                 Ok((id, ast::LiteralPolicy::try_from(p)?))
             })
-            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
+            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
         Ok(Self::new(templates.into_iter(), links.into_iter()))
     }
@@ -461,11 +482,11 @@ impl From<&ast::PolicySet> for models::PolicySet {
 }
 
 impl TryFrom<models::PolicySet> for ast::PolicySet {
-    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Error = ProtobufConversionError;
     fn try_from(pset: models::PolicySet) -> Result<Self, Self::Error> {
-        Ok(ast::PolicySet::try_from(ast::LiteralPolicySet::try_from(
-            pset,
-        )?)?)
+        let literal = ast::LiteralPolicySet::try_from(pset)?;
+        ast::PolicySet::try_from(literal)
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}")))
     }
 }
 

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -16,34 +16,42 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
+use super::ast::ProtoToAstError;
 use super::models;
 use cedar_policy_core::{ast, FromNormalizedStr};
 use std::collections::HashMap;
 
-impl From<models::Policy> for ast::LiteralPolicy {
-    fn from(v: models::Policy) -> Self {
+impl TryFrom<models::Policy> for ast::LiteralPolicy {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Policy) -> Result<Self, Self::Error> {
         let mut values: ast::SlotEnv = HashMap::new();
         if let Some(principal_euid) = v.principal_euid {
             values.insert(
                 ast::SlotId::principal(),
-                ast::EntityUID::from(principal_euid),
+                ast::EntityUID::try_from(principal_euid)?,
             );
         }
         if let Some(resource_euid) = v.resource_euid {
-            values.insert(ast::SlotId::resource(), ast::EntityUID::from(resource_euid));
+            values.insert(
+                ast::SlotId::resource(),
+                ast::EntityUID::try_from(resource_euid)?,
+            );
         }
 
         let template_id = ast::PolicyID::from_string(v.template_id);
 
         if v.is_template_link {
-            #[expect(clippy::expect_used, reason = "experimental feature")]
-            Self::template_linked_policy(
+            Ok(Self::template_linked_policy(
                 template_id,
-                ast::PolicyID::from_string(v.link_id.as_ref().expect("link_id field should exist")),
+                ast::PolicyID::from_string(
+                    v.link_id
+                        .as_ref()
+                        .ok_or_else(|| ProtoToAstError::missing("link_id"))?,
+                ),
                 values,
-            )
+            ))
         } else {
-            Self::static_policy(template_id)
+            Ok(Self::static_policy(template_id))
         }
     }
 }
@@ -90,49 +98,56 @@ impl From<&ast::Policy> for models::Policy {
     }
 }
 
-impl From<models::TemplateBody> for ast::Template {
-    fn from(v: models::TemplateBody) -> Self {
-        ast::Template::from(ast::TemplateBody::from(v))
+impl TryFrom<models::TemplateBody> for ast::Template {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
+        Ok(ast::Template::from(ast::TemplateBody::try_from(v)?))
     }
 }
 
-impl From<models::TemplateBody> for ast::TemplateBody {
-    #[expect(
-        clippy::expect_used,
-        clippy::unwrap_used,
-        reason = "experimental feature"
-    )]
-    fn from(v: models::TemplateBody) -> Self {
-        ast::TemplateBody::new(
+impl TryFrom<models::TemplateBody> for ast::TemplateBody {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
+        let effect = models::Effect::try_from(v.effect)
+            .map_err(|e| ProtoToAstError(format!("invalid effect: {e}")))?;
+        Ok(ast::TemplateBody::new(
             ast::PolicyID::from_string(v.id),
             None,
             v.annotations
                 .into_iter()
                 .map(|(key, value)| {
-                    (
-                        ast::AnyId::from_normalized_str(&key).unwrap(),
-                        ast::Annotation {
-                            val: value.into(),
-                            loc: None,
-                        },
-                    )
+                    ast::AnyId::from_normalized_str(&key)
+                        .map(|k| {
+                            (
+                                k,
+                                ast::Annotation {
+                                    val: value.into(),
+                                    loc: None,
+                                },
+                            )
+                        })
+                        .map_err(|e| {
+                            ProtoToAstError(format!("invalid annotation key `{key}`: {e}"))
+                        })
                 })
-                .collect(),
-            ast::Effect::from(models::Effect::try_from(v.effect).expect("decode should succeed")),
-            ast::PrincipalConstraint::from(
+                .collect::<Result<_, _>>()?,
+            ast::Effect::from(effect),
+            ast::PrincipalConstraint::try_from(
                 v.principal_constraint
-                    .expect("principal_constraint field should exist"),
-            ),
-            ast::ActionConstraint::from(
+                    .ok_or_else(|| ProtoToAstError::missing("principal_constraint"))?,
+            )?,
+            ast::ActionConstraint::try_from(
                 v.action_constraint
-                    .expect("action_constraint field should exist"),
-            ),
-            ast::ResourceConstraint::from(
+                    .ok_or_else(|| ProtoToAstError::missing("action_constraint"))?,
+            )?,
+            ast::ResourceConstraint::try_from(
                 v.resource_constraint
-                    .expect("resource_constraint field should exist"),
-            ),
-            v.non_scope_constraints.map(ast::Expr::from),
-        )
+                    .ok_or_else(|| ProtoToAstError::missing("resource_constraint"))?,
+            )?,
+            v.non_scope_constraints
+                .map(ast::Expr::try_from)
+                .transpose()?,
+        ))
     }
 }
 
@@ -165,9 +180,10 @@ impl From<&ast::Template> for models::TemplateBody {
     }
 }
 
-impl From<models::PrincipalOrResourceConstraint> for ast::PrincipalConstraint {
-    fn from(v: models::PrincipalOrResourceConstraint) -> Self {
-        Self::new(ast::PrincipalOrResourceConstraint::from(v))
+impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalConstraint {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
+        Ok(Self::new(ast::PrincipalOrResourceConstraint::try_from(v)?))
     }
 }
 
@@ -177,9 +193,10 @@ impl From<&ast::PrincipalConstraint> for models::PrincipalOrResourceConstraint {
     }
 }
 
-impl From<models::PrincipalOrResourceConstraint> for ast::ResourceConstraint {
-    fn from(v: models::PrincipalOrResourceConstraint) -> Self {
-        Self::new(ast::PrincipalOrResourceConstraint::from(v))
+impl TryFrom<models::PrincipalOrResourceConstraint> for ast::ResourceConstraint {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
+        Ok(Self::new(ast::PrincipalOrResourceConstraint::try_from(v)?))
     }
 }
 
@@ -189,19 +206,20 @@ impl From<&ast::ResourceConstraint> for models::PrincipalOrResourceConstraint {
     }
 }
 
-impl From<models::EntityReference> for ast::EntityReference {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::EntityReference) -> Self {
-        match v.data.expect("data field should exist") {
+impl TryFrom<models::EntityReference> for ast::EntityReference {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::EntityReference) -> Result<Self, Self::Error> {
+        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
             models::entity_reference::Data::Slot(slot) => {
-                match models::entity_reference::Slot::try_from(slot).expect("decode should succeed")
+                match models::entity_reference::Slot::try_from(slot)
+                    .map_err(|e| ProtoToAstError(format!("invalid entity reference slot: {e}")))?
                 {
-                    models::entity_reference::Slot::Unit => ast::EntityReference::Slot(None),
+                    models::entity_reference::Slot::Unit => Ok(ast::EntityReference::Slot(None)),
                 }
             }
-            models::entity_reference::Data::Euid(euid) => {
-                ast::EntityReference::euid(ast::EntityUID::from(euid).into())
-            }
+            models::entity_reference::Data::Euid(euid) => Ok(ast::EntityReference::euid(
+                ast::EntityUID::try_from(euid)?.into(),
+            )),
         }
     }
 }
@@ -223,41 +241,49 @@ impl From<&ast::EntityReference> for models::EntityReference {
     }
 }
 
-impl From<models::PrincipalOrResourceConstraint> for ast::PrincipalOrResourceConstraint {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::PrincipalOrResourceConstraint) -> Self {
-        match v.data.expect("data field should exist") {
+impl TryFrom<models::PrincipalOrResourceConstraint> for ast::PrincipalOrResourceConstraint {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::PrincipalOrResourceConstraint) -> Result<Self, Self::Error> {
+        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
             models::principal_or_resource_constraint::Data::Any(unit) => {
-                match models::principal_or_resource_constraint::Any::try_from(unit)
-                    .expect("decode should succeed")
-                {
+                match models::principal_or_resource_constraint::Any::try_from(unit).map_err(
+                    |e| ProtoToAstError(format!("invalid principal/resource constraint: {e}")),
+                )? {
                     models::principal_or_resource_constraint::Any::Unit => {
-                        ast::PrincipalOrResourceConstraint::Any
+                        Ok(ast::PrincipalOrResourceConstraint::Any)
                     }
                 }
             }
-            models::principal_or_resource_constraint::Data::In(msg) => {
-                ast::PrincipalOrResourceConstraint::In(ast::EntityReference::from(
-                    msg.er.expect("er field should exist"),
-                ))
-            }
-            models::principal_or_resource_constraint::Data::Eq(msg) => {
-                ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::from(
-                    msg.er.expect("er field should exist"),
-                ))
-            }
+            models::principal_or_resource_constraint::Data::In(msg) => Ok(
+                ast::PrincipalOrResourceConstraint::In(ast::EntityReference::try_from(
+                    msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                )?),
+            ),
+            models::principal_or_resource_constraint::Data::Eq(msg) => Ok(
+                ast::PrincipalOrResourceConstraint::Eq(ast::EntityReference::try_from(
+                    msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                )?),
+            ),
             models::principal_or_resource_constraint::Data::Is(msg) => {
-                ast::PrincipalOrResourceConstraint::Is(
-                    ast::EntityType::from(msg.entity_type.expect("entity_type field should exist"))
-                        .into(),
-                )
+                Ok(ast::PrincipalOrResourceConstraint::Is(
+                    ast::EntityType::try_from(
+                        msg.entity_type
+                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                    )?
+                    .into(),
+                ))
             }
             models::principal_or_resource_constraint::Data::IsIn(msg) => {
-                ast::PrincipalOrResourceConstraint::IsIn(
-                    ast::EntityType::from(msg.entity_type.expect("entity_type field should exist"))
-                        .into(),
-                    ast::EntityReference::from(msg.er.expect("er field should exist")),
-                )
+                Ok(ast::PrincipalOrResourceConstraint::IsIn(
+                    ast::EntityType::try_from(
+                        msg.entity_type
+                            .ok_or_else(|| ProtoToAstError::missing("entity_type"))?,
+                    )?
+                    .into(),
+                    ast::EntityReference::try_from(
+                        msg.er.ok_or_else(|| ProtoToAstError::missing("er"))?,
+                    )?,
+                ))
             }
         }
     }
@@ -304,25 +330,29 @@ impl From<&ast::PrincipalOrResourceConstraint> for models::PrincipalOrResourceCo
     }
 }
 
-impl From<models::ActionConstraint> for ast::ActionConstraint {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::ActionConstraint) -> Self {
-        match v.data.expect("data.as_ref()") {
+impl TryFrom<models::ActionConstraint> for ast::ActionConstraint {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::ActionConstraint) -> Result<Self, Self::Error> {
+        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
             models::action_constraint::Data::Any(unit) => {
-                match models::action_constraint::Any::try_from(unit).expect("decode should succeed")
+                match models::action_constraint::Any::try_from(unit)
+                    .map_err(|e| ProtoToAstError(format!("invalid action constraint: {e}")))?
                 {
-                    models::action_constraint::Any::Unit => ast::ActionConstraint::Any,
+                    models::action_constraint::Any::Unit => Ok(ast::ActionConstraint::Any),
                 }
             }
-            models::action_constraint::Data::In(msg) => ast::ActionConstraint::In(
+            models::action_constraint::Data::In(msg) => Ok(ast::ActionConstraint::In(
                 msg.euids
                     .into_iter()
-                    .map(|value| ast::EntityUID::from(value).into())
-                    .collect(),
-            ),
-            models::action_constraint::Data::Eq(msg) => ast::ActionConstraint::Eq(
-                ast::EntityUID::from(msg.euid.expect("euid field should exist")).into(),
-            ),
+                    .map(|value| Ok(ast::EntityUID::try_from(value)?.into()))
+                    .collect::<Result<_, ProtoToAstError>>()?,
+            )),
+            models::action_constraint::Data::Eq(msg) => Ok(ast::ActionConstraint::Eq(
+                ast::EntityUID::try_from(
+                    msg.euid.ok_or_else(|| ProtoToAstError::missing("euid"))?,
+                )?
+                .into(),
+            )),
         }
     }
 }
@@ -380,28 +410,37 @@ impl From<&ast::Effect> for models::Effect {
     }
 }
 
-impl From<models::PolicySet> for ast::LiteralPolicySet {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::PolicySet) -> Self {
-        let templates = v.templates.into_iter().map(|tb| {
-            let id = ast::PolicyID::from_string(&tb.id);
-            (id, ast::Template::from(ast::TemplateBody::from(tb)))
-        });
+impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
+        let templates = v
+            .templates
+            .into_iter()
+            .map(|tb| {
+                let id = ast::PolicyID::from_string(&tb.id);
+                Ok((id, ast::Template::from(ast::TemplateBody::try_from(tb)?)))
+            })
+            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
 
-        let links = v.links.into_iter().map(|p| {
-            // per docs in core.proto, for static policies, `link_id` is omitted/ignored,
-            // and the ID of the policy is the `template_id`.
-            let id = if p.is_template_link {
-                p.link_id
-                    .as_ref()
-                    .expect("template link should have a link_id")
-            } else {
-                &p.template_id
-            };
-            (ast::PolicyID::from_string(id), ast::LiteralPolicy::from(p))
-        });
+        let links = v
+            .links
+            .into_iter()
+            .map(|p| {
+                // per docs in core.proto, for static policies, `link_id` is omitted/ignored,
+                // and the ID of the policy is the `template_id`.
+                let id = if p.is_template_link {
+                    p.link_id
+                        .as_ref()
+                        .ok_or_else(|| ProtoToAstError::missing("link_id"))?
+                } else {
+                    &p.template_id
+                };
+                let id = ast::PolicyID::from_string(id);
+                Ok((id, ast::LiteralPolicy::try_from(p)?))
+            })
+            .collect::<Result<Vec<_>, ProtoToAstError>>()?;
 
-        Self::new(templates, links)
+        Ok(Self::new(templates.into_iter(), links.into_iter()))
     }
 }
 
@@ -422,9 +461,11 @@ impl From<&ast::PolicySet> for models::PolicySet {
 }
 
 impl TryFrom<models::PolicySet> for ast::PolicySet {
-    type Error = ast::ReificationError;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
     fn try_from(pset: models::PolicySet) -> Result<Self, Self::Error> {
-        ast::PolicySet::try_from(ast::LiteralPolicySet::from(pset))
+        Ok(ast::PolicySet::try_from(ast::LiteralPolicySet::try_from(
+            pset,
+        )?)?)
     }
 }
 
@@ -493,13 +534,14 @@ mod test {
         ));
         assert_eq!(
             er1,
-            ast::EntityReference::from(models::EntityReference::from(&er1))
+            ast::EntityReference::try_from(models::EntityReference::from(&er1)).unwrap()
         );
         assert_eq!(
             ast::EntityReference::Slot(None),
-            ast::EntityReference::from(models::EntityReference::from(&ast::EntityReference::Slot(
-                None
-            )))
+            ast::EntityReference::try_from(models::EntityReference::from(
+                &ast::EntityReference::Slot(None)
+            ))
+            .unwrap()
         );
 
         let read_euid = Arc::new(ast::EntityUID::with_eid_and_type("Action", "read").unwrap());
@@ -508,17 +550,18 @@ mod test {
         let ac2 = ast::ActionConstraint::In(vec![read_euid, write_euid]);
         assert_eq!(
             ast::ActionConstraint::Any,
-            ast::ActionConstraint::from(models::ActionConstraint::from(
+            ast::ActionConstraint::try_from(models::ActionConstraint::from(
                 &ast::ActionConstraint::Any
             ))
+            .unwrap()
         );
         assert_eq!(
             ac1,
-            ast::ActionConstraint::from(models::ActionConstraint::from(&ac1))
+            ast::ActionConstraint::try_from(models::ActionConstraint::from(&ac1)).unwrap()
         );
         assert_eq!(
             ac2,
-            ast::ActionConstraint::from(models::ActionConstraint::from(&ac2))
+            ast::ActionConstraint::try_from(models::ActionConstraint::from(&ac2)).unwrap()
         );
 
         let euid1 = Arc::new(ast::EntityUID::with_eid_and_type("A", "friend").unwrap());
@@ -531,44 +574,53 @@ mod test {
         let prc4 = ast::PrincipalOrResourceConstraint::is_entity_type_in(name1, euid1);
         assert_eq!(
             ast::PrincipalOrResourceConstraint::any(),
-            ast::PrincipalOrResourceConstraint::from(models::PrincipalOrResourceConstraint::from(
-                &ast::PrincipalOrResourceConstraint::any()
-            ))
+            ast::PrincipalOrResourceConstraint::try_from(
+                models::PrincipalOrResourceConstraint::from(
+                    &ast::PrincipalOrResourceConstraint::any()
+                )
+            )
+            .unwrap()
         );
         assert_eq!(
             prc1,
-            ast::PrincipalOrResourceConstraint::from(models::PrincipalOrResourceConstraint::from(
-                &prc1
-            ))
+            ast::PrincipalOrResourceConstraint::try_from(
+                models::PrincipalOrResourceConstraint::from(&prc1)
+            )
+            .unwrap()
         );
         assert_eq!(
             prc2,
-            ast::PrincipalOrResourceConstraint::from(models::PrincipalOrResourceConstraint::from(
-                &prc2
-            ))
+            ast::PrincipalOrResourceConstraint::try_from(
+                models::PrincipalOrResourceConstraint::from(&prc2)
+            )
+            .unwrap()
         );
         assert_eq!(
             prc3,
-            ast::PrincipalOrResourceConstraint::from(models::PrincipalOrResourceConstraint::from(
-                &prc3
-            ))
+            ast::PrincipalOrResourceConstraint::try_from(
+                models::PrincipalOrResourceConstraint::from(&prc3)
+            )
+            .unwrap()
         );
         assert_eq!(
             prc4,
-            ast::PrincipalOrResourceConstraint::from(models::PrincipalOrResourceConstraint::from(
-                &prc4
-            ))
+            ast::PrincipalOrResourceConstraint::try_from(
+                models::PrincipalOrResourceConstraint::from(&prc4)
+            )
+            .unwrap()
         );
 
         let pc = ast::PrincipalConstraint::new(prc1);
         let rc = ast::ResourceConstraint::new(prc3);
         assert_eq!(
             pc,
-            ast::PrincipalConstraint::from(models::PrincipalOrResourceConstraint::from(&pc))
+            ast::PrincipalConstraint::try_from(models::PrincipalOrResourceConstraint::from(&pc))
+                .unwrap()
         );
         assert_eq!(
             rc,
-            ast::ResourceConstraint::from(models::PrincipalOrResourceConstraint::from(&rc))
+            ast::ResourceConstraint::try_from(models::PrincipalOrResourceConstraint::from(&rc))
+                .unwrap()
         );
 
         assert_eq!(
@@ -599,7 +651,10 @@ mod test {
             rc.clone(),
             None,
         );
-        assert_eq!(tb, ast::TemplateBody::from(models::TemplateBody::from(&tb)));
+        assert_eq!(
+            tb,
+            ast::TemplateBody::try_from(models::TemplateBody::from(&tb)).unwrap()
+        );
 
         let policy = ast::LiteralPolicy::template_linked_policy(
             ast::PolicyID::from_string("template"),
@@ -611,7 +666,7 @@ mod test {
         );
         assert_eq!(
             policy,
-            ast::LiteralPolicy::from(models::Policy::from(&policy))
+            ast::LiteralPolicy::try_from(models::Policy::from(&policy)).unwrap()
         );
 
         let tb = ast::TemplateBody::new(
@@ -624,7 +679,10 @@ mod test {
             rc,
             None,
         );
-        assert_eq!(tb, ast::TemplateBody::from(models::TemplateBody::from(&tb)));
+        assert_eq!(
+            tb,
+            ast::TemplateBody::try_from(models::TemplateBody::from(&tb)).unwrap()
+        );
 
         let policy = ast::LiteralPolicy::template_linked_policy(
             ast::PolicyID::from_string("template\0\n \' \"+-$^!"),
@@ -636,7 +694,7 @@ mod test {
         );
         assert_eq!(
             policy,
-            ast::LiteralPolicy::from(models::Policy::from(&policy))
+            ast::LiteralPolicy::try_from(models::Policy::from(&policy)).unwrap()
         );
     }
 
@@ -696,7 +754,8 @@ mod test {
         )
         .unwrap();
         let mut mps = models::PolicySet::from(&ps);
-        let mut mps_roundtrip = models::PolicySet::from(&ast::LiteralPolicySet::from(mps.clone()));
+        let mut mps_roundtrip =
+            models::PolicySet::from(&ast::LiteralPolicySet::try_from(mps.clone()).unwrap());
 
         // we accept permutations as equivalent, so before comparison, we sort
         // both `.templates` and `.links`
@@ -766,7 +825,8 @@ mod test {
         )
         .unwrap();
         let mut mps = models::PolicySet::from(&ps);
-        let mut mps_roundtrip = models::PolicySet::from(&ast::LiteralPolicySet::from(mps.clone()));
+        let mut mps_roundtrip =
+            models::PolicySet::from(&ast::LiteralPolicySet::try_from(mps.clone()).unwrap());
 
         // we accept permutations as equivalent, so before comparison, we sort
         // both `.templates` and `.links`

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -495,6 +495,7 @@ mod test {
     use std::sync::Arc;
 
     use super::*;
+    use cool_asserts::assert_matches;
 
     // We add `PartialOrd` and `Ord` implementations for both `models::Policy` and
     // `models::TemplateBody`, so that these can be sorted for testing purposes
@@ -859,5 +860,207 @@ mod test {
         // Can't compare `models::PolicySet` directly, so we compare their fields
         assert_eq!(mps.templates, mps_roundtrip.templates);
         assert_eq!(mps.links, mps_roundtrip.links);
+    }
+
+    #[test]
+    fn template_body_try_from_missing_principal_constraint() {
+        let bad = models::TemplateBody {
+            id: "t".to_string(),
+            annotations: Default::default(),
+            effect: models::Effect::Permit.into(),
+            principal_constraint: None,
+            action_constraint: Some(models::ActionConstraint {
+                data: Some(models::action_constraint::Data::Any(
+                    models::action_constraint::Any::Unit.into(),
+                )),
+            }),
+            resource_constraint: Some(models::PrincipalOrResourceConstraint {
+                data: Some(models::principal_or_resource_constraint::Data::Any(
+                    models::principal_or_resource_constraint::Any::Unit.into(),
+                )),
+            }),
+            non_scope_constraints: None,
+        };
+        assert_matches!(
+            ast::TemplateBody::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "principal_constraint"
+        );
+    }
+
+    #[test]
+    fn template_body_try_from_invalid_annotation_key() {
+        let bad = models::TemplateBody {
+            id: "t".to_string(),
+            annotations: [("".to_string(), "v".to_string())].into_iter().collect(),
+            effect: models::Effect::Permit.into(),
+            principal_constraint: Some(models::PrincipalOrResourceConstraint {
+                data: Some(models::principal_or_resource_constraint::Data::Any(
+                    models::principal_or_resource_constraint::Any::Unit.into(),
+                )),
+            }),
+            action_constraint: Some(models::ActionConstraint {
+                data: Some(models::action_constraint::Data::Any(
+                    models::action_constraint::Any::Unit.into(),
+                )),
+            }),
+            resource_constraint: Some(models::PrincipalOrResourceConstraint {
+                data: Some(models::principal_or_resource_constraint::Data::Any(
+                    models::principal_or_resource_constraint::Any::Unit.into(),
+                )),
+            }),
+            non_scope_constraints: None,
+        };
+        assert_matches!(
+            ast::TemplateBody::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("invalid annotation key")
+        );
+    }
+
+    #[test]
+    fn entity_reference_try_from_missing_data() {
+        let bad = models::EntityReference { data: None };
+        assert_matches!(
+            ast::EntityReference::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "data"
+        );
+    }
+
+    #[test]
+    fn principal_or_resource_constraint_try_from_missing_data() {
+        let bad = models::PrincipalOrResourceConstraint { data: None };
+        assert_matches!(
+            ast::PrincipalOrResourceConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "data"
+        );
+    }
+
+    #[test]
+    fn principal_or_resource_constraint_try_from_in_missing_er() {
+        let bad = models::PrincipalOrResourceConstraint {
+            data: Some(models::principal_or_resource_constraint::Data::In(
+                models::principal_or_resource_constraint::InMessage { er: None },
+            )),
+        };
+        assert_matches!(
+            ast::PrincipalOrResourceConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "er"
+        );
+    }
+
+    #[test]
+    fn principal_or_resource_constraint_try_from_eq_missing_er() {
+        let bad = models::PrincipalOrResourceConstraint {
+            data: Some(models::principal_or_resource_constraint::Data::Eq(
+                models::principal_or_resource_constraint::EqMessage { er: None },
+            )),
+        };
+        assert_matches!(
+            ast::PrincipalOrResourceConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "er"
+        );
+    }
+
+    #[test]
+    fn principal_or_resource_constraint_try_from_is_missing_entity_type() {
+        let bad = models::PrincipalOrResourceConstraint {
+            data: Some(models::principal_or_resource_constraint::Data::Is(
+                models::principal_or_resource_constraint::IsMessage { entity_type: None },
+            )),
+        };
+        assert_matches!(
+            ast::PrincipalOrResourceConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "entity_type"
+        );
+    }
+
+    #[test]
+    fn principal_or_resource_constraint_try_from_is_in_missing_entity_type() {
+        let bad = models::PrincipalOrResourceConstraint {
+            data: Some(models::principal_or_resource_constraint::Data::IsIn(
+                models::principal_or_resource_constraint::IsInMessage {
+                    entity_type: None,
+                    er: None,
+                },
+            )),
+        };
+        assert_matches!(
+            ast::PrincipalOrResourceConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "entity_type"
+        );
+    }
+
+    #[test]
+    fn action_constraint_try_from_missing_data() {
+        let bad = models::ActionConstraint { data: None };
+        assert_matches!(
+            ast::ActionConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "data"
+        );
+    }
+
+    #[test]
+    fn action_constraint_try_from_eq_missing_euid() {
+        let bad = models::ActionConstraint {
+            data: Some(models::action_constraint::Data::Eq(
+                models::action_constraint::EqMessage { euid: None },
+            )),
+        };
+        assert_matches!(
+            ast::ActionConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "euid"
+        );
+    }
+
+    #[test]
+    fn literal_policy_try_from_template_link_missing_link_id() {
+        let bad = models::Policy {
+            template_id: "t".to_string(),
+            link_id: None,
+            is_template_link: true,
+            principal_euid: None,
+            resource_euid: None,
+        };
+        assert_matches!(
+            ast::LiteralPolicy::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_try_from_link_missing_link_id() {
+        let bad = models::PolicySet {
+            templates: vec![models::TemplateBody {
+                id: "t".to_string(),
+                annotations: Default::default(),
+                effect: models::Effect::Permit.into(),
+                principal_constraint: Some(models::PrincipalOrResourceConstraint {
+                    data: Some(models::principal_or_resource_constraint::Data::Any(
+                        models::principal_or_resource_constraint::Any::Unit.into(),
+                    )),
+                }),
+                action_constraint: Some(models::ActionConstraint {
+                    data: Some(models::action_constraint::Data::Any(
+                        models::action_constraint::Any::Unit.into(),
+                    )),
+                }),
+                resource_constraint: Some(models::PrincipalOrResourceConstraint {
+                    data: Some(models::principal_or_resource_constraint::Data::Any(
+                        models::principal_or_resource_constraint::Any::Unit.into(),
+                    )),
+                }),
+                non_scope_constraints: None,
+            }],
+            links: vec![models::Policy {
+                template_id: "t".to_string(),
+                link_id: None,
+                is_template_link: true,
+                principal_euid: None,
+                resource_euid: None,
+            }],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
+        );
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -461,7 +461,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
-        Ok(Self::new(templates.into_iter(), links.into_iter()))
+        Ok(Self::new(templates, links))
     }
 }
 

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use super::ast::ProtobufConversionError;
+
 /// Error type for protobuf decoding failures
 #[derive(Debug, thiserror::Error)]
 pub enum DecodeError {
@@ -22,13 +24,19 @@ pub enum DecodeError {
     Proto(prost::DecodeError),
     /// The protobuf message was well-formed but its contents could not be
     /// converted into the target Cedar type
-    #[error("invalid protobuf message contents: {0}")]
-    Conversion(Box<dyn std::error::Error + Send + Sync>),
+    #[error(transparent)]
+    Conversion(ProtobufConversionError),
 }
 
 impl From<prost::DecodeError> for DecodeError {
     fn from(e: prost::DecodeError) -> Self {
         Self::Proto(e)
+    }
+}
+
+impl From<ProtobufConversionError> for DecodeError {
+    fn from(e: ProtobufConversionError) -> Self {
+        Self::Conversion(e)
     }
 }
 
@@ -79,7 +87,7 @@ pub(crate) fn decode<M: prost::Message + Default, T: From<M>>(
 /// where the conversion from `M` to `T` is fallible
 pub(crate) fn try_decode<
     M: prost::Message + Default,
-    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    E: Into<ProtobufConversionError>,
     T: TryFrom<M, Error = E>,
 >(
     buf: impl prost::bytes::Buf,

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -76,7 +76,10 @@ pub(crate) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
 use std::default::Default;
 
 /// Decode something of type `T` from `buf` using the protobuf format `M`
-#[expect(dead_code, reason = "available for types with infallible From conversions")]
+#[expect(
+    dead_code,
+    reason = "available for types with infallible From conversions"
+)]
 pub(crate) fn decode<M: prost::Message + Default, T: From<M>>(
     buf: impl prost::bytes::Buf,
 ) -> Result<T, DecodeError> {

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -14,6 +14,24 @@
  * limitations under the License.
  */
 
+/// Error type for protobuf decoding failures
+#[derive(Debug, thiserror::Error)]
+pub enum DecodeError {
+    /// The input buffer does not contain a valid protobuf message
+    #[error(transparent)]
+    Proto(prost::DecodeError),
+    /// The protobuf message was well-formed but its contents could not be
+    /// converted into the target Cedar type
+    #[error("invalid protobuf message contents: {0}")]
+    Conversion(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<prost::DecodeError> for DecodeError {
+    fn from(e: prost::DecodeError) -> Self {
+        Self::Proto(e)
+    }
+}
+
 /// Trait allowing serializing and deserializing in protobuf format
 pub trait Protobuf: Sized {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
@@ -22,9 +40,10 @@ pub trait Protobuf: Sized {
     ///
     /// # Errors
     ///
-    /// Will return a `prost::DecodeError` when the input buffer does not contain a
-    /// valid Protobuf message.
-    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError>;
+    /// Will return [`DecodeError::Proto`] when the input buffer does not
+    /// contain a valid protobuf message, or [`DecodeError::Conversion`] when
+    /// the message is well-formed but cannot be converted into the target type.
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError>;
 }
 
 /// Encode `thing` into `buf` using the protobuf format `M`
@@ -49,15 +68,23 @@ pub(crate) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
 use std::default::Default;
 
 /// Decode something of type `T` from `buf` using the protobuf format `M`
+#[expect(dead_code, reason = "available for types with infallible From conversions")]
 pub(crate) fn decode<M: prost::Message + Default, T: From<M>>(
     buf: impl prost::bytes::Buf,
-) -> Result<T, prost::DecodeError> {
-    M::decode(buf).map(T::from)
+) -> Result<T, DecodeError> {
+    Ok(M::decode(buf)?.into())
 }
 
-/// Decode something of type `T` from `buf` using the protobuf format `M`
-pub(crate) fn try_decode<M: prost::Message + Default, E, T: TryFrom<M, Error = E>>(
+/// Decode something of type `T` from `buf` using the protobuf format `M`,
+/// where the conversion from `M` to `T` is fallible
+pub(crate) fn try_decode<
+    M: prost::Message + Default,
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    T: TryFrom<M, Error = E>,
+>(
     buf: impl prost::bytes::Buf,
-) -> Result<Result<T, E>, prost::DecodeError> {
-    M::decode(buf).map(T::try_from)
+) -> Result<T, DecodeError> {
+    M::decode(buf)?
+        .try_into()
+        .map_err(|e: E| DecodeError::Conversion(e.into()))
 }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -323,10 +323,12 @@ mod test {
     use std::sync::Arc;
 
     use super::models;
+    use super::ProtobufConversionError;
     use cedar_policy_core::validator::types::{
         AttributeType, BoolType, EntityKind, EntityLUB, OpenTag, Type,
     };
     use cedar_policy_core::validator::ValidatorSchema;
+    use cool_asserts::assert_matches;
     use similar_asserts::assert_eq;
 
     #[test]
@@ -454,6 +456,90 @@ mod test {
         namespace Another {
           action Do;
         }"#,
+        );
+    }
+
+    #[test]
+    fn validation_mode_roundtrip() {
+        use cedar_policy_core::validator::ValidationMode;
+        assert_eq!(
+            ValidationMode::Strict,
+            ValidationMode::try_from(models::ValidationMode::from(&ValidationMode::Strict))
+                .unwrap()
+        );
+        assert_eq!(
+            ValidationMode::Permissive,
+            ValidationMode::try_from(models::ValidationMode::from(&ValidationMode::Permissive))
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn action_decl_try_from_missing_name() {
+        let bad = models::ActionDecl {
+            name: None,
+            principal_types: vec![],
+            resource_types: vec![],
+            descendants: vec![],
+            context: Default::default(),
+        };
+        assert_matches!(
+            cedar_policy_core::validator::ValidatorActionId::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "name"
+        );
+    }
+
+    #[test]
+    fn entity_decl_try_from_missing_name() {
+        let bad = models::EntityDecl {
+            name: None,
+            descendants: vec![],
+            attributes: Default::default(),
+            tags: None,
+            enum_choices: vec![],
+        };
+        assert_matches!(
+            cedar_policy_core::validator::ValidatorEntityType::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "name"
+        );
+    }
+
+    #[test]
+    fn type_try_from_missing_data() {
+        let bad = models::Type { data: None };
+        assert_matches!(
+            Type::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "data"
+        );
+    }
+
+    #[test]
+    fn attribute_type_try_from_missing_attr_type() {
+        let bad = models::AttributeType {
+            attr_type: None,
+            is_required: true,
+        };
+        assert_matches!(
+            cedar_policy_core::validator::types::AttributeType::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "attr_type"
+        );
+    }
+
+    #[test]
+    fn schema_try_from_invalid_entity_decl() {
+        let bad = models::Schema {
+            entity_decls: vec![models::EntityDecl {
+                name: None,
+                descendants: vec![],
+                attributes: Default::default(),
+                tags: None,
+                enum_choices: vec![],
+            }],
+            action_decls: vec![],
+        };
+        assert_matches!(
+            ValidatorSchema::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "name"
         );
     }
 }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -16,6 +16,7 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
+use super::ast::ProtoToAstError;
 use super::models;
 use cedar_policy_core::ast::{self, Eid};
 use cedar_policy_core::validator::types;
@@ -33,16 +34,19 @@ impl From<&cedar_policy_core::validator::ValidatorSchema> for models::Schema {
     }
 }
 
-impl From<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
-    fn from(v: models::Schema) -> Self {
-        Self::new(
+impl TryFrom<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Schema) -> Result<Self, Self::Error> {
+        Ok(Self::new(
             v.entity_decls
                 .into_iter()
-                .map(cedar_policy_core::validator::ValidatorEntityType::from),
+                .map(cedar_policy_core::validator::ValidatorEntityType::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             v.action_decls
                 .into_iter()
-                .map(cedar_policy_core::validator::ValidatorActionId::from),
-        )
+                .map(cedar_policy_core::validator::ValidatorActionId::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        ))
     }
 }
 
@@ -61,20 +65,21 @@ impl From<&cedar_policy_core::validator::ValidationMode> for models::ValidationM
     }
 }
 
-impl From<models::ValidationMode> for cedar_policy_core::validator::ValidationMode {
-    fn from(v: models::ValidationMode) -> Self {
+impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::ValidationMode {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::ValidationMode) -> Result<Self, Self::Error> {
         match v {
-            models::ValidationMode::Strict => cedar_policy_core::validator::ValidationMode::Strict,
+            models::ValidationMode::Strict => Ok(cedar_policy_core::validator::ValidationMode::Strict),
             models::ValidationMode::Permissive => {
-                cedar_policy_core::validator::ValidationMode::Permissive
+                Ok(cedar_policy_core::validator::ValidationMode::Permissive)
             }
             #[cfg(feature = "partial-validate")]
             models::ValidationMode::Partial => {
-                cedar_policy_core::validator::ValidationMode::Partial
+                Ok(cedar_policy_core::validator::ValidationMode::Partial)
             }
             #[cfg(not(feature = "partial-validate"))]
             models::ValidationMode::Partial => {
-                panic!("Protobuf specifies partial validation, but `partial-validate` feature not enabled in this build")
+                Err(ProtoToAstError::missing("partial-validate feature (required for partial validation mode)"))
             }
         }
     }
@@ -101,20 +106,20 @@ impl From<&cedar_policy_core::validator::ValidatorActionId> for models::ActionDe
     }
 }
 
-impl From<models::ActionDecl> for cedar_policy_core::validator::ValidatorActionId {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::ActionDecl) -> Self {
-        Self::new(
-            ast::EntityUID::from(v.name.expect("name field should exist")),
-            v.principal_types.into_iter().map(ast::EntityType::from),
-            v.resource_types.into_iter().map(ast::EntityType::from),
-            v.descendants.into_iter().map(ast::EntityUID::from),
+impl TryFrom<models::ActionDecl> for cedar_policy_core::validator::ValidatorActionId {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::ActionDecl) -> Result<Self, Self::Error> {
+        Ok(Self::new(
+            ast::EntityUID::try_from(v.name.ok_or_else(|| ProtoToAstError::missing("name"))?)?,
+            v.principal_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
+            v.resource_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
+            v.descendants.into_iter().map(ast::EntityUID::try_from).collect::<Result<Vec<_>, _>>()?,
             types::Type::Record {
-                attrs: model_to_attributes(v.context),
+                attrs: model_to_attributes(v.context)?,
                 open_attributes: types::OpenTag::default(),
             },
             None,
-        )
+        ))
     }
 }
 
@@ -146,56 +151,56 @@ impl From<&cedar_policy_core::validator::ValidatorEntityType> for models::Entity
     }
 }
 
-impl From<models::EntityDecl> for cedar_policy_core::validator::ValidatorEntityType {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::EntityDecl) -> Self {
-        let name = ast::EntityType::from(v.name.expect("name field should exist"));
-        let descendants = v.descendants.into_iter().map(ast::EntityType::from);
+impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEntityType {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::EntityDecl) -> Result<Self, Self::Error> {
+        let name = ast::EntityType::try_from(v.name.ok_or_else(|| ProtoToAstError::missing("name"))?)?;
+        let descendants = v.descendants.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?;
         match NonEmpty::collect(v.enum_choices.into_iter().map(SmolStr::from)) {
             // `enum_choices` is empty, so `v` represents a standard entity type
-            None => Self::new_standard(
+            None => Ok(Self::new_standard(
                 name,
                 descendants,
-                model_to_attributes(v.attributes),
+                model_to_attributes(v.attributes)?,
                 types::OpenTag::default(),
-                v.tags.map(types::Type::from),
+                v.tags.map(types::Type::try_from).transpose()?,
                 None,
-            ),
+            )),
             Some(enum_choices) => {
                 // `enum_choices` is not empty, so `v` represents an enumerated entity type.
                 // enumerated entity types must have no attributes or tags.
                 assert_eq!(v.attributes, HashMap::new());
                 assert_eq!(v.tags, None);
-                Self::new_enum(name, descendants, enum_choices.map(Eid::new), None)
+                Ok(Self::new_enum(name, descendants, enum_choices.map(Eid::new), None))
             }
         }
     }
 }
 
-impl From<models::Type> for types::Type {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::Type) -> Self {
-        match v.data.expect("data field should exist") {
+impl TryFrom<models::Type> for types::Type {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::Type) -> Result<Self, Self::Error> {
+        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
             models::r#type::Data::Prim(vt) => {
-                match models::r#type::Prim::try_from(vt).expect("decode should succeed") {
-                    models::r#type::Prim::Bool => types::Type::primitive_boolean(),
-                    models::r#type::Prim::String => types::Type::primitive_string(),
-                    models::r#type::Prim::Long => types::Type::primitive_long(),
+                match models::r#type::Prim::try_from(vt).map_err(|e| ProtoToAstError::missing(&format!("valid prim variant: {e}")))? {
+                    models::r#type::Prim::Bool => Ok(types::Type::primitive_boolean()),
+                    models::r#type::Prim::String => Ok(types::Type::primitive_string()),
+                    models::r#type::Prim::Long => Ok(types::Type::primitive_long()),
                 }
             }
-            models::r#type::Data::SetElem(elty) => types::Type::Set {
-                element_type: Some(Arc::new(types::Type::from(*elty))),
-            },
-            models::r#type::Data::Entity(e) => types::Type::Entity(types::EntityKind::Entity(
-                types::EntityLUB::single_entity(ast::EntityType::from(e)),
-            )),
-            models::r#type::Data::Record(r) => types::Type::Record {
-                attrs: model_to_attributes(r.attrs),
+            models::r#type::Data::SetElem(elty) => Ok(types::Type::Set {
+                element_type: Some(Arc::new(types::Type::try_from(*elty)?)),
+            }),
+            models::r#type::Data::Entity(e) => Ok(types::Type::Entity(types::EntityKind::Entity(
+                types::EntityLUB::single_entity(ast::EntityType::try_from(e)?),
+            ))),
+            models::r#type::Data::Record(r) => Ok(types::Type::Record {
+                attrs: model_to_attributes(r.attrs)?,
                 open_attributes: types::OpenTag::default(),
-            },
-            models::r#type::Data::Ext(name) => types::Type::ExtensionType {
-                name: ast::Name::from(name),
-            },
+            }),
+            models::r#type::Data::Ext(name) => Ok(types::Type::ExtensionType {
+                name: ast::Name::try_from(name)?,
+            }),
         }
     }
 }
@@ -241,8 +246,12 @@ impl From<&types::Type> for models::Type {
     }
 }
 
-fn model_to_attributes(v: HashMap<String, models::AttributeType>) -> types::Attributes {
-    types::Attributes::with_attributes(v.into_iter().map(|(k, v)| (k.into(), v.into())))
+fn model_to_attributes(v: HashMap<String, models::AttributeType>) -> Result<types::Attributes, ProtoToAstError> {
+    Ok(types::Attributes::with_attributes(
+        v.into_iter()
+            .map(|(k, v)| Ok((k.into(), types::AttributeType::try_from(v)?)))
+            .collect::<Result<Vec<_>, ProtoToAstError>>()?,
+    ))
 }
 
 fn attributes_to_model(v: &types::Attributes) -> HashMap<String, models::AttributeType> {
@@ -251,15 +260,15 @@ fn attributes_to_model(v: &types::Attributes) -> HashMap<String, models::Attribu
         .collect()
 }
 
-impl From<models::AttributeType> for types::AttributeType {
-    #[expect(clippy::expect_used, reason = "experimental feature")]
-    fn from(v: models::AttributeType) -> Self {
-        Self {
-            attr_type: types::Type::from(v.attr_type.expect("attr_type field should exist")).into(),
+impl TryFrom<models::AttributeType> for types::AttributeType {
+    type Error = ProtoToAstError;
+    fn try_from(v: models::AttributeType) -> Result<Self, Self::Error> {
+        Ok(Self {
+            attr_type: types::Type::try_from(v.attr_type.ok_or_else(|| ProtoToAstError::missing("attr_type"))?)?.into(),
             is_required: v.is_required,
             #[cfg(feature = "extended-schema")]
             loc: None,
-        }
+        })
     }
 }
 
@@ -287,7 +296,7 @@ mod test {
     fn type_roundtrip() {
         #[track_caller]
         fn assert_type_roundtrip(ty: Type) {
-            assert_eq!(ty, models::Type::from(&ty).into());
+            assert_eq!(ty, Type::try_from(models::Type::from(&ty)).unwrap());
         }
 
         assert_type_roundtrip(Type::Bool(BoolType::AnyBool));
@@ -348,7 +357,10 @@ mod test {
     #[track_caller]
     fn assert_schema_roundtrip(src: &str) {
         let schema: ValidatorSchema = src.parse().expect("failed to parse cedar schema");
-        assert_eq!(schema, models::Schema::from(&schema).into());
+        assert_eq!(
+            schema,
+            ValidatorSchema::try_from(models::Schema::from(&schema)).unwrap()
+        );
     }
 
     #[test]

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -69,7 +69,9 @@ impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::Validatio
     type Error = ProtobufConversionError;
     fn try_from(v: models::ValidationMode) -> Result<Self, Self::Error> {
         match v {
-            models::ValidationMode::Strict => Ok(cedar_policy_core::validator::ValidationMode::Strict),
+            models::ValidationMode::Strict => {
+                Ok(cedar_policy_core::validator::ValidationMode::Strict)
+            }
             models::ValidationMode::Permissive => {
                 Ok(cedar_policy_core::validator::ValidationMode::Permissive)
             }
@@ -78,9 +80,9 @@ impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::Validatio
                 Ok(cedar_policy_core::validator::ValidationMode::Partial)
             }
             #[cfg(not(feature = "partial-validate"))]
-            models::ValidationMode::Partial => {
-                Err(ProtobufConversionError::missing("partial-validate feature (required for partial validation mode)"))
-            }
+            models::ValidationMode::Partial => Err(ProtobufConversionError::missing(
+                "partial-validate feature (required for partial validation mode)",
+            )),
         }
     }
 }
@@ -110,10 +112,22 @@ impl TryFrom<models::ActionDecl> for cedar_policy_core::validator::ValidatorActi
     type Error = ProtobufConversionError;
     fn try_from(v: models::ActionDecl) -> Result<Self, Self::Error> {
         Ok(Self::new(
-            ast::EntityUID::try_from(v.name.ok_or_else(|| ProtobufConversionError::missing("name"))?)?,
-            v.principal_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
-            v.resource_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
-            v.descendants.into_iter().map(ast::EntityUID::try_from).collect::<Result<Vec<_>, _>>()?,
+            ast::EntityUID::try_from(
+                v.name
+                    .ok_or_else(|| ProtobufConversionError::missing("name"))?,
+            )?,
+            v.principal_types
+                .into_iter()
+                .map(ast::EntityType::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            v.resource_types
+                .into_iter()
+                .map(ast::EntityType::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            v.descendants
+                .into_iter()
+                .map(ast::EntityUID::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             types::Type::Record {
                 attrs: model_to_attributes(v.context)?,
                 open_attributes: types::OpenTag::default(),
@@ -154,8 +168,15 @@ impl From<&cedar_policy_core::validator::ValidatorEntityType> for models::Entity
 impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEntityType {
     type Error = ProtobufConversionError;
     fn try_from(v: models::EntityDecl) -> Result<Self, Self::Error> {
-        let name = ast::EntityType::try_from(v.name.ok_or_else(|| ProtobufConversionError::missing("name"))?)?;
-        let descendants = v.descendants.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?;
+        let name = ast::EntityType::try_from(
+            v.name
+                .ok_or_else(|| ProtobufConversionError::missing("name"))?,
+        )?;
+        let descendants = v
+            .descendants
+            .into_iter()
+            .map(ast::EntityType::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
         match NonEmpty::collect(v.enum_choices.into_iter().map(SmolStr::from)) {
             // `enum_choices` is empty, so `v` represents a standard entity type
             None => Ok(Self::new_standard(
@@ -171,7 +192,12 @@ impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEnti
                 // enumerated entity types must have no attributes or tags.
                 assert_eq!(v.attributes, HashMap::new());
                 assert_eq!(v.tags, None);
-                Ok(Self::new_enum(name, descendants, enum_choices.map(Eid::new), None))
+                Ok(Self::new_enum(
+                    name,
+                    descendants,
+                    enum_choices.map(Eid::new),
+                    None,
+                ))
             }
         }
     }
@@ -180,9 +206,14 @@ impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEnti
 impl TryFrom<models::Type> for types::Type {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Type) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtobufConversionError::missing("data"))? {
+        match v
+            .data
+            .ok_or_else(|| ProtobufConversionError::missing("data"))?
+        {
             models::r#type::Data::Prim(vt) => {
-                match models::r#type::Prim::try_from(vt).map_err(|e| ProtobufConversionError::missing(&format!("valid prim variant: {e}")))? {
+                match models::r#type::Prim::try_from(vt).map_err(|e| {
+                    ProtobufConversionError::missing(&format!("valid prim variant: {e}"))
+                })? {
                     models::r#type::Prim::Bool => Ok(types::Type::primitive_boolean()),
                     models::r#type::Prim::String => Ok(types::Type::primitive_string()),
                     models::r#type::Prim::Long => Ok(types::Type::primitive_long()),
@@ -246,7 +277,9 @@ impl From<&types::Type> for models::Type {
     }
 }
 
-fn model_to_attributes(v: HashMap<String, models::AttributeType>) -> Result<types::Attributes, ProtobufConversionError> {
+fn model_to_attributes(
+    v: HashMap<String, models::AttributeType>,
+) -> Result<types::Attributes, ProtobufConversionError> {
     Ok(types::Attributes::with_attributes(
         v.into_iter()
             .map(|(k, v)| Ok((k.into(), types::AttributeType::try_from(v)?)))
@@ -264,7 +297,11 @@ impl TryFrom<models::AttributeType> for types::AttributeType {
     type Error = ProtobufConversionError;
     fn try_from(v: models::AttributeType) -> Result<Self, Self::Error> {
         Ok(Self {
-            attr_type: types::Type::try_from(v.attr_type.ok_or_else(|| ProtobufConversionError::missing("attr_type"))?)?.into(),
+            attr_type: types::Type::try_from(
+                v.attr_type
+                    .ok_or_else(|| ProtobufConversionError::missing("attr_type"))?,
+            )?
+            .into(),
             is_required: v.is_required,
             #[cfg(feature = "extended-schema")]
             loc: None,

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -16,7 +16,7 @@
 
 #![allow(clippy::use_self, reason = "readability")]
 
-use super::ast::ProtoToAstError;
+use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::ast::{self, Eid};
 use cedar_policy_core::validator::types;
@@ -35,7 +35,7 @@ impl From<&cedar_policy_core::validator::ValidatorSchema> for models::Schema {
 }
 
 impl TryFrom<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Schema) -> Result<Self, Self::Error> {
         Ok(Self::new(
             v.entity_decls
@@ -66,7 +66,7 @@ impl From<&cedar_policy_core::validator::ValidationMode> for models::ValidationM
 }
 
 impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::ValidationMode {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::ValidationMode) -> Result<Self, Self::Error> {
         match v {
             models::ValidationMode::Strict => Ok(cedar_policy_core::validator::ValidationMode::Strict),
@@ -79,7 +79,7 @@ impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::Validatio
             }
             #[cfg(not(feature = "partial-validate"))]
             models::ValidationMode::Partial => {
-                Err(ProtoToAstError::missing("partial-validate feature (required for partial validation mode)"))
+                Err(ProtobufConversionError::missing("partial-validate feature (required for partial validation mode)"))
             }
         }
     }
@@ -107,10 +107,10 @@ impl From<&cedar_policy_core::validator::ValidatorActionId> for models::ActionDe
 }
 
 impl TryFrom<models::ActionDecl> for cedar_policy_core::validator::ValidatorActionId {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::ActionDecl) -> Result<Self, Self::Error> {
         Ok(Self::new(
-            ast::EntityUID::try_from(v.name.ok_or_else(|| ProtoToAstError::missing("name"))?)?,
+            ast::EntityUID::try_from(v.name.ok_or_else(|| ProtobufConversionError::missing("name"))?)?,
             v.principal_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
             v.resource_types.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?,
             v.descendants.into_iter().map(ast::EntityUID::try_from).collect::<Result<Vec<_>, _>>()?,
@@ -152,9 +152,9 @@ impl From<&cedar_policy_core::validator::ValidatorEntityType> for models::Entity
 }
 
 impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEntityType {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::EntityDecl) -> Result<Self, Self::Error> {
-        let name = ast::EntityType::try_from(v.name.ok_or_else(|| ProtoToAstError::missing("name"))?)?;
+        let name = ast::EntityType::try_from(v.name.ok_or_else(|| ProtobufConversionError::missing("name"))?)?;
         let descendants = v.descendants.into_iter().map(ast::EntityType::try_from).collect::<Result<Vec<_>, _>>()?;
         match NonEmpty::collect(v.enum_choices.into_iter().map(SmolStr::from)) {
             // `enum_choices` is empty, so `v` represents a standard entity type
@@ -178,11 +178,11 @@ impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEnti
 }
 
 impl TryFrom<models::Type> for types::Type {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::Type) -> Result<Self, Self::Error> {
-        match v.data.ok_or_else(|| ProtoToAstError::missing("data"))? {
+        match v.data.ok_or_else(|| ProtobufConversionError::missing("data"))? {
             models::r#type::Data::Prim(vt) => {
-                match models::r#type::Prim::try_from(vt).map_err(|e| ProtoToAstError::missing(&format!("valid prim variant: {e}")))? {
+                match models::r#type::Prim::try_from(vt).map_err(|e| ProtobufConversionError::missing(&format!("valid prim variant: {e}")))? {
                     models::r#type::Prim::Bool => Ok(types::Type::primitive_boolean()),
                     models::r#type::Prim::String => Ok(types::Type::primitive_string()),
                     models::r#type::Prim::Long => Ok(types::Type::primitive_long()),
@@ -246,11 +246,11 @@ impl From<&types::Type> for models::Type {
     }
 }
 
-fn model_to_attributes(v: HashMap<String, models::AttributeType>) -> Result<types::Attributes, ProtoToAstError> {
+fn model_to_attributes(v: HashMap<String, models::AttributeType>) -> Result<types::Attributes, ProtobufConversionError> {
     Ok(types::Attributes::with_attributes(
         v.into_iter()
             .map(|(k, v)| Ok((k.into(), types::AttributeType::try_from(v)?)))
-            .collect::<Result<Vec<_>, ProtoToAstError>>()?,
+            .collect::<Result<Vec<_>, ProtobufConversionError>>()?,
     ))
 }
 
@@ -261,10 +261,10 @@ fn attributes_to_model(v: &types::Attributes) -> HashMap<String, models::Attribu
 }
 
 impl TryFrom<models::AttributeType> for types::AttributeType {
-    type Error = ProtoToAstError;
+    type Error = ProtobufConversionError;
     fn try_from(v: models::AttributeType) -> Result<Self, Self::Error> {
         Ok(Self {
-            attr_type: types::Type::try_from(v.attr_type.ok_or_else(|| ProtoToAstError::missing("attr_type"))?)?.into(),
+            attr_type: types::Type::try_from(v.attr_type.ok_or_else(|| ProtobufConversionError::missing("attr_type"))?)?.into(),
             is_required: v.is_required,
             #[cfg(feature = "extended-schema")]
             loc: None,


### PR DESCRIPTION
## Description of changes

Removes places where the protobuf decode implementation could panic when converting from the protobuf model to the internal type. The goal is to eliminate panics in protobuf decoding in the API. 
(will update changelog because this changes some of the proto API, from -> try_from)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
