### PR TITLE
Fix symcc duration parser on multi-byte UTF-8 in unit

### DIFF
--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -316,7 +316,7 @@ impl Duration {
                     .split_at_checked(pos)
                     // `pos` might not be aligned with UTF8 boundary, but this can only happen
                     // if there are non-ascii characters in the duration, which is always an error.
-                    .ok_or(|| DatetimeError::DatetimeParseError(s.to_string()))?;
+                    .ok_or_else(|| DatetimeError::DatetimeParseError(s.to_string()))?;
 
                 let val: i64 = BigInt::from_biguint(
                     if is_neg { Sign::Minus } else { Sign::Plus },

--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -312,11 +312,11 @@ impl Duration {
                 let pos = prefix
                     .rfind(|c: char| !c.is_ascii_digit())
                     .map_or(0, |i| i + 1);
-                #[expect(
-                    clippy::unwrap_used,
-                    reason = "by construction pos must be a valid index into prefix"
-                )]
-                let (prefix, digits) = prefix.split_at_checked(pos).unwrap();
+                let (prefix, digits) = prefix
+                    .split_at_checked(pos)
+                    // `pos` might not be aligned with UTF8 boundary, but this can only happen
+                    // if there are non-ascii characters in the duration, which is always an error.
+                    .ok_or(|| DatetimeError::DatetimeParseError(s.to_string()))?;
 
                 let val: i64 = BigInt::from_biguint(
                     if is_neg { Sign::Minus } else { Sign::Plus },
@@ -576,5 +576,7 @@ mod tests {
         test_invalid_duration("1d9223372036854775807ms", "overflow");
         test_invalid_duration("1d92233720368547758071ms", "overflow ms");
         test_invalid_duration("9223372036854776s1ms", "overflow s");
+        test_invalid_duration("\u{1F600}1ms", "multi-byte UTF-8 before digits");
+        test_invalid_duration("1d\u{00E9}2s", "multi-byte UTF-8 within duration");
     }
 }


### PR DESCRIPTION
Fixes possible panic given invalid duration string with UTF-8 multi-byte characters for units. Not reachable from the public symcc entrypoints which require validating policies first. Validaiton parses extension calls with the `core` implementation which does not have this issue.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
