### PR TITLE
Error on multi chars in proto like pattern

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,11 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ## [Unreleased]
 
+
+### Fixed
+
+- Protobuf parsing for expression now error on encountering a `like` pattern element with multiple characters in a single `PatternElem::Char` isntead of dropping the extra characters.
+
 ## [4.11.0] - 2026-05-18
 
 Cedar Language Version: 4.5

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -20,6 +20,7 @@ use super::models;
 use cedar_policy_core::{
     ast, evaluator::RestrictedEvaluator, extensions::Extensions, FromNormalizedStr,
 };
+use itertools::Itertools;
 use smol_str::ToSmolStr;
 use std::{collections::HashSet, sync::Arc};
 
@@ -688,13 +689,11 @@ impl TryFrom<models::expr::like::PatternElem> for ast::PatternElem {
             .data
             .ok_or_else(|| ProtobufConversionError::missing("data"))?
         {
-            models::expr::like::pattern_elem::Data::C(c) => Ok(ast::PatternElem::Char(
-                c.chars().next().ok_or_else(|| {
-                    ProtobufConversionError::InvalidValue(
-                        "empty char in pattern element".to_string(),
-                    )
-                })?,
-            )),
+            models::expr::like::pattern_elem::Data::C(c) => {
+                Ok(ast::PatternElem::Char(c.chars().exactly_one().map_err(
+                    |e| ProtobufConversionError::InvalidValue(format!("{e} in pattern element")),
+                )?))
+            }
             models::expr::like::pattern_elem::Data::Wildcard(unit) => {
                 match models::expr::like::pattern_elem::Wildcard::try_from(unit).map_err(|e| {
                     ProtobufConversionError::InvalidValue(format!("invalid wildcard: {e}"))

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -1404,7 +1404,18 @@ mod test {
         };
         assert_matches!(
             ast::PatternElem::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("empty char")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("got zero elements")
+        );
+    }
+
+    #[test]
+    fn pattern_elem_try_from_multi_char() {
+        let bad = models::expr::like::PatternElem {
+            data: Some(models::expr::like::pattern_elem::Data::C("foo".to_string())),
+        };
+        assert_matches!(
+            ast::PatternElem::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("got at least 2 elements")
         );
     }
 


### PR DESCRIPTION
## Description of changes

Return on error on this malformed input instead of silently accepting it and ignoring the extra characters.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
