### PR TITLE
add support for variadic-is-in-range in pst

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -505,6 +505,18 @@ impl Expr {
             Expr::ResidualError => builder
                 .call_extension_fn(crate::tpe::residual::ERROR_NAME.clone(), std::iter::empty())
                 .unwrap_infallible(),
+            #[cfg(feature = "variadic-is-in-range")]
+            Expr::VariadicOp { op, left, rights } => {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "VariadicOp::to_name() always returns Some for known ops"
+                )]
+                let fn_name = op.to_name().unwrap().clone();
+                let args = std::iter::once(left)
+                    .chain(rights)
+                    .map(|e| Arc::unwrap_or_clone(e).into_expr::<B>());
+                builder.call_extension_fn(fn_name, args).unwrap_infallible()
+            }
         }
     }
 }
@@ -1029,6 +1041,62 @@ mod tests {
             let expr = parse_expr(expr_str);
             assert_expr_roundtrip(expr);
         }
+    }
+
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_variadic_is_in_range_3_args_roundtrip() {
+        let expr =
+            parse_expr(r#"ip("10.0.0.1").isInRange(ip("192.168.0.0/16"), ip("10.0.0.0/8"))"#);
+        assert_expr_roundtrip(expr);
+    }
+
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_variadic_is_in_range_4_args_roundtrip() {
+        let expr = parse_expr(
+            r#"ip("10.0.0.1").isInRange(ip("192.168.0.0/16"), ip("10.0.0.0/8"), ip("172.16.0.0/12"))"#,
+        );
+        let pst_expr: Expr = expr.clone().try_into().expect("AST->PST failed");
+        assert_matches!(&pst_expr, Expr::VariadicOp { rights, .. } => {
+            assert_eq!(rights.len(), 3);
+        });
+        assert_expr_roundtrip(expr);
+    }
+
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_variadic_is_in_range_3_args_produces_variadic_op() {
+        let expr =
+            parse_expr(r#"ip("10.0.0.1").isInRange(ip("192.168.0.0/16"), ip("10.0.0.0/8"))"#);
+        let pst_expr: Expr = expr.try_into().expect("AST->PST failed");
+        assert_matches!(&pst_expr, Expr::VariadicOp { op, left: _, rights } => {
+            assert_eq!(*op, super::super::VariadicOp::IsInRange);
+            assert_eq!(rights.len(), 2);
+        });
+    }
+
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_variadic_is_in_range_2_args_stays_binary() {
+        let expr = parse_expr(r#"ip("10.0.0.1").isInRange(ip("192.168.0.0/16"))"#);
+        let pst_expr: Expr = expr.clone().try_into().expect("AST->PST failed");
+        assert_matches!(&pst_expr, Expr::BinaryOp { op, .. } => {
+            assert_eq!(*op, BinaryOp::IsInRange);
+        });
+        assert_expr_roundtrip(expr);
+    }
+
+    #[cfg(not(feature = "variadic-is-in-range"))]
+    #[test]
+    fn test_is_in_range_3_args_fails_without_feature() {
+        let expr =
+            parse_expr(r#"ip("10.0.0.1").isInRange(ip("192.168.0.0/16"), ip("10.0.0.0/8"))"#);
+        let result: Result<Expr, _> = expr.try_into();
+        assert!(
+            result.is_err(),
+            "should fail with 3 args when feature disabled"
+        );
     }
 
     /// Test that extension methods that normalize to operators convert correctly

--- a/cedar-policy-core/src/pst/est_conversions.rs
+++ b/cedar-policy-core/src/pst/est_conversions.rs
@@ -1479,4 +1479,32 @@ mod tests {
             PstConstructionError::ExpectedTemplateWithSlots(..)
         ));
     }
+
+    #[cfg(feature = "variadic-is-in-range")]
+    #[test]
+    fn test_est_to_pst_variadic_is_in_range() {
+        use crate::pst::VariadicOp;
+
+        // isInRange(ip("10.0.0.1"), ip("192.168.0.0/16"), ip("10.0.0.0/8"))
+        let json = r#"{"isInRange": [{"ip": [{"Value": "10.0.0.1"}]}, {"ip": [{"Value": "192.168.0.0/16"}]}, {"ip": [{"Value": "10.0.0.0/8"}]}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert_matches!(&pst_expr, Expr::VariadicOp { op, left: _, rights } => {
+            assert_eq!(*op, VariadicOp::IsInRange);
+            assert_eq!(rights.len(), 2);
+        });
+        roundtrips(pst_expr);
+    }
+
+    #[cfg(not(feature = "variadic-is-in-range"))]
+    #[test]
+    fn test_est_to_pst_variadic_is_in_range_fails_without_feature() {
+        let json = r#"{"isInRange": [{"ip": [{"Value": "10.0.0.1"}]}, {"ip": [{"Value": "192.168.0.0/16"}]}, {"ip": [{"Value": "10.0.0.0/8"}]}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let result: Result<Expr, _> = est_expr.try_into();
+        assert!(
+            result.is_err(),
+            "should fail with 3 args when feature disabled"
+        );
+    }
 }

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -582,6 +582,7 @@ impl Display for BinaryOp {
 /// )  // variadic IsInRange
 #[cfg(feature = "variadic-is-in-range")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum VariadicOp {
     /// `ip.isInRange(ip1, ip2, ...)`
     IsInRange,

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -573,6 +573,52 @@ impl Display for BinaryOp {
     }
 }
 
+/// When using the `variadic-is-in-range` feature, the `isInRange` operator
+/// can be interpreted as a variadic operator.
+///
+/// ip("10.0.0.1").isInRange(
+///    ip("198.51.100.0/24"),
+///    ip("203.0.113.0/24"),
+/// )  // variadic IsInRange
+#[cfg(feature = "variadic-is-in-range")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VariadicOp {
+    /// `ip.isInRange(ip1, ip2, ...)`
+    IsInRange,
+}
+
+#[cfg(feature = "variadic-is-in-range")]
+impl VariadicOp {
+    pub(crate) fn to_name(self) -> Option<&'static ast::Name> {
+        use crate::extensions;
+        match self {
+            VariadicOp::IsInRange => Some(&extensions::ipaddr::names::IS_IN_RANGE),
+        }
+    }
+
+    /// Parse a binary operator from a function name
+    pub(crate) fn from_function_name(name: &str) -> Option<Self> {
+        match name {
+            "isInRange" => Some(VariadicOp::IsInRange),
+            _ => None,
+        }
+    }
+
+    /// Every variadic operator has a binary operator equivalent.
+    pub(crate) fn to_binop(self) -> BinaryOp {
+        match self {
+            VariadicOp::IsInRange => BinaryOp::IsInRange,
+        }
+    }
+}
+
+#[cfg(feature = "variadic-is-in-range")]
+impl Display for VariadicOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_binop())
+    }
+}
+
 /// Literal values in Cedar expressions.
 ///
 /// This enum is `#[non_exhaustive]`; match arms must include a wildcard.
@@ -746,6 +792,16 @@ pub enum Expr {
     /// evaluation (e.g., arithmetic overflow).
     #[cfg(feature = "tpe")]
     ResidualError,
+    /// A variadic extension function call (e.g., `ip.isInRange(range1, range2, ...)`).
+    #[cfg(feature = "variadic-is-in-range")]
+    VariadicOp {
+        /// The variadic operator
+        op: VariadicOp,
+        /// The first argument (receiver)
+        left: Arc<Expr>,
+        /// The remaining arguments (one or more)
+        rights: nonempty::NonEmpty<Arc<Expr>>,
+    },
 }
 
 impl Expr {
@@ -778,7 +834,16 @@ impl Expr {
         let expected = extension.arg_types().len();
         let got = args.len();
 
-        if expected != got {
+        #[cfg(feature = "variadic-is-in-range")]
+        let arity_ok = if extension.is_variadic() {
+            got >= expected
+        } else {
+            got == expected
+        };
+        #[cfg(not(feature = "variadic-is-in-range"))]
+        let arity_ok = got == expected;
+
+        if !arity_ok {
             return Err(error_body::WrongArityError::new(name.into(), expected, got).into());
         }
         Ok(match args.len() {
@@ -807,6 +872,22 @@ impl Expr {
                     right: iter.next().unwrap(),
                 }
             }
+            #[cfg(feature = "variadic-is-in-range")]
+            _ => {
+                let op = VariadicOp::from_function_name(&ast_name.to_string())
+                    .ok_or_else(|| error_body::UnknownFunctionError::new(name.clone()))?;
+                let mut iter = args.into_iter();
+                #[expect(clippy::unwrap_used, reason = "length >= 3 checked in match arm")]
+                let left = iter.next().unwrap();
+                #[expect(clippy::unwrap_used, reason = "length >= 3 checked in match arm")]
+                let first_right = iter.next().unwrap();
+                let rights = nonempty::NonEmpty {
+                    head: first_right,
+                    tail: iter.collect(),
+                };
+                Expr::VariadicOp { op, left, rights }
+            }
+            #[cfg(not(feature = "variadic-is-in-range"))]
             _ => return Err(error_body::UnknownFunctionError::new(name).into()),
         })
     }
@@ -861,6 +942,10 @@ impl Expr {
                     Some(first) => iter.fold(recurse(first), |acc, e| op(acc, recurse(e))),
                 }
             }
+            #[cfg(feature = "variadic-is-in-range")]
+            Expr::VariadicOp { left, rights, .. } => rights
+                .iter()
+                .fold(recurse(left), |acc, e| op(acc, recurse(e))),
         }
     }
 
@@ -1379,6 +1464,22 @@ mod tests {
             else_expr: Arc::new(Expr::Slot(SlotId::Principal)),
         };
         assert!(ite.has_slots());
+        // VariadicOp with slot in rights
+        #[cfg(feature = "variadic-is-in-range")]
+        {
+            let variadic_no_slot = Expr::VariadicOp {
+                op: super::VariadicOp::IsInRange,
+                left: lit.clone(),
+                rights: nonempty::nonempty![lit.clone(), lit.clone()],
+            };
+            assert!(!variadic_no_slot.has_slots());
+            let variadic_with_slot = Expr::VariadicOp {
+                op: super::VariadicOp::IsInRange,
+                left: lit.clone(),
+                rights: nonempty::nonempty![Arc::new(Expr::Slot(SlotId::Principal))],
+            };
+            assert!(variadic_with_slot.has_slots());
+        }
     }
 
     #[test]

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -574,12 +574,10 @@ impl Display for BinaryOp {
 }
 
 /// When using the `variadic-is-in-range` feature, the `isInRange` operator
-/// can be interpreted as a variadic operator.
-///
-/// ip("10.0.0.1").isInRange(
-///    ip("198.51.100.0/24"),
-///    ip("203.0.113.0/24"),
-/// )  // variadic IsInRange
+/// can be interpreted as a variadic operator:
+/// ```cedar
+/// ip("10.0.0.1").isInRange(ip("198.51.100.0/24"), ip("203.0.113.0/24"))  // variadic IsInRange
+/// ```
 #[cfg(feature = "variadic-is-in-range")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -591,10 +589,7 @@ pub enum VariadicOp {
 #[cfg(feature = "variadic-is-in-range")]
 impl VariadicOp {
     pub(crate) fn to_name(self) -> Option<&'static ast::Name> {
-        use crate::extensions;
-        match self {
-            VariadicOp::IsInRange => Some(&extensions::ipaddr::names::IS_IN_RANGE),
-        }
+        self.to_binop().to_name()
     }
 
     /// Parse a binary operator from a function name

--- a/cedar-policy-core/src/pst/mod.rs
+++ b/cedar-policy-core/src/pst/mod.rs
@@ -223,6 +223,8 @@ mod policy_set;
 pub use constraints::{ActionConstraint, EntityOrSlot, PrincipalConstraint, ResourceConstraint};
 pub use err::error_body;
 pub use err::PstConstructionError;
+#[cfg(feature = "variadic-is-in-range")]
+pub use expr::VariadicOp;
 pub use expr::{
     BinaryOp, EntityType, EntityUID, Expr, Id, Literal, Name, PatternElem, SlotId, UnaryOp, Var,
 };

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,9 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ## [Unreleased]
 
+### Added
+- Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).
+
 ### Changed
 
 - The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding.


### PR DESCRIPTION
## Description of changes

Adds support for `variadic-is-in-range` feature in the PST. 
This adds a new enum variant in `pst::Expr` under the `variadic-is-in-range` feature flag to allow representing the variadic `isInRange` operator on ip addresses. 

## Issue #, if available

#2380 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
