### PR TITLE
Fix symcc compilation for mixed v4/v6 variadic isInRange

### DIFF
--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -1431,14 +1431,14 @@ mod datetime_tests {
         // IPv6 address tested against IPv4 range first, then correct IPv6 range
         test_valid_bool_simpl_expr(
             r#"ip("1:2:3:4::").isInRange(ip("192.168.0.0/24"), ip("1:2:3:4::/48"))"#,
-            false,
+            true,
         );
 
-        // Test where first matches but last is IPv4/IPv6 type mismatch (error)
+        // Test where first matches but last is IPv4/IPv6 type mismatch
         // IPv4 address in range, followed by IPv6 range that doesn't apply
         test_valid_bool_simpl_expr(
             r#"ip("192.168.0.1").isInRange(ip("192.168.0.0/24"), ip("1:2:3:4::/48"))"#,
-            false,
+            true,
         );
 
         // Test with three ranges where only the last matches

--- a/cedar-policy-symcc/src/symcc/extfun.rs
+++ b/cedar-policy-symcc/src/symcc/extfun.rs
@@ -87,7 +87,7 @@ pub fn subnet_width(w: Width, prefix: Term) -> Term {
 }
 
 /// Panics if `2^w` exceeds `u32::MAX`, i.e., if `w` exceeds 32. Currently, callers do not use `w` exceeding 7.
-pub fn range(w: Width, ip_addr: Term, prefix: Term) -> (Term, Term) {
+fn range(w: Width, ip_addr: Term, prefix: Term) -> (Term, Term) {
     #[expect(
         clippy::expect_used,
         reason = "Function is documented to panic if 2^w exceeds u32::MAX"
@@ -126,15 +126,16 @@ pub fn in_range_v(
 ) -> Term {
     // Apply in_range between t and each term in ts, folding with or
     let range_checks = ts.iter().fold(false.into(), |acc, term| {
-        or(acc, in_range(&range, t.clone(), term.clone()))
+        or(
+            acc,
+            and(
+                is_ip(term.clone()),
+                in_range(&range, t.clone(), term.clone()),
+            ),
+        )
     });
 
-    // Apply is_ip to t and all terms in ts, folding with and
-    let is_ip_checks = ts
-        .into_iter()
-        .fold(is_ip(t), |acc, term| and(acc, is_ip(term)));
-
-    and(is_ip_checks, range_checks)
+    and(is_ip(t), range_checks)
 }
 
 pub fn is_in_range(t: Term, ts: Vec<Term>) -> Term {


### PR DESCRIPTION
## Description of changes

Symcc semantics did not agree with concrete evaluator. `isInRange` was only satisfied if all the argument ranges were the same kind (v4/v6) as the target.

See behavior evaluator behavior tested here https://github.com/cedar-policy/cedar/blob/b15722f3bfafd318e3cc938661f53d579ff3efba/cedar-policy-core/src/extensions/ipaddr.rs#L1119-L1130 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
