### PR TITLE
Fix `add_entities` TC update with dangling parent

### DIFF
--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -95,7 +95,7 @@ where
 {
     let seen: HashSet<K> = nodes
         .keys()
-        .filter(|x| nodes_to_fix.contains(x))
+        .filter(|x| !nodes_to_fix.contains(x))
         .cloned()
         .collect();
 
@@ -386,7 +386,7 @@ where
         if explored.insert(ancestor_id.clone()) {
             let ancestor = match nodes.get(&ancestor_id) {
                 Some(ancestor) => ancestor,
-                None => return,
+                None => continue,
             };
             for grand_ancestor_id in ancestor.out_edges() {
                 ancestors.insert(grand_ancestor_id.clone());
@@ -1483,5 +1483,55 @@ mod tests {
                 ])
             }),
         ]
+    }
+
+    #[test]
+    fn add_ancestors_dangling_parent_adds_transitive() {
+        // Setup A -> B -> C and A -> X
+        let mut a = Entity::with_uid(EntityUID::with_eid("A"));
+        a.add_parent(EntityUID::with_eid("B"));
+        a.add_parent(EntityUID::with_eid("X"));
+        let mut b = Entity::with_uid(EntityUID::with_eid("B"));
+        b.add_parent(EntityUID::with_eid("C"));
+        let c = Entity::with_uid(EntityUID::with_eid("C"));
+        let mut entities = HashMap::from([
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+        ]);
+        compute_tc(&mut entities, false).expect("compute_tc failed");
+
+        // Entity `X` is not in the map. This previously made `add_ancestors`
+        // return early, without adding transitive ancestors, so we lost the
+        // transitive edge A -> C
+        let a = entities.get(&EntityUID::with_eid("A")).unwrap();
+        assert!(a.is_descendant_of(&EntityUID::with_eid("C")),);
+    }
+
+    #[test]
+    fn repair_tc_no_dag_computes_tc() {
+        // Setup A -> B and B -> C
+        let mut a = Entity::with_uid(EntityUID::with_eid("A"));
+        a.add_parent(EntityUID::with_eid("B"));
+        let mut b = Entity::with_uid(EntityUID::with_eid("B"));
+        b.add_parent(EntityUID::with_eid("C"));
+        let c = Entity::with_uid(EntityUID::with_eid("C"));
+        let mut entities = HashMap::from([
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+        ]);
+        compute_tc(&mut entities, false).expect("initial compute_tc failed");
+
+        // Add D -> B and repair TC
+        let mut d = Entity::with_uid(EntityUID::with_eid("D"));
+        d.add_parent(EntityUID::with_eid("B"));
+        entities.insert(d.uid().clone(), d);
+        let nodes_to_fix = HashSet::from([EntityUID::with_eid("D")]);
+        repair_tc(nodes_to_fix, &mut entities, false).expect("repair_tc failed");
+
+        // D should get an edge to C
+        let d = entities.get(&EntityUID::with_eid("D")).unwrap();
+        assert!(d.is_descendant_of(&EntityUID::with_eid("C")));
     }
 }

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -2073,6 +2073,35 @@ mod ancestors_tests {
         assert!(ans.contains(&b_euid));
         assert!(ans.contains(&a_euid));
     }
+
+    #[test]
+    fn dangling_parent_transitive_closure_update() {
+        // Setup B -> C
+        let initial_entities = serde_json::json!([
+            {"uid": {"type": "T", "id": "B"}, "attrs": {}, "parents": [{"type": "T", "id": "C"}]},
+            {"uid": {"type": "T", "id": "C"}, "attrs": {}, "parents": []}
+        ]);
+        let entities =
+            Entities::from_json_value(initial_entities, None).expect("initial parse failed");
+
+        // Add A -> B and A -> X
+        let add_json = serde_json::json!([{
+            "uid": {"type": "T", "id": "A"},
+            "attrs": {},
+            "parents": [{"type": "T", "id": "B"}, {"type": "T", "id": "X"}]
+        }]);
+        let entities = entities
+            .add_entities_from_json_value(add_json, None)
+            .expect("add_entities failed");
+
+        // We should have an edge A -> C
+        let a: EntityUid = r#"T::"A""#.parse().unwrap();
+        let c: EntityUid = r#"T::"C""#.parse().unwrap();
+        assert!(
+            entities.is_ancestor_of(&c, &a),
+            "C should be an ancestor of A (transitive via B) despite dangling parent"
+        );
+    }
 }
 
 /// A few tests of validating entities.


### PR DESCRIPTION
add_ancestors returned early on failing to lookup an ancestors. This caused it drop all transitive ancestors for the child entity. This is publicly visible through `Entities::add_entities`.

Also fixes a bug in `repair_tc` when `enfore_dag` was false. We always enforce dag for this functions. It would effect incremental updates for entity type TC in the schema if we had that as a feature.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
