### PR TITLE
Fix CLI --template-linked argument ignoring file permissions errors

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,10 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+### Changed
+
+- Commands with a `--template-linked` argument will now error when failing to read a link file due to misconfigured file permissions or other similar errors.
+
 ## 4.10.0
 
 ### Added

--- a/cedar-policy-cli/src/utils/links.rs
+++ b/cedar-policy-cli/src/utils/links.rs
@@ -91,11 +91,18 @@ impl From<TemplateLinked> for LiteralTemplateLinked {
 
 /// Given a file containing template links, return a `Vec` of those links
 pub(crate) fn load_links_from_file(path: impl AsRef<Path>) -> Result<Vec<TemplateLinked>> {
-    let f = match std::fs::File::open(path) {
+    let f = match std::fs::File::open(&path) {
         Ok(f) => f,
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             // If the file doesn't exist, then give back the empty entity set
             return Ok(vec![]);
+        }
+        Err(e) => {
+            return Err(miette::miette!(
+                "failed to open links file '{}': {}",
+                path.as_ref().display(),
+                e
+            ));
         }
     };
     if f.metadata()

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::unwrap_used, reason = "tests")]
 use std::collections::HashMap;
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use cedar_policy::EvalResult;
@@ -2013,4 +2014,73 @@ fn test_check_parse_warning_schema() {
       ·        ────
       ╰────
     "###);
+}
+
+#[test]
+fn link_file_does_not_exist() {
+    // linking into a file that does not exist should create it
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let linked = dir.path().join("linked");
+    assert!(
+        !linked.exists(),
+        "trying to test behavior when file doesn't exist"
+    );
+    let output = cargo::cargo_bin_cmd!("cedar")
+        .env("NO_COLOR", "1")
+        .arg("link")
+        .arg("--template-id")
+        .arg("")
+        .arg("--new-id")
+        .arg("l")
+        .arg("--arguments")
+        .arg(r#"{"?principal": "User::\"alice\""}"#)
+        .arg("--template-linked")
+        .arg(&linked)
+        .write_stdin("@id permit(principal == ?principal, action, resource);")
+        .output()
+        .expect("failed to run cedar");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    insta::assert_snapshot!(stdout, @r###"
+    Template-linked policy added: @id
+    permit(principal == User::"alice", action, resource);
+    "###);
+    assert!(output.status.success());
+    assert!(linked.exists());
+}
+
+#[test]
+fn link_file_cant_read() {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let linked = dir.path().join("linked");
+    std::fs::write(
+        &linked,
+        r#"[{"template_id":"foo","link_id":"bar","args":{"?principal":"User::\"alice\""}}]"#,
+    )
+    .unwrap();
+    // Remove read permissions. The file exists, trying to read it will fail.
+    std::fs::set_permissions(&linked, PermissionsExt::from_mode(200)).unwrap();
+    let output = cargo::cargo_bin_cmd!("cedar")
+        .env("NO_COLOR", "1")
+        .arg("link")
+        .arg("--template-id")
+        .arg("")
+        .arg("--new-id")
+        .arg("l")
+        .arg("--arguments")
+        .arg(r#"{"?principal": "User::\"alice\""}"#)
+        .arg("--template-linked")
+        .arg(&linked)
+        .write_stdin("@id permit(principal == ?principal, action, resource);")
+        .output()
+        .expect("failed to run cedar");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"/tmp/[^ ']+/linked", "[TEMPDIR]/linked");
+    settings.bind(|| {
+        insta::assert_snapshot!(stdout, @r###"
+        × failed to open links file '[TEMPDIR]/linked': Permission denied (os
+        │ error 13)
+        "###);
+    });
+    assert!(!output.status.success());
 }


### PR DESCRIPTION
Only treat ErrorKind::NotFound as "no file" and return an empty vec. Error on all other file-open errors (permissions, I/O, etc.)

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
