### PR TITLE
Serialize internal schema objects to json/cedar text

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -82,7 +82,7 @@ lalrpop = "0.22.2"
 similar-asserts = "2.0.0"
 cool_asserts = "2.0"
 miette = { version = "7.6.0", features = ["fancy"] }
-insta = "1.47.2"
+insta = { version = "1.47.2", features = ["glob"] }
 
 [lints]
 workspace = true

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -57,6 +57,7 @@ mod raw_name;
 pub use raw_name::{ConditionalName, RawName, ReferenceType};
 pub(crate) mod err;
 use err::{schema_errors::*, *};
+mod to_json;
 
 /// A `ValidatorSchemaFragment` consists of any number (even 0) of
 /// `ValidatorNamespaceDef`s.

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_hierarchy.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_hierarchy.cedarschema.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/action_hierarchy.cedarschema
+---
+entity User;
+
+action "read" in [Action::"readWrite"] appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {}
+};
+
+action "readWrite";
+
+action "write" in [Action::"readWrite"] appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_no_applies_to.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_no_applies_to.cedarschema.snap
@@ -1,0 +1,6 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/action_no_applies_to.cedarschema
+---
+action "standalone";

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_with_context.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@action_with_context.cedarschema.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/action_with_context.cedarschema
+---
+entity User;
+
+action "view" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    ip: __cedar::String,
+    timestamp: __cedar::Long
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@app_document.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@app_document.cedarschema.snap
@@ -1,0 +1,19 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/app_document.cedarschema
+---
+namespace App {
+  entity Document = {
+    editors: Set<App::User>,
+    owner: App::User
+  };
+
+  entity User;
+
+  action "edit" appliesTo {
+    principal: [App::User],
+    resource: [App::Document],
+    context: {}
+  };
+}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@basic_action.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@basic_action.cedarschema.snap
@@ -1,0 +1,12 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/basic_action.cedarschema
+---
+entity User;
+
+action "view" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@basic_entity.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@basic_entity.cedarschema.snap
@@ -1,0 +1,6 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/basic_entity.cedarschema
+---
+entity User;

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@common_types.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@common_types.cedarschema.snap
@@ -1,0 +1,18 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/common_types.cedarschema
+---
+entity User = {
+  id: __cedar::String,
+  profile: {
+    age: __cedar::Long,
+    name: __cedar::String
+  }
+};
+
+action "view" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@complex_common_types.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@complex_common_types.cedarschema.snap
@@ -1,0 +1,27 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/complex_common_types.cedarschema
+---
+entity User = {
+  active: __cedar::Bool,
+  contact: {
+    address: {
+      city: __cedar::String,
+      street: __cedar::String,
+      zipcode: __cedar::String
+    },
+    email: __cedar::String,
+    phone?: __cedar::String
+  },
+  permissions: Set<__cedar::String>
+};
+
+action "updateContact" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    reason: __cedar::String,
+    timestamp: __cedar::Long
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@complex_types.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@complex_types.cedarschema.snap
@@ -1,0 +1,12 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/complex_types.cedarschema
+---
+entity User = {
+  permissions: Set<__cedar::String>,
+  profile: {
+    name: __cedar::String,
+    settings: Set<__cedar::String>
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@comprehensive_schema.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@comprehensive_schema.cedarschema.snap
@@ -28,7 +28,7 @@ namespace Documents {
   classification: __cedar::String
 };
 
-  action "approve" in [Action::"review"] appliesTo {
+  action "approve" in [Documents::Action::"review"] appliesTo {
     principal: [Organization::Executive],
     resource: [Documents::Report],
     context: {}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@comprehensive_schema.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@comprehensive_schema.cedarschema.snap
@@ -1,0 +1,91 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/comprehensive_schema.cedarschema
+---
+namespace Documents {
+  entity Document in [Documents::Document] = {
+    author: Organization::Employee,
+    reviewers: Set<Organization::Manager>,
+    title: __cedar::String
+  } tags {
+  classification: __cedar::String
+};
+
+  entity Memo in [Documents::Document] = {
+    author: Organization::Employee,
+    reviewers: Set<Organization::Manager>,
+    title: __cedar::String
+  } tags {
+  classification: __cedar::String
+};
+
+  entity Report in [Documents::Document] = {
+    author: Organization::Employee,
+    reviewers: Set<Organization::Manager>,
+    title: __cedar::String
+  } tags {
+  classification: __cedar::String
+};
+
+  action "approve" in [Action::"review"] appliesTo {
+    principal: [Organization::Executive],
+    resource: [Documents::Report],
+    context: {}
+  };
+
+  action "read" appliesTo {
+    principal: [Organization::Employee, Organization::Manager],
+    resource: [Documents::Document, Documents::Memo, Documents::Report],
+    context: {
+      ip_address: __cedar::String,
+      timestamp: __cedar::Long
+    }
+  };
+
+  action "review" appliesTo {
+    principal: [Organization::Employee, Organization::Manager],
+    resource: [Documents::Document, Documents::Memo, Documents::Report],
+    context: {
+      ip_address: __cedar::String,
+      timestamp: __cedar::Long
+    }
+  };
+
+  action "write" appliesTo {
+    principal: [Organization::Employee, Organization::Manager],
+    resource: [Documents::Document, Documents::Memo, Documents::Report],
+    context: {
+      ip_address: __cedar::String,
+      timestamp: __cedar::Long
+    }
+  };
+}
+
+namespace Organization {
+  entity Department = {
+    budget: __cedar::Long,
+    id: __cedar::String,
+    name: __cedar::String
+  };
+
+  entity Employee in [Organization::Employee] = {
+    department: Organization::Department,
+    email: __cedar::String,
+    phone?: __cedar::String
+  };
+
+  entity Executive in [Organization::Employee] = {
+    department: Organization::Department,
+    email: __cedar::String,
+    phone?: __cedar::String
+  };
+
+  entity Manager in [Organization::Employee] = {
+    department: Organization::Department,
+    email: __cedar::String,
+    phone?: __cedar::String
+  };
+
+  entity Status enum ["active", "inactive", "on_leave"];
+}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@cross_namespace_references.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@cross_namespace_references.cedarschema.snap
@@ -1,0 +1,24 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/cross_namespace_references.cedarschema
+---
+namespace App {
+  entity Document = {
+    editors: Set<Core::User>,
+    owner: Core::User
+  };
+
+  action "edit" appliesTo {
+    principal: [Core::User],
+    resource: [App::Document],
+    context: {}
+  };
+}
+
+namespace Core {
+  entity User = {
+    id: __cedar::String,
+    name: __cedar::String
+  };
+}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@deeply_nested_records.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@deeply_nested_records.cedarschema.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/deeply_nested_records.cedarschema
+---
+entity User = {
+  profile: {
+    personal: {
+      contacts: {
+        email: __cedar::String,
+        phone?: __cedar::String
+      },
+      name: __cedar::String
+    },
+    preferences: {
+      notifications: Set<__cedar::String>,
+      theme: __cedar::String
+    }
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@empty_schema.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@empty_schema.cedarschema.snap
@@ -1,0 +1,6 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/empty_schema.cedarschema
+---
+

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_hierarchy.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_hierarchy.cedarschema.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/entity_hierarchy.cedarschema
+---
+entity Admin in [User];
+
+entity SuperAdmin in [Admin, User];
+
+entity User;

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_references.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_references.cedarschema.snap
@@ -1,0 +1,14 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/entity_references.cedarschema
+---
+entity Document = {
+  editors: Set<User>,
+  group: Group,
+  owner: User
+};
+
+entity Group;
+
+entity User;

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_tags.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_tags.cedarschema.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/entity_tags.cedarschema
+---
+entity Document = {
+  title: __cedar::String
+} tags {
+  classification: __cedar::String,
+  department: __cedar::String
+};
+
+entity User = {
+  name: __cedar::String
+} tags __cedar::String;

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_with_attributes.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@entity_with_attributes.cedarschema.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/entity_with_attributes.cedarschema
+---
+entity User = {
+  active: __cedar::Bool,
+  age: __cedar::Long,
+  name: __cedar::String
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@enum_entities.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@enum_entities.cedarschema.snap
@@ -1,0 +1,14 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/enum_entities.cedarschema
+---
+entity Priority enum ["low", "medium", "high"];
+
+entity Status enum ["active", "inactive", "pending"];
+
+entity Task = {
+  priority: Priority,
+  status: Status,
+  title: __cedar::String
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@extension_types.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@extension_types.cedarschema.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/extension_types.cedarschema
+---
+entity User = {
+  a: __cedar::String,
+  balance: __cedar::decimal,
+  id: __cedar::Long,
+  ip: __cedar::ipaddr
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@mixed_declarations.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@mixed_declarations.cedarschema.snap
@@ -1,0 +1,35 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/mixed_declarations.cedarschema
+---
+entity Admin = {
+  id: __cedar::String,
+  name: __cedar::String
+};
+
+entity Group = {
+  id: __cedar::String,
+  members: Set<User>
+};
+
+entity Status enum ["active", "inactive"];
+
+entity User = {
+  id: __cedar::String,
+  name: __cedar::String
+};
+
+action "manage" in [Action::"read", Action::"write"];
+
+action "read" appliesTo {
+  principal: [Admin, User],
+  resource: [Group],
+  context: {}
+};
+
+action "write" appliesTo {
+  principal: [Admin, User],
+  resource: [Group],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@mixed_required_optional.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@mixed_required_optional.cedarschema.snap
@@ -1,0 +1,13 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/mixed_required_optional.cedarschema
+---
+entity User = {
+  active: __cedar::Bool,
+  age?: __cedar::Long,
+  email?: __cedar::String,
+  id: __cedar::String,
+  name: __cedar::String,
+  tags?: Set<__cedar::String>
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_actions_declared_together.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_actions_declared_together.cedarschema.snap
@@ -1,0 +1,32 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/multiple_actions_declared_together.cedarschema
+---
+entity Document;
+
+entity User;
+
+action "admin_read" in [Action::"read", Action::"write"] appliesTo {
+  principal: [User],
+  resource: [Document],
+  context: {}
+};
+
+action "admin_write" in [Action::"read", Action::"write"] appliesTo {
+  principal: [User],
+  resource: [Document],
+  context: {}
+};
+
+action "read" appliesTo {
+  principal: [User],
+  resource: [Document],
+  context: {}
+};
+
+action "write" appliesTo {
+  principal: [User],
+  resource: [Document],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_entities_declared_together.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_entities_declared_together.cedarschema.snap
@@ -1,0 +1,32 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/multiple_entities_declared_together.cedarschema
+---
+entity Admin;
+
+entity Document = {
+  title: __cedar::String
+};
+
+entity Guest;
+
+entity User;
+
+action "delete" appliesTo {
+  principal: [Admin, User],
+  resource: [Document],
+  context: {}
+};
+
+action "read" appliesTo {
+  principal: [Admin, User],
+  resource: [Document],
+  context: {}
+};
+
+action "write" appliesTo {
+  principal: [Admin, User],
+  resource: [Document],
+  context: {}
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_namespaces.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@multiple_namespaces.cedarschema.snap
@@ -1,0 +1,24 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/multiple_namespaces.cedarschema
+---
+namespace App1 {
+  entity User;
+
+  action "view" appliesTo {
+    principal: [App1::User],
+    resource: [App1::User],
+    context: {}
+  };
+}
+
+namespace App2 {
+  entity Document;
+
+  action "edit" appliesTo {
+    principal: [App1::User],
+    resource: [App2::Document],
+    context: {}
+  };
+}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@namespaced_entities.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@namespaced_entities.cedarschema.snap
@@ -1,0 +1,16 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/namespaced_entities.cedarschema
+---
+namespace MyApp {
+  entity User = {
+    name: __cedar::String
+  };
+
+  action "view" appliesTo {
+    principal: [MyApp::User],
+    resource: [MyApp::User],
+    context: {}
+  };
+}

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@optional_attributes.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@optional_attributes.cedarschema.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/optional_attributes.cedarschema
+---
+entity User = {
+  email?: __cedar::String,
+  name: __cedar::String,
+  phone?: __cedar::String
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_entity_and_common.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_entity_and_common.cedarschema.snap
@@ -1,0 +1,31 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/shadowed_entity_and_common.cedarschema
+---
+entity Address = {
+  e_city: __cedar::String,
+  e_street: __cedar::String,
+  e_zipcode: __cedar::String
+};
+
+entity User = {
+  active: __cedar::Bool,
+  address: {
+    city: __cedar::String,
+    street: __cedar::String,
+    zipcode: __cedar::String
+  }
+};
+
+action "updateContact" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    addy: {
+      city: __cedar::String,
+      street: __cedar::String,
+      zipcode: __cedar::String
+    }
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_extension.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_extension.cedarschema.snap
@@ -1,0 +1,32 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/shadowed_extension.cedarschema
+---
+entity User = {
+  active: __cedar::Bool,
+  contact: {
+    address: {
+      city: __cedar::String,
+      street: __cedar::String,
+      zipcode: __cedar::String
+    },
+    email: __cedar::String,
+    phone?: __cedar::String
+  },
+  permissions: Set<__cedar::String>
+};
+
+action "updateContact" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    reason: __cedar::String,
+    score: __cedar::decimal,
+    shadowedScore: {
+      decimalPart: __cedar::Long,
+      wholeValue: __cedar::Long
+    },
+    timestamp: __cedar::Long
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_extension_as_entity.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_extension_as_entity.cedarschema.snap
@@ -1,0 +1,34 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/shadowed_extension_as_entity.cedarschema
+---
+entity User = {
+  active: __cedar::Bool,
+  contact: {
+    address: {
+      city: __cedar::String,
+      street: __cedar::String,
+      zipcode: __cedar::String
+    },
+    email: __cedar::String,
+    phone?: __cedar::String
+  },
+  permissions: Set<__cedar::String>
+};
+
+entity decimal = {
+  decimalPart: __cedar::Long,
+  wholeValue: __cedar::Long
+};
+
+action "updateContact" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    reason: __cedar::String,
+    score: __cedar::decimal,
+    shadowedScore: decimal,
+    timestamp: __cedar::Long
+  }
+};

--- a/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_primitive.cedarschema.snap
+++ b/cedar-policy-core/src/validator/schema/snapshots/cedar_policy_core__validator__schema__to_json__tests__roundtrip_schemas@shadowed_primitive.cedarschema.snap
@@ -1,0 +1,32 @@
+---
+source: cedar-policy-core/src/validator/schema/to_json.rs
+expression: roundtrip_result
+input_file: cedar-policy/src/ffi/test_schemas/shadowed_primitive.cedarschema
+---
+entity String = {
+  realContent: __cedar::String
+};
+
+entity User = {
+  active: __cedar::Bool,
+  contact: {
+    address: {
+      city: String,
+      street: String,
+      zipcode: String
+    },
+    email: String,
+    phone?: String
+  },
+  permissions: Set<__cedar::String>
+};
+
+action "updateContact" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {
+    newtypeReason: String,
+    reason: __cedar::String,
+    timestamp: __cedar::Long
+  }
+};

--- a/cedar-policy-core/src/validator/schema/to_json.rs
+++ b/cedar-policy-core/src/validator/schema/to_json.rs
@@ -96,8 +96,8 @@ impl ValidatorSchema {
     /// Converts a `ValidatorSchema` into a `json_schema::Fragment`.
     /// Roundtripping through this function gives a semantically equivalent
     /// schema but will lose formatting, annotations, and common type
-    /// definition. It will also result in the inlining the transitive closure
-    /// of the entity hierarchy at for each entity type and action.
+    /// definitions. It will also inline the transitive closure of the entity
+    /// hierarchy for each entity type and action.
     pub fn to_json_schema(&self) -> Result<json_schema::Fragment<RawName>, String> {
         let mut namespaces = HashMap::new();
 
@@ -194,7 +194,9 @@ impl ValidatorActionId {
                     .into_iter()
                     .sorted()
                     .map(|action_uid| json_schema::ActionEntityUID {
-                        ty: None,
+                        ty: Some(RawName::from_name(
+                            action_uid.entity_type().as_ref().as_ref().clone(),
+                        )),
                         id: action_uid.eid().as_ref().to_smolstr(),
                         #[cfg(feature = "extended-schema")]
                         loc: None,
@@ -322,7 +324,7 @@ mod tests {
                     .to_cedar_schema()
                     .expect("Failed to convert schema to Cedar format");
 
-                // Parse again to assert that the roundtripped schema is equivlant.
+                // Parse again to assert that the roundtripped schema is equivalent.
                 let (roundtrip_schema, _) = ValidatorSchema::from_cedarschema_str(
                     &roundtrip_result,
                     &Extensions::all_available(),
@@ -330,7 +332,7 @@ mod tests {
                 .expect("Failed to parse roundtrip Cedar schema");
                 similar_asserts::assert_eq!(roundtrip_schema, original_schema);
 
-                // Snapshot the middle cedar scheam text so we can check that it
+                // Snapshot the middle cedar schema text so we can check that it
                 // looks reasonable to a human.
                 insta::assert_snapshot!(roundtrip_result);
             }

--- a/cedar-policy-core/src/validator/schema/to_json.rs
+++ b/cedar-policy-core/src/validator/schema/to_json.rs
@@ -1,0 +1,337 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::{
+    ast::{EntityType, EntityUID, InternalName, Name},
+    est::Annotations,
+    validator::{
+        json_schema,
+        types::{BoolType, EntityKind, OpenTag, Type},
+        RawName, ValidatorActionId, ValidatorEntityType, ValidatorEntityTypeKind, ValidatorSchema,
+    },
+};
+use itertools::Itertools;
+use smol_str::ToSmolStr;
+
+fn validator_type_to_json_type(ty: &Type) -> Result<json_schema::Type<RawName>, String> {
+    let mk_type = |variant| {
+        Ok(json_schema::Type::Type {
+            ty: variant,
+            loc: None,
+        })
+    };
+    match ty {
+        Type::Bool(BoolType::AnyBool) => mk_type(json_schema::TypeVariant::Boolean),
+        Type::Long => mk_type(json_schema::TypeVariant::Long),
+        Type::String => mk_type(json_schema::TypeVariant::String),
+        Type::Set { element_type } => {
+            let element = match element_type {
+                Some(et) => validator_type_to_json_type(et)?,
+                None => return Err("Set with unknown element type not supported".to_string()),
+            };
+            mk_type(json_schema::TypeVariant::Set {
+                element: Box::new(element),
+            })
+        }
+        Type::Record {
+            attrs,
+            open_attributes,
+        } => {
+            let attributes = attrs
+                .iter()
+                .map(|(name, attr_type)| {
+                    Ok((
+                        name.clone(),
+                        json_schema::TypeOfAttribute {
+                            ty: validator_type_to_json_type(&attr_type.attr_type)?,
+                            required: attr_type.is_required,
+                            annotations: Annotations::new(),
+                            #[cfg(feature = "extended-schema")]
+                            loc: None,
+                        },
+                    ))
+                })
+                .collect::<Result<BTreeMap<_, _>, String>>()?;
+
+            mk_type(json_schema::TypeVariant::Record(json_schema::RecordType {
+                attributes,
+                additional_attributes: *open_attributes == OpenTag::OpenAttributes,
+            }))
+        }
+        Type::Entity(EntityKind::Entity(lub)) => {
+            if let Some(entity_type) = lub.get_single_entity() {
+                mk_type(json_schema::TypeVariant::EntityOrCommon {
+                    type_name: RawName::from_name(entity_type.as_ref().as_ref().clone()),
+                })
+            } else {
+                Err("Entity LUB with multiple types not supported".to_string())
+            }
+        }
+        Type::ExtensionType { name } => Ok(json_schema::Type::Type {
+            ty: json_schema::TypeVariant::Extension {
+                name: name.basename().clone(),
+            },
+            loc: None,
+        }),
+        _ => Err("Unsupported type for conversion".to_string()),
+    }
+}
+
+impl ValidatorSchema {
+    /// Converts a `ValidatorSchema` into a `json_schema::Fragment`.
+    /// Roundtripping through this function gives a semantically equivalent
+    /// schema but will lose formatting, annotations, and common type
+    /// definition. It will also result in the inlining the transitive closure
+    /// of the entity hierarchy at for each entity type and action.
+    pub fn to_json_schema(&self) -> Result<json_schema::Fragment<RawName>, String> {
+        let mut namespaces = HashMap::new();
+
+        let mut entity_ancestors = self.entity_ancestors();
+        for (entity_type, validator_entity_type) in &self.entity_types {
+            let ancestors = entity_ancestors.remove(&entity_type).unwrap();
+            let namespace = entity_type.as_ref().as_ref().path.clone();
+            let entity_name = entity_type.as_ref().basename().clone();
+            let json_entity_type = validator_entity_type.to_json_entity_type(ancestors)?;
+            let (entity_types, _) = namespaces
+                .entry(namespace)
+                .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
+            entity_types.insert(entity_name, json_entity_type);
+        }
+
+        for (action_uid, validator_action_id) in &self.action_ids {
+            let action = self.actions.get(&action_uid).unwrap();
+            let namespace = action_uid.entity_type().as_ref().as_ref().path.clone();
+            let action_name = action_uid.eid().as_ref().to_smolstr();
+            let json_action_type =
+                validator_action_id.to_json_action_type(action.ancestors().cloned().collect())?;
+
+            let (_, action_types) = namespaces
+                .entry(namespace)
+                .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
+            action_types.insert(action_name, json_action_type);
+        }
+
+        let mut namespace_definitions = BTreeMap::new();
+        for (namespace, (entity_types, action_types)) in namespaces {
+            let namespace = {
+                let mut namespace = namespace.as_ref().clone();
+                if let Some(id) = namespace.pop() {
+                    Some(
+                        Name::try_from(InternalName::new(id, namespace.into_iter(), None))
+                            .map_err(|e| e.to_string())?,
+                    )
+                } else {
+                    None
+                }
+            };
+            let namespace_def = json_schema::NamespaceDefinition {
+                common_types: BTreeMap::new(),
+                entity_types,
+                actions: action_types,
+                annotations: Annotations::new(),
+                #[cfg(feature = "extended-schema")]
+                loc: None,
+            };
+            namespace_definitions.insert(namespace, namespace_def);
+        }
+
+        Ok(json_schema::Fragment(namespace_definitions))
+    }
+
+    /// Converts a `ValidatorSchema` into a Cedar schema string.
+    /// This first converts to JSON schema format and then to Cedar syntax.
+    pub fn to_cedar_schema(&self) -> Result<String, String> {
+        let fragment = self.to_json_schema()?;
+        fragment.to_cedarschema().map_err(|e| e.to_string())
+    }
+
+    fn entity_ancestors(&self) -> HashMap<EntityType, HashSet<EntityType>> {
+        self.entity_types
+            .keys()
+            .map(|ety| {
+                let ancestors = self
+                    .entity_types
+                    .iter()
+                    .filter(|(_, parent_vety)| parent_vety.descendants.contains(ety))
+                    .map(|(parent_ety, _)| parent_ety.clone())
+                    .collect();
+                (ety.clone(), ancestors)
+            })
+            .collect()
+    }
+}
+
+impl ValidatorActionId {
+    fn to_json_action_type(
+        &self,
+        ancestors: HashSet<EntityUID>,
+    ) -> Result<json_schema::ActionType<RawName>, String> {
+        // Convert ancestors to member_of (JSON schema format)
+        let member_of: Option<Vec<json_schema::ActionEntityUID<RawName>>> = if ancestors.is_empty()
+        {
+            None
+        } else {
+            // Sort for deterministic output
+            Some(
+                ancestors
+                    .into_iter()
+                    .sorted()
+                    .map(|action_uid| json_schema::ActionEntityUID {
+                        ty: None,
+                        id: action_uid.eid().as_ref().to_smolstr(),
+                        #[cfg(feature = "extended-schema")]
+                        loc: None,
+                    })
+                    .collect(),
+            )
+        };
+
+        Ok(json_schema::ActionType {
+            attributes: None,
+            applies_to: Some(json_schema::ApplySpec {
+                resource_types: self
+                    .applies_to
+                    .applicable_resource_types()
+                    .map(|et| RawName::from_name(et.as_ref().as_ref().clone()))
+                    .sorted()
+                    .collect(),
+                principal_types: self
+                    .applies_to
+                    .applicable_principal_types()
+                    .map(|et| RawName::from_name(et.as_ref().as_ref().clone()))
+                    .sorted()
+                    .collect(),
+                context: json_schema::AttributesOrContext(validator_type_to_json_type(
+                    &self.context,
+                )?),
+            }),
+            member_of,
+            annotations: Annotations::new(),
+            loc: self.loc.clone(),
+            #[cfg(feature = "extended-schema")]
+            defn_loc: None,
+        })
+    }
+}
+
+impl ValidatorEntityType {
+    fn to_json_entity_type(
+        &self,
+        ancestors: HashSet<EntityType>,
+    ) -> Result<json_schema::EntityType<RawName>, String> {
+        let kind = match &self.kind {
+            ValidatorEntityTypeKind::Standard(std_type) => {
+                let attributes = self
+                    .attributes
+                    .iter()
+                    .map(|(name, attr_type)| {
+                        Ok((
+                            name.clone(),
+                            json_schema::TypeOfAttribute {
+                                ty: validator_type_to_json_type(&attr_type.attr_type)?,
+                                required: attr_type.is_required,
+                                annotations: Annotations::new(),
+                                #[cfg(feature = "extended-schema")]
+                                loc: None,
+                            },
+                        ))
+                    })
+                    .collect::<Result<BTreeMap<_, _>, String>>()?;
+
+                let member_of_types: Vec<RawName> = ancestors
+                    .into_iter()
+                    .map(|entity_type| RawName::from_name(entity_type.as_ref().as_ref().clone()))
+                    .sorted()
+                    .collect();
+
+                json_schema::EntityTypeKind::Standard(json_schema::StandardEntityType {
+                    member_of_types,
+                    shape: json_schema::AttributesOrContext(json_schema::Type::Type {
+                        ty: json_schema::TypeVariant::Record(json_schema::RecordType {
+                            attributes,
+                            additional_attributes: std_type.open_attributes
+                                == crate::validator::types::OpenTag::OpenAttributes,
+                        }),
+                        loc: None,
+                    }),
+                    tags: std_type
+                        .tags
+                        .as_ref()
+                        .map(|tag_type| validator_type_to_json_type(tag_type))
+                        .transpose()?,
+                })
+            }
+            ValidatorEntityTypeKind::Enum(choices) => json_schema::EntityTypeKind::Enum {
+                choices: choices.clone(),
+            },
+        };
+
+        Ok(json_schema::EntityType {
+            kind,
+            annotations: Annotations::new(),
+            loc: self.loc.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::extensions::Extensions;
+    use crate::validator::ValidatorSchema;
+
+    #[test]
+    fn test_to_json_schema_basic() {
+        let schema = ValidatorSchema::empty();
+        let fragment = schema.to_json_schema().unwrap();
+        assert_eq!(fragment.0.len(), 0);
+    }
+
+    #[test]
+    fn test_roundtrip_schemas() {
+        insta::glob!(
+            "../../../../cedar-policy/src/ffi/test_schemas/",
+            "*.cedarschema",
+            |path| {
+                let cedar_schema = std::fs::read_to_string(path).unwrap();
+
+                // Parse the original Cedar schema and then convert back to a cedar
+                // schema, which goes JSON, testing the logic in this file.
+                let (original_schema, _) = ValidatorSchema::from_cedarschema_str(
+                    &cedar_schema,
+                    &Extensions::all_available(),
+                )
+                .expect("Failed to parse original Cedar schema");
+                let roundtrip_result = original_schema
+                    .to_cedar_schema()
+                    .expect("Failed to convert schema to Cedar format");
+
+                // Parse again to assert that the roundtripped schema is equivlant.
+                let (roundtrip_schema, _) = ValidatorSchema::from_cedarschema_str(
+                    &roundtrip_result,
+                    &Extensions::all_available(),
+                )
+                .expect("Failed to parse roundtrip Cedar schema");
+                similar_asserts::assert_eq!(roundtrip_schema, original_schema);
+
+                // Snapshot the middle cedar scheam text so we can check that it
+                // looks reasonable to a human.
+                insta::assert_snapshot!(roundtrip_result);
+            }
+        );
+    }
+}

--- a/cedar-policy-core/src/validator/schema/to_json.rs
+++ b/cedar-policy-core/src/validator/schema/to_json.rs
@@ -84,7 +84,7 @@ fn validator_type_to_json_type(ty: &Type) -> Result<json_schema::Type<RawName>, 
         }
         Type::ExtensionType { name } => Ok(json_schema::Type::Type {
             ty: json_schema::TypeVariant::Extension {
-                name: name.basename().clone(),
+                name: name.basename(),
             },
             loc: None,
         }),
@@ -103,27 +103,29 @@ impl ValidatorSchema {
 
         let mut entity_ancestors = self.entity_ancestors();
         for (entity_type, validator_entity_type) in &self.entity_types {
-            let ancestors = entity_ancestors.remove(&entity_type).unwrap();
-            let namespace = entity_type.as_ref().as_ref().path.clone();
-            let entity_name = entity_type.as_ref().basename().clone();
-            let json_entity_type = validator_entity_type.to_json_entity_type(ancestors)?;
-            let (entity_types, _) = namespaces
-                .entry(namespace)
-                .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
-            entity_types.insert(entity_name, json_entity_type);
+            if let Some(ancestors) = entity_ancestors.remove(&entity_type) {
+                let namespace = entity_type.as_ref().as_ref().path.clone();
+                let entity_name = entity_type.as_ref().basename().clone();
+                let json_entity_type = validator_entity_type.to_json_entity_type(ancestors)?;
+                let (entity_types, _) = namespaces
+                    .entry(namespace)
+                    .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
+                entity_types.insert(entity_name, json_entity_type);
+            }
         }
 
         for (action_uid, validator_action_id) in &self.action_ids {
-            let action = self.actions.get(&action_uid).unwrap();
-            let namespace = action_uid.entity_type().as_ref().as_ref().path.clone();
-            let action_name = action_uid.eid().as_ref().to_smolstr();
-            let json_action_type =
-                validator_action_id.to_json_action_type(action.ancestors().cloned().collect())?;
+            if let Some(action) = self.actions.get(action_uid) {
+                let namespace = action_uid.entity_type().as_ref().as_ref().path.clone();
+                let action_name = action_uid.eid().as_ref().to_smolstr();
+                let json_action_type = validator_action_id
+                    .to_json_action_type(action.ancestors().cloned().collect())?;
 
-            let (_, action_types) = namespaces
-                .entry(namespace)
-                .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
-            action_types.insert(action_name, json_action_type);
+                let (_, action_types) = namespaces
+                    .entry(namespace)
+                    .or_insert_with(|| (BTreeMap::new(), BTreeMap::new()));
+                action_types.insert(action_name, json_action_type);
+            }
         }
 
         let mut namespace_definitions = BTreeMap::new();
@@ -272,7 +274,7 @@ impl ValidatorEntityType {
                     tags: std_type
                         .tags
                         .as_ref()
-                        .map(|tag_type| validator_type_to_json_type(tag_type))
+                        .map(validator_type_to_json_type)
                         .transpose()?,
                 })
             }


### PR DESCRIPTION
## Description of changes

Adds a functions for converting form the internal schema representation to the JSON format (and from that to Cedar format using existing conversion functions). Does not add anything to the public API.

This should be useful for testing certain roundtrip properties, but I'm not sure about adding it to the public API. This conversion function looses a lot of information about the schema formatting (common types and annotations in particular). Users of the public API would likely prefer a to convert directly between Cedar and JSON which preserves more detail. This function would still be required for for converting protobuf to either of the other formats. We should ideally make a public API that does the highest fidelity translation using the given input and target format. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
