### PR TITLE
also take json policies/schemas integration tests

### DIFF
--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -42,17 +42,39 @@ use std::{
     str::FromStr,
 };
 
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PolicyFormat {
+    #[default]
+    Cedar,
+    Json,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SchemaFormat {
+    #[default]
+    Cedar,
+    Json,
+}
+
 /// JSON representation of our integration test file format
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonTest {
-    /// Filename of the policy set (in Cedar syntax)
+    /// Filename of the policy set
     pub policies: String,
+    /// Format of the policy set
+    #[serde(default)]
+    pub policy_format: PolicyFormat,
     /// Filename of a JSON file representing the entity hierarchy
     pub entities: String,
-    /// Filename of the schema (in Cedar syntax)
+    /// Filename of the schema
     pub schema: String,
+    /// Format of the schema
+    #[serde(default)]
+    pub schema_format: SchemaFormat,
     /// Whether the given policies are expected to pass the validator with this
     /// schema, or not
     pub should_validate: bool,
@@ -144,8 +166,12 @@ pub fn parse_policies_from_test(test: &JsonTest) -> PolicySet {
     let policy_file = resolve_integration_test_path(&test.policies);
     let policies_text = std::fs::read_to_string(policy_file)
         .unwrap_or_else(|e| panic!("error loading policy file {}: {e}", test.policies));
-    PolicySet::from_str(&policies_text)
-        .unwrap_or_else(|e| panic!("error parsing policy file {}: {e}", &test.policies))
+    match test.policy_format {
+        PolicyFormat::Cedar => PolicySet::from_str(&policies_text)
+            .unwrap_or_else(|e| panic!("error parsing policy file {}: {e}", &test.policies)),
+        PolicyFormat::Json => PolicySet::from_json_str(&policies_text)
+            .unwrap_or_else(|e| panic!("error parsing policy file {}: {e}", &test.policies)),
+    }
 }
 
 /// Given a `JsonTest`, parse the provided schema file.
@@ -155,9 +181,15 @@ pub fn parse_schema_from_test(test: &JsonTest) -> Schema {
     let schema_file = resolve_integration_test_path(&test.schema);
     let schema_text = std::fs::read_to_string(schema_file)
         .unwrap_or_else(|e| panic!("error loading schema file {}: {e}", &test.schema));
-    Schema::from_cedarschema_str(&schema_text)
-        .unwrap_or_else(|e| panic!("error parsing schema in {}: {e}", &test.schema))
-        .0
+    match test.schema_format {
+        SchemaFormat::Cedar => {
+            Schema::from_cedarschema_str(&schema_text)
+                .unwrap_or_else(|e| panic!("error parsing schema in {}: {e}", &test.schema))
+                .0
+        }
+        SchemaFormat::Json => Schema::from_json_str(&schema_text)
+            .unwrap_or_else(|e| panic!("error parsing schema in {}: {e}", &test.schema)),
+    }
 }
 
 /// Given a `JsonTest`, parse (and validate) the provided entities file.

--- a/cedar-testing/src/test_files.rs
+++ b/cedar-testing/src/test_files.rs
@@ -19,7 +19,7 @@
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-use crate::integration_testing::resolve_integration_test_path;
+use crate::integration_testing::{resolve_integration_test_path, JsonTest};
 
 /// Path of the folder containing the (handwritten) integration tests
 fn integration_test_folder() -> &'static Path {
@@ -39,11 +39,16 @@ pub fn get_integration_tests() -> impl Iterator<Item = PathBuf> {
     WalkDir::new(&tests_folder)
         .into_iter()
         .map(|e| e.expect("failed to access file in tests").into_path())
-        // ignore non-JSON files (and directories, which don't have an extension)
+        // ignore non-JSON files (and directories, which don't have an extension) and ignore
+        // files that don't parse as a Json Test
         .filter(|p| {
             p.extension()
                 .map(|ext| ext.eq_ignore_ascii_case("json"))
                 .unwrap_or(false)
+                && serde_json::from_str::<JsonTest>(
+                    &std::fs::read_to_string(resolve_integration_test_path(p).as_path()).unwrap(),
+                )
+                .is_ok()
         })
 }
 

--- a/cedar-testing/src/test_files.rs
+++ b/cedar-testing/src/test_files.rs
@@ -45,10 +45,9 @@ pub fn get_integration_tests() -> impl Iterator<Item = PathBuf> {
             p.extension()
                 .map(|ext| ext.eq_ignore_ascii_case("json"))
                 .unwrap_or(false)
-                && serde_json::from_str::<JsonTest>(
-                    &std::fs::read_to_string(resolve_integration_test_path(p).as_path()).unwrap(),
-                )
-                .is_ok()
+                && std::fs::read_to_string(resolve_integration_test_path(p).as_path())
+                    .and_then(|f| Ok(serde_json::from_str::<JsonTest>(&f)?))
+                    .is_ok()
         })
 }
 

--- a/cedar-testing/tests/cedar-policy/example_use_cases.rs
+++ b/cedar-testing/tests/cedar-policy/example_use_cases.rs
@@ -81,3 +81,13 @@ fn scenario_4f() {
 fn scenario_5b() {
     perform_integration_test_from_json(folder().join("5b.json"));
 }
+
+#[test]
+fn scenario_2a_json_policy() {
+    perform_integration_test_from_json(folder().join("2a_json_policy.json"));
+}
+
+#[test]
+fn scenario_2a_json_schema() {
+    perform_integration_test_from_json(folder().join("2a_json_schema.json"));
+}


### PR DESCRIPTION
This allows specifying `"schemaFormat": "json"` or `"policyFormat": "json"` in the integration tests, so that we can provide implementation-independent tests for the json format.

Backwards compatible with the existing tests.

Needs: https://github.com/cedar-policy/cedar-spec/pull/947

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.