### PR TITLE
Added support for computing the height of an est::Expr iteratively

### DIFF
--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -365,6 +365,54 @@ impl CedarValueJson {
         }
     }
 
+    /// Compute the height of this value tree, defined as the number of
+    /// edges on the longest root-to-leaf path through nested
+    /// `CedarValueJson` nodes.
+    ///
+    /// Leaf nodes (`Bool`, `Long`, `String`, `Null`, `ExprEscape`, and `EntityEscape`)
+    /// have height 0.
+    /// An empty `Set` or empty `Record` also has height 0.
+    ///
+    /// For internal nodes (`Set`, `Record`, and `ExtnEscape`) with at least
+    /// one child, the height is 1 + the maximum height among all
+    /// children.
+    ///
+    /// Uses an iterative depth-first traversal rather than recursion.
+    pub fn height(&self) -> usize {
+        // Stack of (node, depth) pairs.
+        // Start with this node at depth 0.
+        let mut stack: Vec<(&CedarValueJson, usize)> = vec![(self, 0)];
+        let mut max_depth: usize = 0;
+        while let Some((val, depth)) = stack.pop() {
+            max_depth = max_depth.max(depth);
+            let child_depth = depth + 1;
+            match val {
+                Self::Bool(_)
+                | Self::Long(_)
+                | Self::String(_)
+                | Self::Null
+                | Self::ExprEscape { .. }
+                | Self::EntityEscape { .. } => {}
+                Self::Set(vals) => {
+                    for v in vals {
+                        stack.push((v, child_depth));
+                    }
+                }
+                Self::Record(rec) => {
+                    for (_, v) in rec {
+                        stack.push((v, child_depth));
+                    }
+                }
+                Self::ExtnEscape { __extn } => {
+                    for arg in __extn.args() {
+                        stack.push((arg, child_depth));
+                    }
+                }
+            }
+        }
+        max_depth
+    }
+
     /// Convert this `CedarValueJson` into a Cedar "restricted expression"
     pub fn into_expr(
         self,
@@ -1054,4 +1102,106 @@ pub enum ExtnValueJson {
     // This is listed last so that it has lowest priority when deserializing.
     // If one of the above forms fits, we use that.
     ImplicitConstructor(CedarValueJson),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn height_leaf() {
+        assert_eq!(CedarValueJson::Bool(true).height(), 0);
+        assert_eq!(CedarValueJson::Long(42).height(), 0);
+        assert_eq!(CedarValueJson::String("hi".into()).height(), 0);
+        assert_eq!(CedarValueJson::Null.height(), 0);
+        assert_eq!(
+            CedarValueJson::ExprEscape {
+                __expr: "1 + 2".into()
+            }
+            .height(),
+            0
+        );
+        assert_eq!(
+            CedarValueJson::EntityEscape {
+                __entity: TypeAndId {
+                    entity_type: "User".into(),
+                    id: "alice".into(),
+                }
+            }
+            .height(),
+            0
+        );
+        assert_eq!(CedarValueJson::Set(vec![]).height(), 0);
+        assert_eq!(
+            CedarValueJson::Record(vec![].into_iter().collect()).height(),
+            0
+        );
+    }
+
+    #[test]
+    fn height_set() {
+        let val = CedarValueJson::Set(vec![CedarValueJson::Long(1), CedarValueJson::Long(2)]);
+        assert_eq!(val.height(), 1);
+    }
+
+    #[test]
+    fn height_record() {
+        let rec: JsonRecord = vec![("a".into(), CedarValueJson::Long(1))]
+            .into_iter()
+            .collect();
+        assert_eq!(CedarValueJson::Record(rec).height(), 1);
+    }
+
+    #[test]
+    fn height_nested_set() {
+        let inner = CedarValueJson::Set(vec![CedarValueJson::Long(1)]);
+        let outer = CedarValueJson::Set(vec![inner]);
+        assert_eq!(outer.height(), 2);
+    }
+
+    #[test]
+    fn height_asymmetric_set() {
+        let val = CedarValueJson::Set(vec![
+            CedarValueJson::Long(1),
+            CedarValueJson::Set(vec![CedarValueJson::Long(2)]),
+        ]);
+        assert_eq!(val.height(), 2);
+    }
+
+    #[test]
+    fn height_extn_escape() {
+        let val = CedarValueJson::ExtnEscape {
+            __extn: FnAndArgs::Single {
+                ext_fn: "decimal".into(),
+                arg: Box::new(CedarValueJson::String("1.0".into())),
+            },
+        };
+        assert_eq!(val.height(), 1);
+    }
+
+    #[test]
+    fn height_extn_escape_multi() {
+        let val = CedarValueJson::ExtnEscape {
+            __extn: FnAndArgs::Multi {
+                ext_fn: "foo".into(),
+                args: vec![CedarValueJson::Long(1), CedarValueJson::Long(2)],
+            },
+        };
+        assert_eq!(val.height(), 1);
+    }
+
+    #[test]
+    fn height_nested_composites() {
+        // Record containing a Set containing an ExtnEscape
+        let extn = CedarValueJson::ExtnEscape {
+            __extn: FnAndArgs::Single {
+                ext_fn: "decimal".into(),
+                arg: Box::new(CedarValueJson::String("1.0".into())),
+            },
+        };
+        let set = CedarValueJson::Set(vec![extn]);
+        let rec: JsonRecord = vec![("a".into(), set)].into_iter().collect();
+        let val = CedarValueJson::Record(rec);
+        assert_eq!(val.height(), 3);
+    }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -2283,4 +2283,273 @@ mod test {
         let expr = Expr::ExprNoExt(ExprNoExt::Record(map));
         assert_eq!(expr.height(), 1);
     }
+
+    #[test]
+    fn height_neg() {
+        // Simple negation of a leaf has height 1
+        let expr = Expr::ExprNoExt(ExprNoExt::Neg {
+            arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(5)))),
+        });
+        assert_eq!(expr.height(), 1);
+
+        // Nested negation has height 2
+        let expr = Expr::ExprNoExt(ExprNoExt::Neg {
+            arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Neg {
+                arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(5)))),
+            })),
+        });
+        assert_eq!(expr.height(), 2);
+    }
+
+    #[test]
+    fn height_not_eq() {
+        let expr = Expr::ExprNoExt(ExprNoExt::NotEq {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_in() {
+        let expr = Expr::ExprNoExt(ExprNoExt::In {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Resource))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_less() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Less {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_less_eq() {
+        let expr = Expr::ExprNoExt(ExprNoExt::LessEq {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_greater() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Greater {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_greater_eq() {
+        let expr = Expr::ExprNoExt(ExprNoExt::GreaterEq {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_and() {
+        let expr = Expr::ExprNoExt(ExprNoExt::And {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                true,
+            )))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                false,
+            )))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_or() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Or {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                true,
+            )))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                false,
+            )))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_add() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Add {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_sub() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Sub {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(3)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_mul() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Mul {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(3)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_contains() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Contains {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Set(vec![Expr::ExprNoExt(
+                ExprNoExt::Value(CedarValueJson::Long(1)),
+            )]))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+        });
+        assert_eq!(expr.height(), 2);
+    }
+
+    #[test]
+    fn height_contains_all() {
+        let expr = Expr::ExprNoExt(ExprNoExt::ContainsAll {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Context))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Set(vec![]))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_contains_any() {
+        let expr = Expr::ExprNoExt(ExprNoExt::ContainsAny {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Context))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Set(vec![]))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_get_tag() {
+        let expr = Expr::ExprNoExt(ExprNoExt::GetTag {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::String(
+                "tag_name".into(),
+            )))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_has_tag() {
+        let expr = Expr::ExprNoExt(ExprNoExt::HasTag {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::String(
+                "tag_name".into(),
+            )))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_get_attr() {
+        let expr = Expr::ExprNoExt(ExprNoExt::GetAttr {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Context))),
+            attr: "foo".into(),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_has_attr() {
+        // Simple HasAttr
+        let expr = Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Simple {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Context))),
+            attr: "foo".into(),
+        }));
+        assert_eq!(expr.height(), 1);
+
+        // Extended HasAttr
+        use nonempty::nonempty;
+        let expr = Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Extended {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Context))),
+            attr: nonempty!["user".into(), "profile".into()],
+        }));
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_like() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Like {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            pattern: vec![PatternElem::Wildcard],
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_is() {
+        // Is without in_expr
+        let expr = Expr::ExprNoExt(ExprNoExt::Is {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            entity_type: "User".into(),
+            in_expr: None,
+        });
+        assert_eq!(expr.height(), 1);
+
+        // Is with in_expr
+        let expr = Expr::ExprNoExt(ExprNoExt::Is {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            entity_type: "User".into(),
+            in_expr: Some(Arc::new(Expr::ExprNoExt(ExprNoExt::Var(
+                ast::Var::Resource,
+            )))),
+        });
+        assert_eq!(expr.height(), 1);
+
+        // Is with deeper in_expr
+        let expr = Expr::ExprNoExt(ExprNoExt::Is {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            entity_type: "User".into(),
+            in_expr: Some(Arc::new(Expr::ExprNoExt(ExprNoExt::Not {
+                arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Resource))),
+            }))),
+        });
+        assert_eq!(expr.height(), 2);
+    }
+
+    #[test]
+    fn height_ext_func_call() {
+        // ExtFuncCall with a leaf argument has height 1
+        let expr = Expr::ExtFuncCall(ExtFuncCall {
+            call: HashMap::from([(
+                "ip".to_smolstr(),
+                vec![Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::String(
+                    "127.0.0.1".into(),
+                )))],
+            )]),
+        });
+        assert_eq!(expr.height(), 1);
+
+        // ExtFuncCall with a nested argument has height 2
+        let expr = Expr::ExtFuncCall(ExtFuncCall {
+            call: HashMap::from([(
+                "ip".to_smolstr(),
+                vec![Expr::ExprNoExt(ExprNoExt::Not {
+                    arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                        true,
+                    )))),
+                })],
+            )]),
+        });
+        assert_eq!(expr.height(), 2);
+    }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1027,6 +1027,13 @@ impl Expr {
                     }
                     ExprNoExt::HasAttr(repr) => match repr {
                         HasAttrRepr::Simple { left, .. } | HasAttrRepr::Extended { left, .. } => {
+                            // For the `Extended` variant, the attr list is
+                            // flat (a list of strings), not nested sub-expressions,
+                            // so only `left` contributes to EST height.
+                            // Note that the AST desugars this into a
+                            // nested tree of `and`/`hasAttr`/`getAttr`
+                            // nodes, which will result in a deeper tree.
+                            // However, the conversion to the AST uses an iterator + fold.
                             stack.push((left, child_depth));
                         }
                     },

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -962,6 +962,115 @@ impl Expr {
             }
         }
     }
+
+    /// Compute the height of this expression tree, defined as the number of
+    /// edges on the longest root-to-leaf path through nested `Expr` and
+    /// `CedarValueJson` nodes.
+    ///
+    /// Leaf nodes (`Var`, `Slot`, etc.) have height 0.
+    /// An empty `Set` or empty `Record` expression also has height 0.
+    ///
+    /// For internal nodes (`Not`, `Eq`, `If`, `Set`, `Record`, etc.)
+    /// with at least one child, the height is 1 + the maximum height among
+    /// all children.
+    ///
+    /// Uses an iterative depth-first traversal rather than recursion.
+    pub fn height(&self) -> usize {
+        // Stack of (node, depth) pairs.
+        // Start with this expression at depth 0.
+        let mut stack: Vec<(&Expr, usize)> = vec![(self, 0)];
+        let mut max_depth: usize = 0;
+
+        while let Some((expr, depth)) = stack.pop() {
+            max_depth = max_depth.max(depth);
+            let child_depth = depth + 1;
+
+            match expr {
+                Expr::ExprNoExt(e) => match e {
+                    ExprNoExt::Value(v) => {
+                        // A literal value may itself be a nested structure
+                        // (e.g., a set of records). Use CedarValueJson::height()
+                        // to account for its internal depth.
+                        let value_height = depth + v.height();
+                        max_depth = max_depth.max(value_height);
+                    }
+                    ExprNoExt::Var(_) | ExprNoExt::Slot(_) => {}
+                    #[cfg(feature = "tolerant-ast")]
+                    ExprNoExt::Error(_) => {}
+                    ExprNoExt::Not { arg }
+                    | ExprNoExt::Neg { arg }
+                    | ExprNoExt::IsEmpty { arg } => {
+                        stack.push((arg, child_depth));
+                    }
+                    ExprNoExt::Eq { left, right }
+                    | ExprNoExt::NotEq { left, right }
+                    | ExprNoExt::In { left, right }
+                    | ExprNoExt::Less { left, right }
+                    | ExprNoExt::LessEq { left, right }
+                    | ExprNoExt::Greater { left, right }
+                    | ExprNoExt::GreaterEq { left, right }
+                    | ExprNoExt::And { left, right }
+                    | ExprNoExt::Or { left, right }
+                    | ExprNoExt::Add { left, right }
+                    | ExprNoExt::Sub { left, right }
+                    | ExprNoExt::Mul { left, right }
+                    | ExprNoExt::Contains { left, right }
+                    | ExprNoExt::ContainsAll { left, right }
+                    | ExprNoExt::ContainsAny { left, right }
+                    | ExprNoExt::GetTag { left, right }
+                    | ExprNoExt::HasTag { left, right } => {
+                        stack.push((left, child_depth));
+                        stack.push((right, child_depth));
+                    }
+                    ExprNoExt::GetAttr { left, .. } => {
+                        stack.push((left, child_depth));
+                    }
+                    ExprNoExt::HasAttr(repr) => match repr {
+                        HasAttrRepr::Simple { left, .. } | HasAttrRepr::Extended { left, .. } => {
+                            stack.push((left, child_depth));
+                        }
+                    },
+                    ExprNoExt::Like { left, .. } => {
+                        stack.push((left, child_depth));
+                    }
+                    ExprNoExt::Is { left, in_expr, .. } => {
+                        stack.push((left, child_depth));
+                        if let Some(in_e) = in_expr {
+                            stack.push((in_e, child_depth));
+                        }
+                    }
+                    ExprNoExt::If {
+                        cond_expr,
+                        then_expr,
+                        else_expr,
+                    } => {
+                        stack.push((cond_expr, child_depth));
+                        stack.push((then_expr, child_depth));
+                        stack.push((else_expr, child_depth));
+                    }
+                    ExprNoExt::Set(elements) => {
+                        for el in elements {
+                            stack.push((el, child_depth));
+                        }
+                    }
+                    ExprNoExt::Record(map) => {
+                        for v in map.values() {
+                            stack.push((v, child_depth));
+                        }
+                    }
+                },
+                Expr::ExtFuncCall(ExtFuncCall { call }) => {
+                    for args in call.values() {
+                        for arg in args {
+                            stack.push((arg, child_depth));
+                        }
+                    }
+                }
+            }
+        }
+
+        max_depth
+    }
 }
 
 impl Expr {
@@ -2086,5 +2195,92 @@ mod test {
             attr: nonempty!["user".into(), "profile".into(), "email".into()],
         }));
         assert_eq!(format!("{expr}"), "context has user.profile.email");
+    }
+
+    #[test]
+    fn height_leaf() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)));
+        assert_eq!(expr.height(), 0);
+        let expr = Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal));
+        assert_eq!(expr.height(), 0);
+    }
+
+    #[test]
+    fn height_unary() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Not {
+            arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_binary() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Eq {
+            left: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_nested() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Not {
+            arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Not {
+                arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Var(ast::Var::Principal))),
+            })),
+        });
+        assert_eq!(expr.height(), 2);
+    }
+
+    #[test]
+    fn height_asymmetric() {
+        let deep_left = Expr::ExprNoExt(ExprNoExt::Not {
+            arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Not {
+                arg: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            })),
+        });
+        let expr = Expr::ExprNoExt(ExprNoExt::Eq {
+            left: Arc::new(deep_left),
+            right: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 3);
+    }
+
+    #[test]
+    fn height_if_then_else() {
+        let expr = Expr::ExprNoExt(ExprNoExt::If {
+            cond_expr: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Bool(
+                true,
+            )))),
+            then_expr: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1)))),
+            else_expr: Arc::new(Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2)))),
+        });
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_set() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Set(vec![
+            Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1))),
+            Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(2))),
+        ]));
+        assert_eq!(expr.height(), 1);
+    }
+
+    #[test]
+    fn height_empty_set() {
+        let expr = Expr::ExprNoExt(ExprNoExt::Set(vec![]));
+        assert_eq!(expr.height(), 0);
+    }
+
+    #[test]
+    fn height_record() {
+        let mut map = BTreeMap::new();
+        map.insert(
+            "a".into(),
+            Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(1))),
+        );
+        let expr = Expr::ExprNoExt(ExprNoExt::Record(map));
+        assert_eq!(expr.height(), 1);
     }
 }

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use super::Clause;
 use super::Policy;
 use super::PolicySetFromJsonError;
 use crate::ast::{self, EntityUID, PolicyID, SlotId};
@@ -76,6 +77,20 @@ impl PolicySet {
     /// (e.g., after successful conversion to an `ast::PolicySet`)
     pub fn get_template(&self, id: &PolicyID) -> Option<Policy> {
         self.templates.get(id).cloned()
+    }
+
+    /// Return the largest `Expr::height` across every condition body in
+    /// every static policy and template in this policy set.
+    /// Returns `None` when there are no conditions.
+    pub fn max_expr_height(&self) -> Option<usize> {
+        self.static_policies
+            .values()
+            .chain(self.templates.values())
+            .flat_map(|p| &p.conditions)
+            .map(|clause| match clause {
+                Clause::When(e) | Clause::Unless(e) => e.height(),
+            })
+            .max()
     }
 }
 
@@ -375,5 +390,364 @@ mod test {
         let src = r#"principal(p, action, resource);"#;
         let node = crate::parser::text_to_cst::parse_policies(src).expect("policies should parse");
         PolicySet::try_from(node).expect_err("Expected parse error to result in err");
+    }
+
+    #[test]
+    fn max_expr_height_empty_policy_set() {
+        let json = json!({
+            "staticPolicies": {},
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), None);
+    }
+
+    #[test]
+    fn max_expr_height_no_conditions() {
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": []
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), None);
+    }
+
+    #[test]
+    fn max_expr_height_single_literal_condition() {
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": { "Value": true }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(0));
+    }
+
+    #[test]
+    fn max_expr_height_nested_expression() {
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "==": {
+                                    "left": { "Value": 1 },
+                                    "right": { "Value": 2 }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(1));
+    }
+
+    #[test]
+    fn max_expr_height_multiple_policies_takes_max() {
+        // policy1 condition: `true` => height 0
+        // policy2 condition: `!(1 == 2)` => height 2
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": { "Value": true }
+                        }
+                    ]
+                },
+                "policy2": {
+                    "effect": "forbid",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "!": {
+                                    "arg": {
+                                        "==": {
+                                            "left": { "Value": 1 },
+                                            "right": { "Value": 2 }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(2));
+    }
+
+    #[test]
+    fn max_expr_height_unless_clause() {
+        // `unless { 1 == 2 }` => height 1
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "unless",
+                            "body": {
+                                "==": {
+                                    "left": { "Value": 1 },
+                                    "right": { "Value": 2 }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(1));
+    }
+
+    #[test]
+    fn max_expr_height_templates_included() {
+        // static policy condition: `true` => height 0
+        // template condition: `!(1 == 2)` => height 2
+        // max should be 2 (from template)
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": { "Value": true }
+                        }
+                    ]
+                }
+            },
+            "templates": {
+                "template1": {
+                    "effect": "permit",
+                    "principal": { "op": "==", "slot": "?principal" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "!": {
+                                    "arg": {
+                                        "==": {
+                                            "left": { "Value": 1 },
+                                            "right": { "Value": 2 }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(2));
+    }
+
+    #[test]
+    fn max_expr_height_multiple_conditions_per_policy() {
+        // Two conditions on one policy:
+        //   when { true } => height 0
+        //   when { 1 == 2 } => height 1
+        // Max should be 1
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": { "Value": true }
+                        },
+                        {
+                            "kind": "when",
+                            "body": {
+                                "==": {
+                                    "left": { "Value": 1 },
+                                    "right": { "Value": 2 }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(1));
+    }
+
+    #[test]
+    fn max_expr_height_literal_nested_set_matches_non_literal() {
+        // A literal set-of-set-of-set expressed as a Value node:
+        // Value(Set([Set([Set([Long(1)])])])) has CedarValueJson height 3,
+        // which is added to the Value node's depth (0), giving height 3.
+        let json_literal = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "Value": [[[1]]]
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set_literal: PolicySet =
+            serde_json::from_value(json_literal).expect("failed to parse from JSON");
+        assert_eq!(policy_set_literal.max_expr_height(), Some(3));
+        // The same nesting expressed as non-literal Expr Set nodes:
+        // Set([Set([Set([Value(1)])])])
+        // 3 edges on the longest root-to-leaf path => height 3
+        let json_non_literal = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "Set": [
+                                    { "Set": [
+                                        { "Set": [
+                                            { "Value": 1 }
+                                        ]}
+                                    ]}
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set_non_literal: PolicySet =
+            serde_json::from_value(json_non_literal).expect("failed to parse from JSON");
+        assert_eq!(policy_set_non_literal.max_expr_height(), Some(3));
+        // Both representations have the same height
+        assert_eq!(
+            policy_set_literal.max_expr_height(),
+            policy_set_non_literal.max_expr_height()
+        );
+    }
+
+    #[test]
+    fn max_expr_height_deeply_nested() {
+        // !(!(!(true))): 3 edges on the longest root-to-leaf path => height 3
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": { "op": "All" },
+                    "action": { "op": "All" },
+                    "resource": { "op": "All" },
+                    "conditions": [
+                        {
+                            "kind": "when",
+                            "body": {
+                                "!": {
+                                    "arg": {
+                                        "!": {
+                                            "arg": {
+                                                "!": {
+                                                    "arg": { "Value": true }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "templates": {},
+            "templateLinks": []
+        });
+        let policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        assert_eq!(policy_set.max_expr_height(), Some(3));
     }
 }


### PR DESCRIPTION
## Description of changes
Added support for computing the height of an est::Expr iteratively. Need to address this issue: https://github.com/cedar-policy/cedar-spec/issues/942
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
