### PR TITLE
Fix protobuf entity/context decoding for extension values

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -24,6 +24,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - `FunctionArgumentValidation` errors now include a help message describing the expected format for extension function arguments: `decimal`, `ip`, `datetime`, and `duration`. (#834)
 - Serialization of residual policies with `error()` nodes does not fail, instead results in JSON with `{"error": []}`. (#2202)
 - Fixed conversion from `protobuf` policy sets to public type for policy sets containing templates and template-linked policies. (#2330)
+- Fixed deserialization from protobuf of entity can context attributes containing extension values. (#2344)
 
 ## [4.10.0] - 2026-04-23
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -24,7 +24,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - `FunctionArgumentValidation` errors now include a help message describing the expected format for extension function arguments: `decimal`, `ip`, `datetime`, and `duration`. (#834)
 - Serialization of residual policies with `error()` nodes does not fail, instead results in JSON with `{"error": []}`. (#2202)
 - Fixed conversion from `protobuf` policy sets to public type for policy sets containing templates and template-linked policies. (#2330)
-- Fixed deserialization from protobuf of entity can context attributes containing extension values. (#2344)
+- Fixed deserialization from protobuf of entity and context attributes containing extension values. (#2344)
 
 ## [4.10.0] - 2026-04-23
 

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -151,7 +151,7 @@ impl From<&ast::EntityUIDEntry> for models::EntityUid {
 impl TryFrom<models::Entity> for ast::Entity {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Entity) -> Result<Self, Self::Error> {
-        let eval = RestrictedEvaluator::new(Extensions::none());
+        let eval = RestrictedEvaluator::new(Extensions::all_available());
 
         let attrs = v
             .attrs
@@ -798,7 +798,7 @@ impl TryFrom<models::Expr> for ast::Context {
                 "invalid restricted expr in context: {e}"
             ))
         })?;
-        ast::Context::from_expr(restricted, Extensions::none())
+        ast::Context::from_expr(restricted, Extensions::all_available())
             .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid context: {e}")))
     }
 }
@@ -811,8 +811,12 @@ impl From<&ast::Context> for models::Expr {
 
 #[cfg(test)]
 mod test {
+    use crate::{Context, Entity, Request};
+
     use super::*;
+    use cedar_policy_core::assert_deep_eq;
     use cool_asserts::assert_matches;
+    use serde_json::json;
 
     #[test]
     fn name_and_slot_roundtrip() {
@@ -877,7 +881,7 @@ mod test {
             Extensions::none(),
         )
         .unwrap();
-        assert_eq!(
+        assert_deep_eq!(
             entity,
             ast::Entity::try_from(models::Entity::from(&entity)).unwrap()
         );
@@ -901,10 +905,59 @@ mod test {
             Extensions::none(),
         )
         .unwrap();
-        assert_eq!(
+        assert_deep_eq!(
             entity,
             ast::Entity::try_from(models::Entity::from(&entity)).unwrap()
         );
+    }
+
+    #[test]
+    fn entity_ext_attr_value() {
+        #[track_caller]
+        fn assert_ext_roundtrip(ext: serde_json::Value) {
+            let entity = Entity::from_json_value(
+                json!({
+                    "uid": {"type": "User", "id": "alice"},
+                    "parents": [],
+                    "attrs": { "ext": {"__extn": ext}, },
+                }),
+                None,
+            )
+            .unwrap();
+            assert_deep_eq!(
+                entity,
+                Entity::try_from(models::Entity::from(&entity)).unwrap()
+            );
+        }
+        assert_ext_roundtrip(json!({"fn": "ip", "arg": "127.0.0.1"}));
+        assert_ext_roundtrip(json!({"fn": "decimal", "arg": "1.0"}));
+        assert_ext_roundtrip(json!({"fn": "datetime", "arg": "2024-10-15"}));
+        assert_ext_roundtrip(json!({"fn": "duration", "arg": "1s"}));
+    }
+
+    #[test]
+    fn entity_ext_tag_value() {
+        #[track_caller]
+        fn assert_ext_roundtrip(ext: serde_json::Value) {
+            let entity = Entity::from_json_value(
+                json!({
+                    "uid": {"type": "User", "id": "alice"},
+                    "parents": [],
+                    "attrs": {},
+                    "tags": { "ext": {"__extn": ext}, },
+                }),
+                None,
+            )
+            .unwrap();
+            assert_deep_eq!(
+                entity,
+                Entity::try_from(models::Entity::from(&entity)).unwrap()
+            );
+        }
+        assert_ext_roundtrip(json!({"fn": "ip", "arg": "127.0.0.1"}));
+        assert_ext_roundtrip(json!({"fn": "decimal", "arg": "1.0"}));
+        assert_ext_roundtrip(json!({"fn": "datetime", "arg": "2024-10-15"}));
+        assert_ext_roundtrip(json!({"fn": "duration", "arg": "1s"}));
     }
 
     #[test]
@@ -1056,6 +1109,27 @@ mod test {
         assert_eq!(request.principal().uid(), request_rt.principal().uid());
         assert_eq!(request.action().uid(), request_rt.action().uid());
         assert_eq!(request.resource().uid(), request_rt.resource().uid());
+    }
+
+    #[test]
+    fn context_ext_value() {
+        #[track_caller]
+        fn assert_ext_roundtrip(ext: serde_json::Value) {
+            let ctx = Context::from_json_value(json!({ "ext": {"__extn": ext} }), None).unwrap();
+            let req = Request::new(
+                r#"User::"alice""#.parse().unwrap(),
+                r#"Action::"view""#.parse().unwrap(),
+                r#"Photo::"vacation.jpg""#.parse().unwrap(),
+                ctx,
+                None,
+            )
+            .unwrap();
+            assert_eq!(req, Request::try_from(models::Request::from(&req)).unwrap());
+        }
+        assert_ext_roundtrip(json!({"fn": "ip", "arg": "127.0.0.1"}));
+        assert_ext_roundtrip(json!({"fn": "decimal", "arg": "1.0"}));
+        assert_ext_roundtrip(json!({"fn": "datetime", "arg": "2024-10-15"}));
+        assert_ext_roundtrip(json!({"fn": "duration", "arg": "1s"}));
     }
 
     #[test]

--- a/cedar-policy/tests/proto_decode_regression.rs
+++ b/cedar-policy/tests/proto_decode_regression.rs
@@ -25,6 +25,7 @@
 
 use cedar_policy::proto::traits::Protobuf;
 use cedar_policy::*;
+use cedar_policy_core::assert_deep_eq;
 use similar_asserts::assert_eq;
 
 fn proto_file(name: &str) -> Vec<u8> {
@@ -83,7 +84,7 @@ fn decode_entities() {
         None,
     )
     .unwrap();
-    assert_eq!(decoded, expected);
+    assert_deep_eq!(decoded, expected);
 }
 
 #[test]


### PR DESCRIPTION
## Description of changes

Protobuf used `Extensions::none` for decoding entity and context attributes. This caused decoding to fail for any extensions values.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
