### PR TITLE
Check slot name for `is ... in ?slot` in EST

### DIFF
--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -794,30 +794,30 @@ impl TryFrom<PrincipalConstraint> for ast::PrincipalOrResourceConstraint {
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
                 entity_type,
                 in_entity,
-            }) => {
-                ast::EntityType::from_normalized_str(entity_type.as_str())
-                    .map_err(Self::Error::InvalidEntityType)
-                    .and_then(|entity_type| {
-                        Ok(match in_entity {
-                            None => ast::PrincipalOrResourceConstraint::is_entity_type(Arc::new(
-                                entity_type,
-                            )),
-                            Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
-                                ast::PrincipalOrResourceConstraint::is_entity_type_in(
-                                    Arc::new(entity_type),
-                                    Arc::new(entity.into_euid(&|| {
-                                        JsonDeserializationErrorContext::EntityUid
-                                    })?),
-                                )
-                            }
-                            Some(PrincipalOrResourceInConstraint::Slot { .. }) => {
-                                ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(
-                                    Arc::new(entity_type),
-                                )
-                            }
-                        })
-                    })
-            }
+            }) => ast::EntityType::from_normalized_str(entity_type.as_str())
+                .map_err(Self::Error::InvalidEntityType)
+                .and_then(|entity_type| match in_entity {
+                    None => Ok(ast::PrincipalOrResourceConstraint::is_entity_type(
+                        Arc::new(entity_type),
+                    )),
+                    Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
+                        Ok(ast::PrincipalOrResourceConstraint::is_entity_type_in(
+                            Arc::new(entity_type),
+                            Arc::new(
+                                entity.into_euid(&|| JsonDeserializationErrorContext::EntityUid)?,
+                            ),
+                        ))
+                    }
+                    Some(PrincipalOrResourceInConstraint::Slot { slot }) => {
+                        if slot == ast::SlotId::principal() {
+                            Ok(ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(
+                                Arc::new(entity_type),
+                            ))
+                        } else {
+                            Err(Self::Error::InvalidSlotName)
+                        }
+                    }
+                }),
         }
     }
 }
@@ -860,30 +860,30 @@ impl TryFrom<ResourceConstraint> for ast::PrincipalOrResourceConstraint {
             ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
                 entity_type,
                 in_entity,
-            }) => {
-                ast::EntityType::from_normalized_str(entity_type.as_str())
-                    .map_err(Self::Error::InvalidEntityType)
-                    .and_then(|entity_type| {
-                        Ok(match in_entity {
-                            None => ast::PrincipalOrResourceConstraint::is_entity_type(Arc::new(
-                                entity_type,
-                            )),
-                            Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
-                                ast::PrincipalOrResourceConstraint::is_entity_type_in(
-                                    Arc::new(entity_type),
-                                    Arc::new(entity.into_euid(&|| {
-                                        JsonDeserializationErrorContext::EntityUid
-                                    })?),
-                                )
-                            }
-                            Some(PrincipalOrResourceInConstraint::Slot { .. }) => {
-                                ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(
-                                    Arc::new(entity_type),
-                                )
-                            }
-                        })
-                    })
-            }
+            }) => ast::EntityType::from_normalized_str(entity_type.as_str())
+                .map_err(Self::Error::InvalidEntityType)
+                .and_then(|entity_type| match in_entity {
+                    None => Ok(ast::PrincipalOrResourceConstraint::is_entity_type(
+                        Arc::new(entity_type),
+                    )),
+                    Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
+                        Ok(ast::PrincipalOrResourceConstraint::is_entity_type_in(
+                            Arc::new(entity_type),
+                            Arc::new(
+                                entity.into_euid(&|| JsonDeserializationErrorContext::EntityUid)?,
+                            ),
+                        ))
+                    }
+                    Some(PrincipalOrResourceInConstraint::Slot { slot }) => {
+                        if slot == ast::SlotId::resource() {
+                            Ok(ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(
+                                Arc::new(entity_type),
+                            ))
+                        } else {
+                            Err(Self::Error::InvalidSlotName)
+                        }
+                    }
+                }),
         }
     }
 }
@@ -954,6 +954,12 @@ impl TryFrom<ActionConstraint> for ast::ActionConstraint {
 
 #[cfg(test)]
 mod test {
+    use crate::{
+        ast,
+        est::{FromJsonError, PrincipalConstraint, ResourceConstraint},
+    };
+    use cool_asserts::assert_matches;
+
     fn parse_policy(template: &str) -> crate::est::Policy {
         let cst = crate::parser::text_to_cst::parse_policy(template)
             .unwrap()
@@ -1042,5 +1048,29 @@ mod test {
     #[test]
     fn has_slot_resource_is_slot() {
         assert!(resource_has_slot(r#"resource is Photo in ?resource"#));
+    }
+
+    #[test]
+    fn principal_is_in_wrong_slot_rejected() {
+        let json = serde_json::json!({
+            "op": "is",
+            "entity_type": "User",
+            "in": {"slot": "?resource"}
+        });
+        let constraint: PrincipalConstraint = serde_json::from_value(json).expect("parse failed");
+        let result = ast::PrincipalOrResourceConstraint::try_from(constraint);
+        assert_matches!(result, Err(FromJsonError::InvalidSlotName));
+    }
+
+    #[test]
+    fn resource_is_in_wrong_slot_rejected() {
+        let json = serde_json::json!({
+            "op": "is",
+            "entity_type": "Photo",
+            "in": {"slot": "?principal"}
+        });
+        let constraint: ResourceConstraint = serde_json::from_value(json).expect("parse failed");
+        let result = ast::PrincipalOrResourceConstraint::try_from(constraint);
+        assert_matches!(result, Err(FromJsonError::InvalidSlotName));
     }
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -25,6 +25,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Serialization of residual policies with `error()` nodes does not fail, instead results in JSON with `{"error": []}`. (#2202)
 - Fixed conversion from `protobuf` policy sets to public type for policy sets containing templates and template-linked policies. (#2330)
 - Fixed deserialization from protobuf of entity and context attributes containing extension values. (#2344)
+- Slot identifiers are now checked for JSON policy templates using slots in `is Type in ?slot` scope constraints. Loading a JSON format policy using `principal is Type in ?resource` or `resource is Type in ?principal`. (#2351)
 
 ## [4.10.0] - 2026-04-23
 


### PR DESCRIPTION
EST `is in` scope constraints were not checking that the slot name matched the actual variable.

Indentation changed, but the diff should basically be adding `if slot == ast::SlotId::principal()` and `if slot == ast::SlotId::resource()` 

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
