### PR TITLE
Fix FFI `stateful_is_authorized` to error on unknown cached schema key

### DIFF
--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -752,7 +752,7 @@ impl StatefulAuthorizationCall {
                                     "preparsed schema '{}' not found",
                                     schema_name
                                 ));
-                                Ok(None)
+                                Err(())
                             },
                             |schema| Ok(Some(schema)),
                         )
@@ -1943,6 +1943,41 @@ mod test {
         assert_matches!(result, AuthorizationAnswer::Failure { errors, .. } => {
             assert!(!errors.is_empty());
             assert!(errors[0].message.contains("preparsed policy set 'nonexistent_policies' not found"));
+        });
+    }
+
+    #[test]
+    fn test_stateful_is_authorized_missing_schema() {
+        let policies = json!({
+            "staticPolicies": "permit(principal, action, resource);"
+        });
+        let policy_set: PolicySet = serde_json::from_value(policies).unwrap();
+        preparse_policy_set("ps".to_string(), policy_set);
+
+        let call = json!({
+            "principal": {
+                "type": "User",
+                "id": "alice"
+            },
+            "action": {
+                "type": "Action",
+                "id": "view"
+            },
+            "resource": {
+                "type": "User",
+                "id": "bob"
+            },
+            "context": {},
+            "preparsedSchemaName": "not_in_cache",
+            "preparsedPolicySetId": "ps",
+            "entities": []
+        });
+
+        let stateful_call: StatefulAuthorizationCall = serde_json::from_value(call).unwrap();
+        let result = stateful_is_authorized(stateful_call);
+
+        assert_matches!(result, AuthorizationAnswer::Failure { errors, .. } => {
+            assert!(errors[0].message.contains("preparsed schema 'not_in_cache' not found"));
         });
     }
 

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- `isAuthorizedPartial` will now error when `preparsedSchemaName` is not found in cache, matching behavior for preparsed policy sets.
+- `isAuthorizedPartial` will now error when `preparsedSchemaName` is not found in cache, matching behavior for preparsed policy sets. (#2348)
 
 ## 4.10.0
 

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `isAuthorizedPartial` will now error when `preparsedSchemaName` is not found in cache, matching behavior for preparsed policy sets.
+
 ## 4.10.0
 
 ## 4.9.1


### PR DESCRIPTION
When the preparsed schema name was provided but not found in the cache, we returned `Ok(None)` instead of `Err(())`, allowing authorization to proceed without validation.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
