### PR TITLE
fix model decoding to work zith z3

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Cedar Language Version: TBD
 
+### Fixed
+- Model decoder now skips unknown `define-fun` entries in solver output, improving compatibility with Z3 and other solvers that include intermediate terms in `(get-model)` responses.
+
 ## [0.5.0] - 2026-05-18
 Cedar Language Version: 4.5
 

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -1162,21 +1162,29 @@ impl SExpr {
                     if define_fun == "define-fun" =>
                 {
                     match args.as_slice() {
-                        // Decode unary function
+                        // Decode unary function (skip if not a known UUF)
                         [SExpr::App(arg)] if arg.len() == 2 => match arg.as_slice() {
                             [SExpr::Symbol(arg_name), arg_ty] => {
-                                let (uuf, udf) = Self::decode_unary_function(
-                                    id_maps, name, arg_name, arg_ty, ret_ty, body,
-                                )?;
-                                funs.insert(uuf, udf);
+                                if id_maps.uufs.contains_key(name) {
+                                    let (uuf, udf) = Self::decode_unary_function(
+                                        id_maps, name, arg_name, arg_ty, ret_ty, body,
+                                    )?;
+                                    funs.insert(uuf, udf);
+                                }
+                                // else: skip unknown unary functions (e.g., Z3 intermediate terms)
                             }
                             _ => return Err(DecodeError::UnexpectedModel),
                         },
 
                         // Decode SMT constant definition as interpretation to a Cedar variable
+                        // (skip if not a known variable — Z3 includes define-fun entries
+                        // for intermediate terms that aren't declare-const variables)
                         [] => {
-                            let (term_var, term) = Self::decode_var(id_maps, name, ret_ty, body)?;
-                            vars.insert(term_var, term);
+                            if id_maps.vars.contains_key(name) {
+                                let (term_var, term) =
+                                    Self::decode_var(id_maps, name, ret_ty, body)?;
+                                vars.insert(term_var, term);
+                            }
                         }
 
                         _ => return Err(DecodeError::UnexpectedModel),
@@ -1514,6 +1522,72 @@ mod test_decode {
             TermType::String,
             SmolStr::new_static("foo"),
         );
+    }
+
+    /// Z3 includes `define-fun` entries in its model for intermediate terms
+    /// (e.g., terms introduced by `define-fun` in the input), not just
+    /// `declare-const` variables. The decoder should skip these unknown
+    /// symbols rather than failing with `UnknownVariable`.
+    ///
+    /// Reproduces the model format seen when using Z3 4.12.5 as the solver:
+    /// ```text
+    /// (define-fun t0 () E0 (E0 "!0!"))    <-- the actual declare-const var
+    /// (define-fun t3 () Bool (not ...))    <-- intermediate, not in IdMaps
+    /// (define-fun t1 () E0 (E0 "a"))      <-- intermediate
+    /// (define-fun t2 () Bool (= t0 ...))  <-- intermediate
+    /// ```
+    #[test]
+    fn decode_model_skips_unknown_define_funs() {
+        // Z3-style model with extra define-funs for intermediate terms.
+        // The decoder should skip unknown names and still decode known vars.
+        let z3_model = r#"(
+            (define-fun t0 () Bool true)
+            (define-fun t3 () Bool (not true))
+        )"#;
+        let sexpr = parse_sexpr(z3_model.as_bytes()).expect("failed to parse");
+        let var = TermVar {
+            id: "t0".into(),
+            ty: TermType::Bool,
+        };
+        let result = sexpr.decode_model(
+            &TEST_ENV,
+            &IdMaps {
+                types: BTreeMap::new(),
+                vars: BTreeMap::from([(&var.id, &var)]), // only t0 in consts
+                uufs: BTreeMap::new(),
+                enums: BTreeMap::new(),
+            },
+        );
+        let interp = result.expect("decode_model should skip unknown define-funs");
+        let val = interp.vars.get(&var).expect("t0 should be in the model");
+        assert_eq!(*val, Term::Prim(crate::symcc::term::TermPrim::Bool(true)));
+    }
+
+    #[test]
+    fn decode_model_skips_unknown_unary_funs() {
+        // Z3-style model with an unknown unary function (not in IdMaps.uufs).
+        // The decoder should skip it.
+        let z3_model = r#"(
+            (define-fun t0 () Bool true)
+            (define-fun unknown_fn ((x Bool)) Bool (ite (= true x) false true))
+        )"#;
+        let sexpr = parse_sexpr(z3_model.as_bytes()).expect("failed to parse");
+        let var = TermVar {
+            id: "t0".into(),
+            ty: TermType::Bool,
+        };
+        let result = sexpr.decode_model(
+            &TEST_ENV,
+            &IdMaps {
+                types: BTreeMap::new(),
+                vars: BTreeMap::from([(&var.id, &var)]), // only t0 in consts
+                uufs: BTreeMap::new(),
+                enums: BTreeMap::new(),
+            },
+        );
+        let interp = result.expect("decode_model should skip unknown unary funs");
+        let val = interp.vars.get(&var).expect("t0 should be in the model");
+        assert_eq!(*val, Term::Prim(crate::symcc::term::TermPrim::Bool(true)));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes
Skips extra `(define-fun ...` in solver model output because some solver may include more declaration than the expected model values for the `(define-const`'d variables. 

Skipping extra definitions in the model should have no impact on backwards compatibility; an extra definition is not an error. Later on, we may want to validate models further (e.g., that those extra definitions are declarations in the input of the solver). 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.