### PR TITLE
A optional depth-limit when parsing policies 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,7 @@ dependencies = [
  "nonempty",
  "ref-cast",
  "regex",
+ "rstest",
  "rustc-literal-escaper",
  "serde",
  "serde-wasm-bindgen",

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -83,6 +83,7 @@ similar-asserts = "2.0.0"
 cool_asserts = "2.0"
 miette = { version = "7.6.0", features = ["fancy"] }
 insta = { version = "1.47.2", features = ["json", "glob"] }
+rstest = "0.26.1"
 
 [lints]
 workspace = true

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -31,6 +31,8 @@ pub use loc::Loc;
 /// Metadata wrapper for CST Nodes
 mod node;
 pub use node::Node;
+/// Depth computation for CST expressions
+mod depth;
 /// Step one: Convert text to CST
 pub mod text_to_cst;
 /// Utility functions to unescape string literals
@@ -44,6 +46,9 @@ use std::collections::HashMap;
 use crate::ast;
 use crate::ast::RestrictedExpressionParseError;
 use crate::est;
+use crate::parser::depth::{
+    check_depth, check_policies_depth, check_policy_depth, cst_effective_depth, CstNode,
+};
 
 /// simple main function for parsing policies
 /// generates numbered ids
@@ -61,10 +66,20 @@ pub fn parse_policyset_and_also_return_policy_text(
     text: &str,
 ) -> Result<(HashMap<ast::PolicyID, Option<&str>>, ast::PolicySet), err::ParseErrors> {
     let cst = text_to_cst::parse_policies(text)?;
+    // Must call `to_policyset` first to satisfy invariant on `extract_policy_text`
     let pset = cst.to_policyset()?;
+    Ok((extract_policy_texts(text, &cst), pset))
+}
+
+/// Extract per-policy source text slices from the CST.
+/// INVARIANT: Must be called after a successful `to_policyset()` on the same CST.
+fn extract_policy_texts<'a>(
+    text: &'a str,
+    cst: &Node<Option<cst::Policies>>,
+) -> HashMap<ast::PolicyID, Option<&'a str>> {
     #[expect(
         clippy::expect_used,
-        reason = "Shouldn't be `none` since `parse_policies()` and `to_policyset()` didn't return `Err`"
+        reason = "Shouldn't be `None` since caller guarantees `to_policyset()` didn't return `Err`"
     )]
     #[expect(
         clippy::string_slice,
@@ -75,8 +90,7 @@ pub fn parse_policyset_and_also_return_policy_text(
     // generate the ids for policies and templates in `cst.to_policyset()`,
     // so every static policy and template in the policy set will have its
     // `PolicyId` present as a key in this map.
-    let texts = cst
-        .with_generated_policyids()
+    cst.with_generated_policyids()
         .expect("shouldn't be `None` since `parse_policies` and `to_policyset` didn't return `Err`")
         .map(|(id, policy)| {
             if let Some(loc) = &policy.loc {
@@ -85,8 +99,7 @@ pub fn parse_policyset_and_also_return_policy_text(
                 (id, None)
             }
         })
-        .collect::<HashMap<ast::PolicyID, Option<&str>>>();
-    Ok((texts, pset))
+        .collect()
 }
 
 /// Like `parse_policyset()`, but also returns the (lossless) ESTs -- that is,
@@ -287,6 +300,70 @@ fn validate_template_has_slots(
     } else {
         Ok(template)
     }
+}
+
+/// Like [`parse_policyset`], but rejects any policy whose expression depth
+/// exceeds `depth_limit`.
+pub fn parse_policyset_with_depth_limit(
+    text: &str,
+    depth_limit: usize,
+) -> Result<ast::PolicySet, err::ParseErrors> {
+    let cst = text_to_cst::parse_policies(text)?;
+    check_policies_depth(&cst, depth_limit)?;
+    cst.to_policyset()
+}
+
+/// Like [`parse_policyset_and_also_return_policy_text`], but rejects any
+/// policy whose expression depth exceeds `depth_limit`.
+/// INVARIANT: See [`parse_policyset_and_also_return_policy_text`]
+pub fn parse_policyset_with_depth_limit_and_also_return_policy_text(
+    text: &str,
+    depth_limit: usize,
+) -> Result<(HashMap<ast::PolicyID, Option<&str>>, ast::PolicySet), err::ParseErrors> {
+    let cst = text_to_cst::parse_policies(text)?;
+    check_policies_depth(&cst, depth_limit)?;
+    // Must call `to_policyset` first to satisfy invariant on `extract_policy_text`
+    let pset = cst.to_policyset()?;
+    Ok((extract_policy_texts(text, &cst), pset))
+}
+
+/// Like [`parse_policy`], but rejects if expression depth exceeds `depth_limit`.
+pub fn parse_policy_with_depth_limit(
+    id: Option<ast::PolicyID>,
+    text: &str,
+    depth_limit: usize,
+) -> Result<ast::StaticPolicy, err::ParseErrors> {
+    let id = id.unwrap_or_else(|| ast::PolicyID::from_string("policy0"));
+    let cst = text_to_cst::parse_policy(text)?;
+    check_policy_depth(&cst, depth_limit)?;
+    cst.to_policy(id)
+}
+
+/// Like [`parse_template`], but rejects if expression depth exceeds `depth_limit`.
+pub fn parse_template_with_depth_limit(
+    id: Option<ast::PolicyID>,
+    text: &str,
+    depth_limit: usize,
+) -> Result<ast::Template, err::ParseErrors> {
+    let id = id.unwrap_or_else(|| ast::PolicyID::from_string("policy0"));
+    let cst = text_to_cst::parse_policy(text)?;
+    check_policy_depth(&cst, depth_limit)?;
+    let template = cst.to_template(id)?;
+    validate_template_has_slots(template, cst)
+}
+
+/// Like [`parse_expr`], but rejects if expression depth exceeds `depth_limit`.
+pub fn parse_expr_with_depth_limit(
+    text: &str,
+    depth_limit: usize,
+) -> Result<ast::Expr, err::ParseErrors> {
+    let cst = text_to_cst::parse_expr(text)?;
+    check_depth(
+        cst_effective_depth(CstNode::Expr(&cst)),
+        depth_limit,
+        cst.loc(),
+    )?;
+    cst.to_expr::<ast::ExprBuilder<()>>()
 }
 
 /// Utilities used in tests in this file (and maybe other files in this crate)

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -21,6 +21,12 @@ use smol_str::SmolStr;
 // still recover other parts
 type Node<N> = super::node::Node<Option<N>>;
 
+impl<N> Default for Node<N> {
+    fn default() -> Self {
+        Node::new(None)
+    }
+}
+
 /// The set of policy statements that forms a policy set
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Policies(pub Vec<Node<Policy>>);
@@ -222,7 +228,7 @@ pub enum Relation {
     },
 }
 
-/// The operation involved in a comparision
+/// The operation involved in a comparison
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RelOp {
     /// <
@@ -404,5 +410,157 @@ impl Slot {
             (Slot::Principal, crate::ast::Var::Principal)
                 | (Slot::Resource, crate::ast::Var::Resource)
         )
+    }
+}
+
+/// Iteratively drop to prevent stack overflow on deeply nested CST expressions.
+impl Drop for Expr {
+    fn drop(&mut self) {
+        let mut work: Vec<Node<Expr>> = Vec::new();
+        collect_child_exprs(self, &mut work);
+        while let Some(mut expr_node) = work.pop() {
+            let Some(expr) = expr_node.node.as_mut() else {
+                continue;
+            };
+            // Move all children out of `expr` and on to the working stack
+            collect_child_exprs(expr, &mut work);
+            // `expr_node` now holds no recursive `Node<Expr>`, so it's safe to drop.
+        }
+    }
+}
+
+/// Extract all `Node<Expr>` children from `expr`, appending them to `out`.
+/// After this call, every nested `Node<Expr>` is `None`, so we can drop `expr`
+/// without recursion.
+///
+/// This function calls the helpers below for convenience, but the helpers must
+/// not recursively call back into this function.
+fn collect_child_exprs(expr: &mut Expr, out: &mut Vec<Node<Expr>>) {
+    let expr = match expr {
+        Expr::Expr(expr) => expr,
+        #[cfg(feature = "tolerant-ast")]
+        Expr::ErrorExpr => {
+            return;
+        }
+    };
+    match expr.expr.as_mut() {
+        ExprData::If(cond, then_expr, else_expr) => {
+            out.push(std::mem::take(cond));
+            out.push(std::mem::take(then_expr));
+            out.push(std::mem::take(else_expr));
+        }
+        ExprData::Or(or) => {
+            let Some(or) = or.node.as_mut() else { return };
+            collect_child_exprs_from_and(&mut or.initial, out);
+            for ext in &mut or.extended {
+                collect_child_exprs_from_and(ext, out);
+            }
+        }
+    }
+}
+
+fn collect_child_exprs_from_and(and_node: &mut Node<And>, out: &mut Vec<Node<Expr>>) {
+    let Some(and) = and_node.node.as_mut() else {
+        return;
+    };
+    collect_child_exprs_from_relation(&mut and.initial, out);
+    for ext in &mut and.extended {
+        collect_child_exprs_from_relation(ext, out);
+    }
+}
+
+fn collect_child_exprs_from_relation(rel_node: &mut Node<Relation>, out: &mut Vec<Node<Expr>>) {
+    let Some(rel) = rel_node.node.as_mut() else {
+        return;
+    };
+    match rel {
+        Relation::Common { initial, extended } => {
+            collect_child_exprs_from_add(initial, out);
+            for (_, ext) in extended {
+                collect_child_exprs_from_add(ext, out);
+            }
+        }
+        Relation::Has { target, field } => {
+            collect_child_exprs_from_add(target, out);
+            collect_child_exprs_from_add(field, out);
+        }
+        Relation::Like { target, pattern } => {
+            collect_child_exprs_from_add(target, out);
+            collect_child_exprs_from_add(pattern, out);
+        }
+        Relation::IsIn {
+            target,
+            entity_type,
+            in_entity,
+        } => {
+            collect_child_exprs_from_add(target, out);
+            collect_child_exprs_from_add(entity_type, out);
+            if let Some(e) = in_entity {
+                collect_child_exprs_from_add(e, out);
+            }
+        }
+    }
+}
+
+fn collect_child_exprs_from_add(add_node: &mut Node<Add>, out: &mut Vec<Node<Expr>>) {
+    let Some(add) = add_node.node.as_mut() else {
+        return;
+    };
+    collect_child_exprs_from_mult(&mut add.initial, out);
+    for (_, ext) in &mut add.extended {
+        collect_child_exprs_from_mult(ext, out);
+    }
+}
+
+fn collect_child_exprs_from_mult(mult_node: &mut Node<Mult>, out: &mut Vec<Node<Expr>>) {
+    let Some(mult) = mult_node.node.as_mut() else {
+        return;
+    };
+    collect_child_exprs_from_unary(&mut mult.initial, out);
+    for (_, ext) in &mut mult.extended {
+        collect_child_exprs_from_unary(ext, out);
+    }
+}
+
+fn collect_child_exprs_from_unary(unary_node: &mut Node<Unary>, out: &mut Vec<Node<Expr>>) {
+    let Some(unary) = unary_node.node.as_mut() else {
+        return;
+    };
+    collect_child_exprs_from_member(&mut unary.item, out);
+}
+
+fn collect_child_exprs_from_member(mem_node: &mut Node<Member>, out: &mut Vec<Node<Expr>>) {
+    let Some(mem) = mem_node.node.as_mut() else {
+        return;
+    };
+    collect_child_exprs_from_primary(&mut mem.item, out);
+    for acc_node in &mut mem.access {
+        let Some(acc) = acc_node.node.as_mut() else {
+            continue;
+        };
+        match acc {
+            MemAccess::Field(_) => {}
+            MemAccess::Call(args) => out.append(args),
+            MemAccess::Index(idx) => out.push(std::mem::take(idx)),
+        }
+    }
+}
+
+fn collect_child_exprs_from_primary(prim_node: &mut Node<Primary>, out: &mut Vec<Node<Expr>>) {
+    let Some(prim) = prim_node.node.as_mut() else {
+        return;
+    };
+    match prim {
+        Primary::Expr(e) => out.push(std::mem::take(e)),
+        Primary::EList(elts) => out.append(elts),
+        Primary::RInits(inits) => {
+            for init_node in inits {
+                if let Some(ri) = init_node.node.as_mut() {
+                    out.push(std::mem::take(&mut ri.0));
+                    out.push(std::mem::take(&mut ri.1));
+                }
+            }
+        }
+        _ => {}
     }
 }

--- a/cedar-policy-core/src/parser/depth.rs
+++ b/cedar-policy-core/src/parser/depth.rs
@@ -1,0 +1,550 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Iterative depth computation for CST expressions.
+
+use crate::parser::{err, Loc};
+
+use super::cst;
+use super::node::Node;
+
+/// Work item for the iterative depth computation.
+struct WorkItem<'a> {
+    node: CstNode<'a>,
+    depth: usize,
+}
+
+/// The different CST node types we need to visit.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum CstNode<'a> {
+    Expr(&'a Node<Option<cst::Expr>>),
+    Or(&'a Node<Option<cst::Or>>),
+    And(&'a Node<Option<cst::And>>),
+    Relation(&'a Node<Option<cst::Relation>>),
+    Add(&'a Node<Option<cst::Add>>),
+    Mult(&'a Node<Option<cst::Mult>>),
+    Unary(&'a Node<Option<cst::Unary>>),
+    Member(&'a Node<Option<cst::Member>>),
+    Primary(&'a Node<Option<cst::Primary>>),
+}
+
+impl<'a> From<&'a Node<Option<cst::Expr>>> for CstNode<'a> {
+    fn from(value: &'a Node<Option<cst::Expr>>) -> Self {
+        CstNode::Expr(value)
+    }
+}
+
+impl<'a> From<&'a Node<Option<cst::Add>>> for CstNode<'a> {
+    fn from(value: &'a Node<Option<cst::Add>>) -> Self {
+        CstNode::Add(value)
+    }
+}
+
+/// Check depth of all condition expressions in a policies CST node.
+pub(crate) fn check_policies_depth(
+    cst: &Node<Option<cst::Policies>>,
+    depth_limit: usize,
+) -> Result<(), err::ParseErrors> {
+    let Some(policies) = cst.node.as_ref() else {
+        return Ok(());
+    };
+    for policy_node in &policies.0 {
+        check_policy_depth(policy_node, depth_limit)?;
+    }
+    Ok(())
+}
+
+/// Check depth of all expressions in a CST policy
+pub(crate) fn check_policy_depth(
+    cst: &Node<Option<cst::Policy>>,
+    depth_limit: usize,
+) -> Result<(), err::ParseErrors> {
+    let Some(policy) = cst.node.as_ref() else {
+        return Ok(());
+    };
+    let policy_impl = match policy {
+        cst::Policy::Policy(p) => p,
+        #[cfg(feature = "tolerant-ast")]
+        cst::Policy::PolicyError => return Ok(()),
+    };
+    for var in &policy_impl.variables {
+        let Some(var) = var.node.as_ref() else {
+            continue;
+        };
+        if let Some(entity_type) = var.entity_type.as_ref() {
+            check_depth(
+                cst_effective_depth(entity_type.into()),
+                depth_limit,
+                entity_type.loc(),
+            )?;
+        }
+        if let Some((_, ineq)) = &var.ineq {
+            check_depth(cst_effective_depth(ineq.into()), depth_limit, ineq.loc())?;
+        }
+    }
+    let cond_exprs = policy_impl
+        .conds
+        .iter()
+        .filter_map(|cond_node| cond_node.node.as_ref()?.expr.as_ref());
+    if let Some(depth) = effective_depth_right_assoc(cond_exprs) {
+        check_depth(depth, depth_limit, cst.loc())?;
+    }
+
+    Ok(())
+}
+
+/// Return an error if `depth` exceeds `depth_limit`.
+pub(crate) fn check_depth(
+    depth: usize,
+    depth_limit: usize,
+    loc: Option<&Loc>,
+) -> Result<(), err::ParseErrors> {
+    if depth > depth_limit {
+        Err(err::ToASTError::new(
+            err::ToASTErrorKind::ExpressionTooDeep {
+                depth,
+                limit: depth_limit,
+            },
+            loc.cloned(),
+        )
+        .into())
+    } else {
+        Ok(())
+    }
+}
+
+/// Compute the maximum effective depth of a list of cst expressions that are
+/// used to build a right associated ast expression. As we progress throught the
+/// list, each element is at a progressively deeper depth due to association
+/// being explicitly imposed by nesting AST nodes.
+fn effective_depth_right_assoc<'a>(
+    exprs: impl Iterator<Item = &'a Node<Option<cst::Expr>>>,
+) -> Option<usize> {
+    exprs
+        .enumerate()
+        .map(|(assoc_depth, e)| cst_effective_depth(e.into()) + assoc_depth)
+        .max()
+}
+
+/// Iteratively compute a conservative depth bound for the depth of this CST
+/// expression.  Accounts for depth that exists directly in the  CST
+/// (parenthesized sub-expressions, list/record elements, method args) as well
+/// as nesting introduced in the conversion to an AST (expanding flat
+/// representations of chained binary operators).
+pub(crate) fn cst_effective_depth(root: CstNode<'_>) -> usize {
+    let mut stack: Vec<WorkItem<'_>> = vec![WorkItem {
+        node: root,
+        depth: 0,
+    }];
+    let mut max_depth: usize = 0;
+
+    while let Some(WorkItem { node, depth }) = stack.pop() {
+        max_depth = max_depth.max(depth);
+
+        match node {
+            CstNode::Expr(expr_node) => {
+                let Some(expr) = expr_node.node.as_ref() else {
+                    continue;
+                };
+                let expr_impl = match expr {
+                    cst::Expr::Expr(e) => e,
+                    #[cfg(feature = "tolerant-ast")]
+                    cst::Expr::ErrorExpr => continue,
+                };
+                match &*expr_impl.expr {
+                    cst::ExprData::Or(or) => {
+                        stack.push(WorkItem {
+                            node: CstNode::Or(or),
+                            depth,
+                        });
+                    }
+                    cst::ExprData::If(cond, then_expr, else_expr) => {
+                        let child_depth = depth + 1;
+                        stack.push(WorkItem {
+                            node: CstNode::Expr(cond),
+                            depth: child_depth,
+                        });
+                        stack.push(WorkItem {
+                            node: CstNode::Expr(then_expr),
+                            depth: child_depth,
+                        });
+                        stack.push(WorkItem {
+                            node: CstNode::Expr(else_expr),
+                            depth: child_depth,
+                        });
+                    }
+                }
+            }
+
+            CstNode::Or(or_node) => {
+                let Some(or) = or_node.node.as_ref() else {
+                    continue;
+                };
+                push_left_assoc_exprs(
+                    &mut stack,
+                    depth,
+                    CstNode::And(&or.initial),
+                    or.extended.iter().map(CstNode::And),
+                    or.extended.len(),
+                );
+            }
+
+            CstNode::And(and_node) => {
+                let Some(and) = and_node.node.as_ref() else {
+                    continue;
+                };
+                push_left_assoc_exprs(
+                    &mut stack,
+                    depth,
+                    CstNode::Relation(&and.initial),
+                    and.extended.iter().map(CstNode::Relation),
+                    and.extended.len(),
+                );
+            }
+
+            CstNode::Relation(rel_node) => {
+                let Some(rel) = rel_node.node.as_ref() else {
+                    continue;
+                };
+                match rel {
+                    cst::Relation::Common { initial, extended } => {
+                        push_left_assoc_exprs(
+                            &mut stack,
+                            depth,
+                            CstNode::Add(initial),
+                            extended.iter().map(|(_, ext)| CstNode::Add(ext)),
+                            extended.len(),
+                        );
+                    }
+                    cst::Relation::Has { target, field } => {
+                        let child_depth = depth + 1;
+                        stack.push(WorkItem {
+                            node: CstNode::Add(target),
+                            depth: child_depth,
+                        });
+                        stack.push(WorkItem {
+                            node: CstNode::Add(field),
+                            depth: child_depth,
+                        });
+                    }
+                    cst::Relation::Like { target, pattern } => {
+                        let child_depth = depth + 1;
+                        stack.push(WorkItem {
+                            node: CstNode::Add(target),
+                            depth: child_depth,
+                        });
+                        stack.push(WorkItem {
+                            node: CstNode::Add(pattern),
+                            depth: child_depth,
+                        });
+                    }
+                    cst::Relation::IsIn {
+                        target,
+                        entity_type,
+                        in_entity,
+                    } => {
+                        let child_depth = depth + 2;
+                        stack.push(WorkItem {
+                            node: CstNode::Add(target),
+                            depth: child_depth,
+                        });
+                        stack.push(WorkItem {
+                            node: CstNode::Add(entity_type),
+                            depth: child_depth,
+                        });
+                        if let Some(in_e) = in_entity {
+                            stack.push(WorkItem {
+                                node: CstNode::Add(in_e),
+                                depth: child_depth,
+                            });
+                        }
+                    }
+                }
+            }
+
+            CstNode::Add(add_node) => {
+                let Some(add) = add_node.node.as_ref() else {
+                    continue;
+                };
+                push_left_assoc_exprs(
+                    &mut stack,
+                    depth,
+                    CstNode::Mult(&add.initial),
+                    add.extended.iter().map(|(_, ext)| CstNode::Mult(ext)),
+                    add.extended.len(),
+                );
+            }
+
+            CstNode::Mult(mult_node) => {
+                let Some(mult) = mult_node.node.as_ref() else {
+                    continue;
+                };
+                push_left_assoc_exprs(
+                    &mut stack,
+                    depth,
+                    CstNode::Unary(&mult.initial),
+                    mult.extended.iter().map(|(_, ext)| CstNode::Unary(ext)),
+                    mult.extended.len(),
+                );
+            }
+
+            CstNode::Unary(unary_node) => {
+                let Some(unary) = unary_node.node.as_ref() else {
+                    continue;
+                };
+                let neg_depth = match unary.op {
+                    Some(cst::NegOp::Bang(n)) | Some(cst::NegOp::Dash(n)) => n as usize,
+                    Some(cst::NegOp::OverBang) | Some(cst::NegOp::OverDash) => 0,
+                    None => 0,
+                };
+                stack.push(WorkItem {
+                    node: CstNode::Member(&unary.item),
+                    depth: depth + neg_depth,
+                });
+            }
+
+            CstNode::Member(mem_node) => {
+                let Some(mem) = mem_node.node.as_ref() else {
+                    continue;
+                };
+                let access_depth = mem.access.len();
+                let item_depth = depth + access_depth;
+                stack.push(WorkItem {
+                    node: CstNode::Primary(&mem.item),
+                    depth: item_depth,
+                });
+                for (i, acc_node) in mem.access.iter().enumerate() {
+                    let Some(acc) = acc_node.node.as_ref() else {
+                        continue;
+                    };
+                    // Accounting for left-association of MemAccess elements
+                    let arg_depth = depth + access_depth - i;
+                    match acc {
+                        cst::MemAccess::Field(_) => {}
+                        cst::MemAccess::Call(args) => {
+                            for arg in args {
+                                stack.push(WorkItem {
+                                    node: CstNode::Expr(arg),
+                                    depth: arg_depth,
+                                });
+                            }
+                        }
+                        cst::MemAccess::Index(idx) => {
+                            stack.push(WorkItem {
+                                node: CstNode::Expr(idx),
+                                depth: arg_depth,
+                            });
+                        }
+                    }
+                }
+            }
+
+            CstNode::Primary(prim_node) => {
+                let Some(prim) = prim_node.node.as_ref() else {
+                    continue;
+                };
+                match prim {
+                    cst::Primary::Literal(_)
+                    | cst::Primary::Ref(_)
+                    | cst::Primary::Name(_)
+                    | cst::Primary::Slot(_) => {}
+                    cst::Primary::Expr(inner) => {
+                        stack.push(WorkItem {
+                            node: CstNode::Expr(inner),
+                            depth: depth + 1,
+                        });
+                    }
+                    cst::Primary::EList(elts) => {
+                        let child_depth = depth + 1;
+                        for elt in elts {
+                            stack.push(WorkItem {
+                                node: CstNode::Expr(elt),
+                                depth: child_depth,
+                            });
+                        }
+                    }
+                    cst::Primary::RInits(inits) => {
+                        let child_depth = depth + 1;
+                        for init in inits {
+                            let Some(rec_init) = init.node.as_ref() else {
+                                continue;
+                            };
+                            stack.push(WorkItem {
+                                node: CstNode::Expr(&rec_init.0),
+                                depth: child_depth,
+                            });
+                            stack.push(WorkItem {
+                                node: CstNode::Expr(&rec_init.1),
+                                depth: child_depth,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    max_depth
+}
+
+/// Push work items for a left-associative nary operator. The initial element
+/// sits at the deepest point of the fold; each extended element is a right
+/// child at its fold level.
+fn push_left_assoc_exprs<'a>(
+    stack: &mut Vec<WorkItem<'a>>,
+    depth: usize,
+    initial: CstNode<'a>,
+    extended: impl Iterator<Item = CstNode<'a>>,
+    extended_len: usize,
+) {
+    stack.push(WorkItem {
+        node: initial,
+        depth: depth + extended_len,
+    });
+    for (i, ext) in extended.enumerate() {
+        stack.push(WorkItem {
+            node: ext,
+            depth: depth + i + 1,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::text_to_cst;
+    use rstest::rstest;
+
+    fn depth_of(src: &str) -> usize {
+        let cst = text_to_cst::parse_expr(src).expect("parse failed");
+        cst_effective_depth(CstNode::Expr(&cst))
+    }
+
+    #[rstest]
+    // Literals
+    #[case("1", 0)]
+    #[case("true", 0)]
+    #[case("\"hello\"", 0)]
+    #[case("principal", 0)]
+    // Binary ops
+    #[case("1 + 2", 1)]
+    #[case("1 * 2", 1)]
+    #[case("1 - 2", 1)]
+    // Left-fold amplification
+    #[case("true || false || true", 2)]
+    #[case("true && false && true", 2)]
+    #[case("1 + 2 + 3 + 4", 3)]
+    #[case("1 * 2 * 3 * 4", 3)]
+    // Parens add CST recursion depth
+    #[case("((1))", 2)]
+    #[case("(((1)))", 3)]
+    #[case("(1 + 2) + 3", 3)]
+    #[case("1 + 2 + 3 + (5 * 5)", 5)]
+    // If-then-else
+    #[case("if true then 1 else 2", 1)]
+    #[case("if if true then true else false then 1 else 2", 2)]
+    // Member access chains
+    #[case("principal.a", 1)]
+    #[case("principal.a.b.c", 3)]
+    #[case(r#"principal["a"]["b"]["c"]"#, 3)]
+    #[case(r#"principal["a"].b["c"].d"#, 4)]
+    // Method calls
+    #[case("[1,2,3].contains(1)", 3)]
+    #[case("principal.a.contains(1)", 3)]
+    // Negation
+    #[case("!true", 1)]
+    #[case("!!true", 2)]
+    #[case("-1", 1)]
+    #[case("--1", 2)]
+    // Set and record literals
+    #[case("[1, 2, 3]", 1)]
+    #[case("[[1]]", 2)]
+    #[case("{\"a\": 1}", 1)]
+    #[case("{\"a\": {\"b\": 1}}", 2)]
+    // Relation operators
+    #[case("1 < 2", 1)]
+    #[case("1 == 2", 1)]
+    // `has` with extended path
+    #[case("principal has foo", 1)]
+    #[case("principal has foo.bar", 2)]
+    #[case("principal has foo.bar.baz", 3)]
+    // `is` and `is in`
+    #[case("principal is User", 2)]
+    #[case("principal is User in Group::\"admin\"", 2)]
+    // `like`
+    #[case("\"abc\" like \"a*\"", 1)]
+    // Combined depth
+    #[case("if 1 + 2 + 3 > 4 then [1,2].contains(3) else principal.a.b", 4)]
+    fn expr_depth(#[case] src: &str, #[case] expected: usize) {
+        assert_eq!(depth_of(src), expected, "depth mismatch for: {src:?}");
+    }
+
+    fn policy_depth_of(src: &str) -> Option<usize> {
+        let cst = text_to_cst::parse_policy(src).ok()?;
+        let policy = cst.node.as_ref()?;
+        let policy_impl = match policy {
+            cst::Policy::Policy(p) => p,
+            #[cfg(feature = "tolerant-ast")]
+            cst::Policy::PolicyError => return None,
+        };
+        let cond_exprs: Vec<_> = policy_impl
+            .conds
+            .iter()
+            .filter_map(|cond_node| cond_node.node.as_ref()?.expr.as_ref())
+            .collect();
+        effective_depth_right_assoc(cond_exprs.into_iter())
+    }
+
+    #[rstest]
+    #[case("permit(principal, action, resource) when { true };", Some(0))]
+    #[case(
+        "permit(principal, action, resource) when { true } when { true };",
+        Some(1)
+    )]
+    #[case(
+        "permit(principal, action, resource) when { true } when { true } when { true };",
+        Some(2)
+    )]
+    #[case(
+        "permit(principal, action, resource) when { true } when { 1 + 2 + 3 };",
+        Some(3)
+    )]
+    #[case("permit(principal, action, resource);", None)]
+    fn policy_cond_depth(#[case] src: &str, #[case] expected: Option<usize>) {
+        assert_eq!(
+            policy_depth_of(src),
+            expected,
+            "depth mismatch for: {src:?}"
+        );
+    }
+
+    #[rstest]
+    #[case("permit(principal, action, resource) when { 1 + 2 }; forbid(principal, action, resource) when { true };", 1, true)]
+    #[case("permit(principal, action, resource) when { true }; forbid(principal, action, resource) when { 1 + 2 + 3 };", 1, false)]
+    fn check_policyset_depth_limit(
+        #[case] src: &str,
+        #[case] limit: usize,
+        #[case] should_pass: bool,
+    ) {
+        use crate::parser::parse_policyset_with_depth_limit;
+        let result = parse_policyset_with_depth_limit(src, limit);
+        assert_eq!(
+            result.is_ok(),
+            should_pass,
+            "for policyset: {src:?} with limit {limit}"
+        );
+    }
+}

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -413,6 +413,14 @@ pub enum ToASTErrorKind {
     #[cfg(feature = "tolerant-ast")]
     #[error("Trying to convert AST error node")]
     ASTErrorNode,
+    /// Returned when an expression exceeds the configured depth limit
+    #[error("expression depth {depth} exceeds the configured limit of {limit}")]
+    ExpressionTooDeep {
+        /// Actual depth of the expression
+        depth: usize,
+        /// Configured limit
+        limit: usize,
+    },
 }
 
 fn invalid_is_help(lhs: &str, rhs: &str) -> String {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,9 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Added
 - Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).
 - Functions for inspecting TPE policy evaluation results (`TpeResponse::reason` and iterators for true/false/error/residual permit/forbid policy IDs).
+- Depth limited parsing functions for `PolicySet`, `Template`, `Policy`, and `Expression`. These allow configuring a depth limit
+  for policies, avoiding stack overflows when parsing policies of unknown depth, assuming that the limit is set low enough to
+  avoid exhausting stack space in your environment. (#2383)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2545,40 +2545,78 @@ impl FromStr for PolicySet {
     /// See [`Policy`] for more.
     fn from_str(policies: &str) -> Result<Self, Self::Err> {
         let (texts, pset) = parser::parse_policyset_and_also_return_policy_text(policies)?;
-        #[expect(clippy::expect_used, reason = "By the invariant on `parse_policyset_and_also_return_policy_text(policies)`, every `PolicyId` in `pset.policies()` occurs as a key in `text`.")]
-        let policies = pset.policies().map(|p|
-            (
-                PolicyId::new(p.id().clone()),
-                Policy { lossless: LosslessPolicy::policy_or_template_text(*texts.get(p.id()).expect("internal invariant violation: policy id exists in asts but not texts")), ast: p.clone() }
-            )
-        ).collect();
-        #[expect(
-            clippy::expect_used,
-            reason = "By the invariant on `parse_policyset_and_also_return_policy_text(policies)`, every `PolicyId` in `pset.templates()` also occurs as a key in `text`."
-        )]
+        Ok(PolicySet::from_parsed_with_text(texts, pset))
+    }
+}
+
+impl PolicySet {
+    /// Create a policy set as in [`PolicySet::from_str`], but rejecting any
+    /// policy whose expression depth exceeds `depth_limit`.
+    ///
+    /// This function can be used to limit the maximum recursion depth, avoiding
+    /// the stackoverflows when parsing policies with unknown depth.
+    pub fn from_str_with_depth_limit(
+        policies: &str,
+        depth_limit: usize,
+    ) -> Result<Self, ParseErrors> {
+        let (texts, pset) = parser::parse_policyset_with_depth_limit_and_also_return_policy_text(
+            policies,
+            depth_limit,
+        )?;
+        Ok(Self::from_parsed_with_text(texts, pset))
+    }
+
+    /// Build a [`PolicySet`] from a parsed AST and the per-policy source text
+    /// map. This preserves lossless representations for each policy/template.
+    ///
+    /// INVARIANT: Every policy and template id in `pset` must be present as a key into `texts`.
+    /// This is satisfied by `parser::parse_policyset_and_also_return_policy_text` and
+    /// `parser::parse_policyset_with_depth_limit_and_also_return_policy_text`.
+    fn from_parsed_with_text(
+        texts: HashMap<ast::PolicyID, Option<&str>>,
+        pset: ast::PolicySet,
+    ) -> Self {
+        let policies = pset
+            .policies()
+            .map(|p| {
+                (
+                    PolicyId::new(p.id().clone()),
+                    Policy {
+                        lossless: LosslessPolicy::policy_or_template_text(
+                            #[expect(clippy::expect_used, reason = "By policy id invariant")]
+                            *texts.get(p.id()).expect(
+                                "internal invariant violation: policy id exists in asts but not texts",
+                            ),
+                        ),
+                        ast: p.clone(),
+                    },
+                )
+            })
+            .collect();
         let templates = pset
             .templates()
             .map(|t| {
                 (
                     PolicyId::new(t.id().clone()),
                     Template {
-                        lossless: LosslessTemplate::from_text(*texts.get(t.id()).expect(
-                            "internal invariant violation: template id exists in asts but not ests",
-                        )),
+                        lossless: LosslessTemplate::from_text(
+                            #[expect(clippy::expect_used, reason = "By template id invariant")]
+                            *texts.get(t.id()).expect(
+                                "internal invariant violation: template id exists in asts but not texts",
+                            ),
+                        ),
                         ast: t.clone(),
                     },
                 )
             })
             .collect();
-        Ok(Self {
+        Self {
             ast: pset,
             policies,
             templates,
-        })
+        }
     }
-}
 
-impl PolicySet {
     /// Build the policy set AST from the EST
     fn from_est(est: &est::PolicySet) -> Result<Self, PolicySetError> {
         let ast: ast::PolicySet = est.clone().try_into()?;
@@ -3528,6 +3566,21 @@ impl Template {
         })
     }
 
+    /// Like [`Template::parse`], but rejects the template if its expression
+    /// depth exceeds `depth_limit`.
+    pub fn parse_with_depth_limit(
+        id: Option<PolicyId>,
+        src: impl AsRef<str>,
+        depth_limit: usize,
+    ) -> Result<Self, ParseErrors> {
+        let ast =
+            parser::parse_template_with_depth_limit(id.map(Into::into), src.as_ref(), depth_limit)?;
+        Ok(Self {
+            ast,
+            lossless: LosslessTemplate::from_text(Some(src.as_ref())),
+        })
+    }
+
     /// Get the `PolicyId` of this `Template`
     pub fn id(&self) -> &PolicyId {
         PolicyId::ref_cast(self.ast.id())
@@ -4058,6 +4111,25 @@ impl Policy {
     /// policies
     pub fn parse(id: Option<PolicyId>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
         let inline_ast = parser::parse_policy(id.map(Into::into), policy_src.as_ref())?;
+        let (_, ast) = ast::Template::link_static_policy(inline_ast);
+        Ok(Self {
+            ast,
+            lossless: LosslessPolicy::policy_or_template_text(Some(policy_src.as_ref())),
+        })
+    }
+
+    /// Like [`Policy::parse`], but rejects the policy if its expression depth
+    /// exceeds `depth_limit`.
+    pub fn parse_with_depth_limit(
+        id: Option<PolicyId>,
+        policy_src: impl AsRef<str>,
+        depth_limit: usize,
+    ) -> Result<Self, ParseErrors> {
+        let inline_ast = parser::parse_policy_with_depth_limit(
+            id.map(Into::into),
+            policy_src.as_ref(),
+            depth_limit,
+        )?;
         let (_, ast) = ast::Template::link_static_policy(inline_ast);
         Ok(Self {
             ast,
@@ -4708,6 +4780,16 @@ impl Expression {
     /// This function is only intended to be used internally.
     pub(crate) fn into_inner(self) -> ast::Expr {
         self.0
+    }
+}
+
+impl Expression {
+    /// Parse an [`Expression`] from Cedar syntax, rejecting if its depth
+    /// exceeds `depth_limit`.
+    pub fn parse_with_depth_limit(src: &str, depth_limit: usize) -> Result<Self, ParseErrors> {
+        parser::parse_expr_with_depth_limit(src, depth_limit)
+            .map(Expression)
+            .map_err(Into::into)
     }
 }
 

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -12272,3 +12272,133 @@ mod tolerant_ast_tests {
         let _ = policy.action_constraint();
     }
 }
+
+#[cfg(test)]
+mod test_depth_limit {
+    use super::*;
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
+    use cool_asserts::assert_matches;
+    use miette::Report;
+
+    #[test]
+    fn expression_parse_with_depth_limit() {
+        let src = "1 + 2";
+        assert!(Expression::parse_with_depth_limit(src, 1).is_ok());
+        assert_matches!(Expression::parse_with_depth_limit(src, 0), Err(e) => {
+            expect_err(
+                src,
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    "expression depth 1 exceeds the configured limit of 0",
+                )
+                .exactly_one_underline("1 + 2")
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn policy_parse_with_depth_limit() {
+        let src = "permit(principal, action, resource) when { 1 + 2 };";
+        assert!(Policy::parse_with_depth_limit(None, src, 1).is_ok());
+        assert_matches!(Policy::parse_with_depth_limit(None, src, 0), Err(e) => {
+            expect_err(
+                src,
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    "expression depth 1 exceeds the configured limit of 0",
+                )
+                .exactly_one_underline(src)
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn template_parse_with_depth_limit() {
+        let src = "permit(principal == ?principal, action, resource) when { 1 + 2 };";
+        assert!(Template::parse_with_depth_limit(None, src, 1).is_ok());
+        assert_matches!(Template::parse_with_depth_limit(None, src, 0), Err(e) => {
+            expect_err(
+                src,
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    "expression depth 1 exceeds the configured limit of 0",
+                )
+                .exactly_one_underline(src)
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn policyset_from_str_with_depth_limit() {
+        let src = "permit(principal, action, resource) when { 1 + 2 }; forbid(principal, action, resource);";
+        assert!(PolicySet::from_str_with_depth_limit(src, 1).is_ok());
+        assert_matches!(PolicySet::from_str_with_depth_limit(src, 0), Err(e) => {
+            expect_err(
+                src,
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    "expression depth 1 exceeds the configured limit of 0",
+                )
+                .exactly_one_underline("permit(principal, action, resource) when { 1 + 2 };")
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn very_deep_cst_no_stack_overflow() {
+        let depth = 10000;
+        let src = "(".repeat(depth) + "1" + &")".repeat(depth);
+        assert_matches!(Expression::parse_with_depth_limit(&src, depth - 1), Err(e) => {
+            expect_err(
+                src.as_str(),
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    &format!("expression depth {depth} exceeds the configured limit of {}", depth - 1),
+                )
+                .exactly_one_underline(&src)
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn very_deep_ast_no_stack_overflow() {
+        let depth = 10000;
+        let src = (0..=depth)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(" + ");
+        assert_matches!(Expression::parse_with_depth_limit(&src, depth - 1), Err(e) => {
+            expect_err(
+                src.as_str(),
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    &format!("expression depth {depth} exceeds the configured limit of {}", depth - 1),
+                )
+                .exactly_one_underline(&src)
+                .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn very_deep_ast_and_cst_no_stack_overflow() {
+        let depth = 10000;
+        let src = "[".repeat(depth) + "1" + &"]".repeat(depth);
+        assert_matches!(Expression::parse_with_depth_limit(&src, depth - 1), Err(e) => {
+            expect_err(
+                src.as_str(),
+                &Report::new(e),
+                &ExpectedErrorMessageBuilder::error(
+                    &format!("expression depth {depth} exceeds the configured limit of {}", depth - 1),
+                )
+                .exactly_one_underline(&src)
+                .build(),
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Description of changes

Adds new functions to the public API to configure an optional depth limit for policies when parsing. These function will return an error result for any policy that exceeds the limit, avoiding any possible stack overflow.

As an additional complication, I also had to add a `Drop` implementation for the CST so that we would not stackoverflow when dropping that structure after returning an error. The drop impl is from Claude. IIUC, Rust will always full free the structure regardless of what we do in our Drop, so there's no risk of memory leaks. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
