### PR TITLE
Bump versions for 4.11.0 x symcc 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "assert-json-diff",
  "cedar-policy-core",
@@ -383,7 +383,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-cli"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "cedar-policy-core",
  "insta",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-symcc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-recursion",
  "cedar-policy",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-testing"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "cedar-policy",
  "cedar-policy-cli",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-wasm"
-version = "4.10.0"
+version = "4.11.0"
 dependencies = [
  "cedar-policy",
  "cedar-policy-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ similar.opt-level = 3
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.89"
-version = "4.10.0"
+version = "4.11.0"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.10.0", path = "../cedar-policy-core", features = ["tolerant-ast", "extended-schema"] }
-cedar-policy-formatter = { version = "=4.10.0", path = "../cedar-policy-formatter", features = ["tolerant-ast"] }
-cedar-policy = { version = "=4.10.0", path = "../cedar-policy", features = ["tolerant-ast"]}
+cedar-policy-core = { version = "=4.11.0", path = "../cedar-policy-core", features = ["tolerant-ast", "extended-schema"] }
+cedar-policy-formatter = { version = "=4.11.0", path = "../cedar-policy-formatter", features = ["tolerant-ast"] }
+cedar-policy = { version = "=4.11.0", path = "../cedar-policy", features = ["tolerant-ast"]}
 anyhow = "1.0.102"
 itertools = "0.14.0"
 miette = "7.4.0"

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.10.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.10.0", path = "../cedar-policy-formatter" }
-cedar-policy-symcc = { version = "0.4.0", path = "../cedar-policy-symcc", optional = true }
+cedar-policy = { version = "=4.11.0", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.11.0", path = "../cedar-policy-formatter" }
+cedar-policy-symcc = { version = "0.5.0", path = "../cedar-policy-symcc", optional = true }
 clap = { version = "4", features = ["derive", "env"] }
 itertools = { version = "0.14", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.10.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.11.0", path = "../cedar-policy-core" }
 pretty = "0.12.5"
 logos = "0.16.0"
 itertools = "0.14"

--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-symcc"
 edition.workspace = true
 rust-version.workspace = true
-version = "0.4.0"
+version = "0.5.0"
 license.workspace = true
 categories.workspace = true
 description = "Symbolic Cedar Compiler (SymCC): translates queries about Cedar policies to SMT"
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { path = "../cedar-policy", version = "=4.10.0" }
-cedar-policy-core = { path = "../cedar-policy-core", version = "=4.10.0" }
+cedar-policy = { path = "../cedar-policy", version = "=4.11.0" }
+cedar-policy-core = { path = "../cedar-policy-core", version = "=4.11.0" }
 async-recursion = "1.1"
 itertools = "0.14"
 ref-cast = "1.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.10.0", path = "../cedar-policy-core" }
-cedar-policy-formatter = { version = "=4.10.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.11.0", path = "../cedar-policy-core" }
+cedar-policy-formatter = { version = "=4.11.0", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -87,7 +87,7 @@ similar-asserts = "2.0.0"
 criterion = "0.8"
 globset = "0.4"
 insta = { version = "1.47.2", features = ["glob", "json"] }
-cedar-policy-core = { version = "=4.10.0", features = [
+cedar-policy-core = { version = "=4.11.0", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -8593,7 +8593,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.10.0");
+        assert_eq!(get_sdk_version().to_string(), "4.11.0");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.10.0", path = "../cedar-policy", features = ["partial-eval", "tpe"] }
+cedar-policy = { version = "=4.11.0", path = "../cedar-policy", features = ["partial-eval", "tpe"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -10,9 +10,9 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.10.0", path = "../cedar-policy", features = ["wasm", "partial-eval"] }
-cedar-policy-core = { version = "=4.10.0", path = "../cedar-policy-core", features = ["wasm", "partial-eval"] }
-cedar-policy-formatter = { version = "=4.10.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.11.0", path = "../cedar-policy", features = ["wasm", "partial-eval"] }
+cedar-policy-core = { version = "=4.11.0", path = "../cedar-policy-core", features = ["wasm", "partial-eval"] }
+cedar-policy-formatter = { version = "=4.11.0", path = "../cedar-policy-formatter" }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
Bump core versions and cli version to 4.11.0 and symcc version to 0.5.0

Note: done on the release branch, will cherry-pick to main afterwards.
