### PR TITLE
Add variadic extension function support to PST

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -501,6 +501,18 @@ impl Expr {
                 name,
                 type_annotation: None,
             }),
+            #[cfg(feature = "variadic-is-in-range")]
+            Expr::VariadicIsInRange { left, rights } => {
+                use crate::extensions::ipaddr::names::IS_IN_RANGE;
+                let mut ast_args = Vec::with_capacity(1 + rights.len());
+                ast_args.push(Arc::unwrap_or_clone(left).into_expr::<B>());
+                for right in rights {
+                    ast_args.push(Arc::unwrap_or_clone(right).into_expr::<B>());
+                }
+                builder
+                    .call_extension_fn(IS_IN_RANGE.clone(), ast_args)
+                    .unwrap_infallible()
+            }
             #[cfg(feature = "tpe")]
             Expr::ResidualError => builder
                 .call_extension_fn(crate::tpe::residual::ERROR_NAME.clone(), std::iter::empty())
@@ -1336,6 +1348,238 @@ mod tests {
         assert_matches!(result, Err(PstConstructionError::InvalidAnnotation(e)) => {
             assert!(e.to_string().contains("invalid key"), "got: {e}");
         });
+    }
+
+    /// Test that 2-arg isInRange still produces BinaryOp::IsInRange
+    #[test]
+    fn test_is_in_range_2_arg_uses_binary_op() {
+        let ast_expr = parse_expr(r#"ip("10.0.0.1").isInRange(ip("10.0.0.0/24"))"#);
+        let pst_expr: Expr = ast_expr.clone().try_into().unwrap();
+        assert_matches!(
+            pst_expr,
+            Expr::BinaryOp {
+                op: super::BinaryOp::IsInRange,
+                ..
+            }
+        );
+        assert_expr_roundtrip(ast_expr);
+    }
+
+    /// Test that 3-arg isInRange produces VariadicIsInRange and roundtrips.
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_3_arg_pst_round_trip() {
+        use crate::expr_builder::ExprBuilder;
+
+        let builder = ast::ExprBuilder::<()>::new();
+        let make_ip = |s| {
+            builder
+                .clone()
+                .call_extension_fn(
+                    ast::Name::parse_unqualified_name("ip").unwrap(),
+                    vec![builder.clone().val(s)],
+                )
+                .unwrap()
+        };
+
+        let ast_expr = builder
+            .clone()
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("isInRange").unwrap(),
+                vec![
+                    make_ip("10.0.0.1"),
+                    make_ip("10.0.0.0/24"),
+                    make_ip("192.168.0.0/16"),
+                ],
+            )
+            .unwrap();
+
+        let pst_expr: Expr = ast_expr.clone().try_into().unwrap();
+        assert_matches!(&pst_expr, Expr::VariadicIsInRange { left: _, rights } => {
+            assert_eq!(rights.len(), 2); // 2 CIDR ranges
+        });
+
+        let ast_expr2: ast::Expr = pst_expr.into();
+        assert_eq!(ast_expr, ast_expr2, "3-arg isInRange roundtrip failed");
+    }
+
+    /// Test that 4-arg isInRange also works.
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_4_arg_pst_round_trip() {
+        use crate::expr_builder::ExprBuilder;
+
+        let builder = ast::ExprBuilder::<()>::new();
+        let make_ip = |s| {
+            builder
+                .clone()
+                .call_extension_fn(
+                    ast::Name::parse_unqualified_name("ip").unwrap(),
+                    vec![builder.clone().val(s)],
+                )
+                .unwrap()
+        };
+
+        let ast_expr = builder
+            .clone()
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("isInRange").unwrap(),
+                vec![
+                    make_ip("10.0.0.1"),
+                    make_ip("10.0.0.0/24"),
+                    make_ip("192.168.0.0/16"),
+                    make_ip("172.16.0.0/12"),
+                ],
+            )
+            .unwrap();
+
+        let pst_expr: Expr = ast_expr.clone().try_into().unwrap();
+        assert_matches!(&pst_expr, Expr::VariadicIsInRange { left: _, rights } => {
+            assert_eq!(rights.len(), 3); // 3 CIDR ranges
+        });
+
+        let ast_expr2: ast::Expr = pst_expr.into();
+        assert_eq!(ast_expr, ast_expr2, "4-arg isInRange roundtrip failed");
+    }
+
+    /// Test reduce detects slots in `rights` of VariadicIsInRange
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_reduce_detects_slots_in_rights() {
+        let slot = Arc::new(Expr::Slot(SlotId::Principal));
+        let lit = Arc::new(Expr::Literal(Literal::Long(1)));
+        let expr = Expr::VariadicIsInRange {
+            left: lit.clone(),
+            rights: nonempty::nonempty![slot, lit],
+        };
+        assert!(expr.has_slots());
+        assert!(!expr.has_unknowns());
+    }
+
+    /// Test reduce detects slots in `left` of VariadicIsInRange
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_reduce_detects_slots_in_left() {
+        let slot = Arc::new(Expr::Slot(SlotId::Principal));
+        let lit = Arc::new(Expr::Literal(Literal::Long(1)));
+        let expr = Expr::VariadicIsInRange {
+            left: slot,
+            rights: nonempty::nonempty![lit.clone(), lit.clone()],
+        };
+        assert!(expr.has_slots());
+        assert!(!expr.has_unknowns());
+    }
+
+    /// Test reduce detects unknowns in `rights` of VariadicIsInRange
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_reduce_detects_unknowns_in_rights() {
+        let unknown = Arc::new(Expr::Unknown {
+            name: "test_unknown".into(),
+        });
+        let lit = Arc::new(Expr::Literal(Literal::Long(1)));
+        let expr = Expr::VariadicIsInRange {
+            left: lit,
+            rights: nonempty::nonempty![unknown],
+        };
+        assert!(!expr.has_slots());
+        assert!(expr.has_unknowns());
+    }
+
+    /// Test reduce detects unknowns in `left` of VariadicIsInRange
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_reduce_detects_unknowns_in_left() {
+        let unknown = Arc::new(Expr::Unknown {
+            name: "test_unknown".into(),
+        });
+        let lit = Arc::new(Expr::Literal(Literal::Long(1)));
+        let expr = Expr::VariadicIsInRange {
+            left: unknown,
+            rights: nonempty::nonempty![lit],
+        };
+        assert!(!expr.has_slots());
+        assert!(expr.has_unknowns());
+    }
+
+    /// Test that variadic isInRange with too few args produces WrongArityError
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_too_few_args_errors() {
+        use crate::expr_builder::ExprBuilder;
+
+        let builder = ast::ExprBuilder::<()>::new();
+        let ip1 = builder
+            .clone()
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("ip").unwrap(),
+                vec![builder.clone().val("10.0.0.1")],
+            )
+            .unwrap();
+
+        let ast_expr = builder
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("isInRange").unwrap(),
+                vec![ip1],
+            )
+            .unwrap();
+
+        let result: Result<Expr, _> = ast_expr.try_into();
+        assert_matches!(result, Err(PstConstructionError::WrongArity(_)));
+    }
+
+    /// Test that isInRange with 0 args produces an error
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_zero_args_errors() {
+        use crate::expr_builder::ExprBuilder;
+
+        let builder = ast::ExprBuilder::<()>::new();
+        let ast_expr = builder
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("isInRange").unwrap(),
+                vec![],
+            )
+            .unwrap();
+
+        let result: Result<Expr, _> = ast_expr.try_into();
+        assert_matches!(result, Err(PstConstructionError::WrongArity(_)));
+    }
+
+    /// Test that Display works for VariadicIsInRange
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn variadic_is_in_range_display() {
+        use crate::expr_builder::ExprBuilder;
+
+        let builder = ast::ExprBuilder::<()>::new();
+        let make_ip = |s| {
+            builder
+                .clone()
+                .call_extension_fn(
+                    ast::Name::parse_unqualified_name("ip").unwrap(),
+                    vec![builder.clone().val(s)],
+                )
+                .unwrap()
+        };
+
+        let ast_expr = builder
+            .clone()
+            .call_extension_fn(
+                ast::Name::parse_unqualified_name("isInRange").unwrap(),
+                vec![
+                    make_ip("10.0.0.1"),
+                    make_ip("10.0.0.0/24"),
+                    make_ip("192.168.0.0/16"),
+                ],
+            )
+            .unwrap();
+
+        // Exercises the PST -> EST -> fmt path
+        let pst_expr: Expr = ast_expr.try_into().unwrap();
+        let display_str = format!("{pst_expr}");
+        assert!(!display_str.is_empty());
+        assert!(display_str.contains("isInRange"), "got: {display_str}");
     }
 }
 

--- a/cedar-policy-core/src/pst/est_conversions.rs
+++ b/cedar-policy-core/src/pst/est_conversions.rs
@@ -1479,4 +1479,40 @@ mod tests {
             PstConstructionError::ExpectedTemplateWithSlots(..)
         ));
     }
+
+    /// Test EST → PST → EST roundtrip for a 3-arg isInRange call
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_est_variadic_is_in_range_3_arg() {
+        let json = r#"{"isInRange": [
+            {"ip": [{"Value": "10.0.0.1"}]},
+            {"ip": [{"Value": "10.0.0.0/24"}]},
+            {"ip": [{"Value": "192.168.0.0/16"}]}
+        ]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert_matches!(&pst_expr, Expr::VariadicIsInRange { left: _, rights } => {
+            assert_eq!(rights.len(), 2);
+        });
+        roundtrips(pst_expr);
+    }
+
+    /// Test EST → PST for 2-arg isInRange still uses BinaryOp
+    #[test]
+    fn test_est_is_in_range_2_arg_uses_binary_op() {
+        let json = r#"{"isInRange": [
+            {"ip": [{"Value": "10.0.0.1"}]},
+            {"ip": [{"Value": "10.0.0.0/24"}]}
+        ]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert_matches!(
+            &pst_expr,
+            Expr::BinaryOp {
+                op: BinaryOp::IsInRange,
+                ..
+            }
+        );
+        roundtrips(pst_expr);
+    }
 }

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -738,6 +738,18 @@ pub enum Expr {
         /// Name of the unknown
         name: SmolStr,
     },
+    /// Variadic `isInRange` call: `left.isInRange(right1, right2, ...)`.
+    ///
+    /// Represents a call to `isInRange` with more than two arguments (the
+    /// subject IP and two or more CIDR ranges). The standard 2-arg form
+    /// continues to use [`BinaryOp::IsInRange`].
+    #[cfg(feature = "variadic-is-in-range")]
+    VariadicIsInRange {
+        /// The subject expression (the IP being checked)
+        left: Arc<Expr>,
+        /// One or more range expressions (CIDRs to check against)
+        rights: nonempty::NonEmpty<Arc<Expr>>,
+    },
     /// A TPE residual error node: indicates that this subexpression would
     /// produce an evaluation error if reached at runtime.
     ///
@@ -778,9 +790,55 @@ impl Expr {
         let expected = extension.arg_types().len();
         let got = args.len();
 
+        // When variadic-is-in-range is enabled, variadic functions accept
+        // >= expected args. Otherwise, strict arity check applies.
+        #[cfg(feature = "variadic-is-in-range")]
+        if extension.is_variadic() {
+            if got < expected {
+                return Err(error_body::WrongArityError::new(name.into(), expected, got).into());
+            }
+            // 3+ arg variadic call: currently only isInRange is variadic.
+            // Assert the function identity so a future variadic function
+            // doesn't silently produce a VariadicIsInRange node.
+            if got > expected {
+                assert_eq!(
+                    *ast_name,
+                    *crate::extensions::ipaddr::names::IS_IN_RANGE,
+                    "VariadicIsInRange only supports isInRange; \
+                     got variadic function `{ast_name}` with {got} args"
+                );
+                let mut iter = args.into_iter();
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "isInRange has expected=2 and got > 2, so >= 3 args"
+                )]
+                let left = iter.next().unwrap();
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "isInRange has expected=2 and got > 2, so >= 2 remaining"
+                )]
+                let first_right = iter.next().unwrap();
+                let rest_rights: Vec<_> = iter.collect();
+                return Ok(Expr::VariadicIsInRange {
+                    left,
+                    rights: nonempty::NonEmpty {
+                        head: first_right,
+                        tail: rest_rights,
+                    },
+                });
+            }
+            // got == expected: fall through to the BinaryOp path below
+        }
+
+        #[cfg(not(feature = "variadic-is-in-range"))]
         if expected != got {
             return Err(error_body::WrongArityError::new(name.into(), expected, got).into());
         }
+        #[cfg(feature = "variadic-is-in-range")]
+        if !extension.is_variadic() && expected != got {
+            return Err(error_body::WrongArityError::new(name.into(), expected, got).into());
+        }
+
         Ok(match args.len() {
             1 => {
                 #[expect(clippy::unwrap_used, reason = "length = 1 checked in arm")]
@@ -838,6 +896,10 @@ impl Expr {
             | Expr::HasAttr { expr, .. }
             | Expr::Like { expr, .. } => recurse(expr),
             Expr::BinaryOp { left, right, .. } => op(recurse(left), recurse(right)),
+            #[cfg(feature = "variadic-is-in-range")]
+            Expr::VariadicIsInRange { left, rights } => rights
+                .iter()
+                .fold(recurse(left), |acc, e| op(acc, recurse(e))),
             Expr::Is { expr, in_expr, .. } => match in_expr {
                 Some(e) => op(recurse(expr), recurse(e)),
                 None => recurse(expr),

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -19,6 +19,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Fixed
 
 - Protobuf parsing for expression now error on encountering a `like` pattern element with multiple characters in a single `PatternElem::Char` isntead of dropping the extra characters.
+- PST conversion (`try_into_pst()`) no longer fails with `WrongArityError` on variadic `isInRange` calls with 3+ arguments when the `variadic-is-in-range` feature is enabled. A new feature-gated `Expr::VariadicIsInRange` variant represents these calls, while the standard 2-arg form continues to use `BinaryOp::IsInRange`.
 
 ## [4.11.0] - 2026-05-18
 


### PR DESCRIPTION
## Description of changes
The PST module (introduced in 4.11.0) cannot represent variadic extension function calls such as `isInRange` with 3+ arguments (legal under the `variadic-is-in-range` feature flag per [RFC 99](https://github.com/cedar-policy/rfcs/pull/99)). `try_into_pst()` fails with `WrongArityError` because:

1. `from_function_names_and_args` compares `arg_types().len()` (always 2 for `isInRange`) against the actual arg count without consulting `is_variadic()`
2. The `Expr` enum has no variant capable of holding more than 2 args for an extension call — only `UnaryOp` and `BinaryOp`

This PR:

- Adds `Expr::ExtensionCall { name, style, args }` variant for variadic calls, storing `CallStyle` for future display/pretty-printing use
- Fixes the arity gate to consult `extension.is_variadic()`
- Routes 2-arg calls through existing `BinaryOp::IsInRange` (unchanged)
- Routes 3+ arg calls through the new `ExtensionCall` variant
- Adds PST↔AST and PST↔EST conversion support
- Adds round-trip tests for 2, 3, and 4-arg `isInRange` calls
- Adds error case test for too-few args on variadic functions
- Adds Display round-trip and unknowns detection tests
- Documents feature-flag requirement and invariant caveats on the variant

The design is generic — future variadic extension functions will route through `ExtensionCall` automatically without additional PST changes.

## Issue #, if available
Issue #2380

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.