### PR TITLE
Fix durationSince extension declaring wrong second argument type

### DIFF
--- a/cedar-language-server/src/policy/completion/provider.rs
+++ b/cedar-language-server/src/policy/completion/provider.rs
@@ -649,7 +649,7 @@ pub(crate) mod tests {
         complete_extension_methods_datetime,
         r#"permit(principal, action, resource) when { datetime("127").t|caret| };"#,
         vec![
-            "durationSince(${1:duration})",
+            "durationSince(${1:datetime})",
             "offset(${1:duration})",
             "toDate()",
             "toDays()",

--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -720,7 +720,7 @@ pub fn extension() -> Extension {
                 CallStyle::MethodStyle,
                 Box::new(duration_since),
                 duration_type.clone(),
-                (datetime_type.clone(), duration_type.clone()),
+                (datetime_type.clone(), datetime_type.clone()),
             ),
             ExtensionFunction::unary(
                 constants::TO_DATE_NAME.clone(),


### PR DESCRIPTION
The second argument was declared as a duration but it should be a datetime value.

As far as I can tell this has no effect on anything. We use these argument types to detect "constructors" which are single-argument functions accepting a string. We also look at the number of arguments in a few places. Neither use cares about the type of the second argument. 

The typechecker does need the correct type, but it declares its expected type separately (and correctly). 

edit: turns out this fixes an autocomplete suggestion in the LSP

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
