### PR TITLE
Cleanup common type resolution code

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -148,11 +148,11 @@ impl LocatedType {
 
     /// New located type with source location. If the `extend-schema` feature is
     /// not enabled, the `loc` is not stored.
-    pub fn new_with_loc(ty: Type, _loc: &Option<Loc>) -> Self {
+    pub fn new_with_loc(ty: Type, _loc: Option<&Loc>) -> Self {
         Self {
             ty,
             #[cfg(feature = "extended-schema")]
-            loc: _loc.clone(),
+            loc: _loc.cloned(),
         }
     }
 
@@ -733,16 +733,12 @@ impl ValidatorSchema {
                         tags,
                     } => {
                         let (attributes, open_attributes) = {
-                            let attr_loc = attributes.0.loc().cloned();
-                            let unresolved = try_jsonschema_type_into_validator_type(
+                            let attrs_ty = try_jsonschema_type_into_validator_type(
                                 attributes.0,
                                 extensions,
-                                attr_loc,
+                                &common_types,
                             )?;
-                            Self::record_attributes_or_none(
-                                unresolved.resolve_common_type_refs(&common_types)?,
-                            )
-                            .ok_or_else(|| {
+                            Self::record_attributes_or_none(attrs_ty).ok_or_else(|| {
                                 ContextOrShapeNotRecordError {
                                     ctx_or_shape: ContextOrShape::EntityTypeShape(name.clone()),
                                 }
@@ -750,11 +746,12 @@ impl ValidatorSchema {
                         };
                         let tags = tags
                             .map(|tags| {
-                                let tags_loc = tags.loc().cloned();
-                                try_jsonschema_type_into_validator_type(tags, extensions, tags_loc)
+                                try_jsonschema_type_into_validator_type(
+                                    tags,
+                                    extensions,
+                                    &common_types,
+                                )
                             })
-                            .transpose()?
-                            .map(|unresolved| unresolved.resolve_common_type_refs(&common_types))
                             .transpose()?;
 
                         Ok((
@@ -787,17 +784,15 @@ impl ValidatorSchema {
             .map(|(name, action)| -> Result<_> {
                 let descendants = action_children.remove(&name).unwrap_or_default();
                 let (context, open_context_attributes) = {
-                    let context_loc = action.context.loc().cloned();
-                    let unresolved = try_jsonschema_type_into_validator_type(
+                    let context_ty = try_jsonschema_type_into_validator_type(
                         action.context,
                         extensions,
-                        context_loc,
+                        &common_types,
                     )?;
-                    Self::record_attributes_or_none(
-                        unresolved.resolve_common_type_refs(&common_types)?,
-                    )
-                    .ok_or_else(|| ContextOrShapeNotRecordError {
-                        ctx_or_shape: ContextOrShape::ActionContext(name.clone()),
+                    Self::record_attributes_or_none(context_ty).ok_or_else(|| {
+                        ContextOrShapeNotRecordError {
+                            ctx_or_shape: ContextOrShape::ActionContext(name.clone()),
+                        }
                     })?
                 };
                 Ok((
@@ -1569,13 +1564,11 @@ impl<'a> CommonTypeResolver<'a> {
             let ty = self.defs.get(name).unwrap();
             let substituted_ty = Self::resolve_type(&resolve_table, ty.clone())?;
             resolve_table.insert(name, substituted_ty.clone());
-            let substituted_ty_loc = substituted_ty.loc().cloned();
             let validator_type = try_jsonschema_type_into_validator_type(
                 substituted_ty,
                 extensions,
-                substituted_ty_loc,
+                &HashMap::new(),
             )?;
-            let validator_type = validator_type.resolve_common_type_refs(&HashMap::new())?;
 
             tys.insert(name, validator_type);
         }
@@ -2270,11 +2263,12 @@ pub(crate) mod test {
             InternalName::from_str("Bar").unwrap(),
         ]);
         let schema_ty = schema_ty.fully_qualify_type_references(&all_defs).unwrap();
-        let ty: LocatedType =
-            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available(), None)
-                .expect("Error converting schema type to type.")
-                .resolve_common_type_refs(&HashMap::new())
-                .unwrap();
+        let ty: LocatedType = try_jsonschema_type_into_validator_type(
+            schema_ty,
+            Extensions::all_available(),
+            &HashMap::new(),
+        )
+        .expect("Error converting schema type to type.");
         assert_eq!(ty.ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
 
@@ -2299,11 +2293,12 @@ pub(crate) mod test {
             InternalName::from_str("Foo").unwrap(),
         ]);
         let schema_ty = schema_ty.fully_qualify_type_references(&all_defs).unwrap();
-        let ty: LocatedType =
-            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available(), None)
-                .expect("Error converting schema type to type.")
-                .resolve_common_type_refs(&HashMap::new())
-                .unwrap();
+        let ty: LocatedType = try_jsonschema_type_into_validator_type(
+            schema_ty,
+            Extensions::all_available(),
+            &HashMap::new(),
+        )
+        .expect("Error converting schema type to type.");
         assert_eq!(ty.ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
 
@@ -2333,11 +2328,12 @@ pub(crate) mod test {
         let schema_ty = schema_ty.conditionally_qualify_type_references(None);
         let all_defs = AllDefs::from_entity_defs([InternalName::from_str("Foo").unwrap()]);
         let schema_ty = schema_ty.fully_qualify_type_references(&all_defs).unwrap();
-        let ty: LocatedType =
-            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available(), None)
-                .expect("Error converting schema type to type.")
-                .resolve_common_type_refs(&HashMap::new())
-                .unwrap();
+        let ty: LocatedType = try_jsonschema_type_into_validator_type(
+            schema_ty,
+            Extensions::all_available(),
+            &HashMap::new(),
+        )
+        .expect("Error converting schema type to type.");
         assert_eq!(ty.ty, Type::closed_record_with_attributes(None));
     }
 

--- a/cedar-policy-core/src/validator/schema/namespace_def.rs
+++ b/cedar-policy-core/src/validator/schema/namespace_def.rs
@@ -953,18 +953,13 @@ fn parse_record_attributes(
     let attrs = attrs
         .into_iter()
         .map(|(attr, ty)| -> crate::validator::err::Result<_> {
-            #[cfg(feature = "extended-schema")]
-            let loc = ty.loc;
-            #[cfg(not(feature = "extended-schema"))]
-            let loc = None;
-
             let attr_ty = try_jsonschema_type_into_validator_type(
                 ty.ty.clone(),
                 extensions,
                 common_type_defs,
             )?;
             #[cfg(feature = "extended-schema")]
-            let attr_ty = AttributeType::new_with_loc(attr_ty.ty.into(), ty.required, loc);
+            let attr_ty = AttributeType::new_with_loc(attr_ty.ty.into(), ty.required, ty.loc);
             #[cfg(not(feature = "extended-schema"))]
             let attr_ty = AttributeType::new(attr_ty.ty.into(), ty.required);
             Ok((attr, attr_ty))

--- a/cedar-policy-core/src/validator/schema/namespace_def.rs
+++ b/cedar-policy-core/src/validator/schema/namespace_def.rs
@@ -781,93 +781,6 @@ impl ActionFragment<ConditionalName, ConditionalName> {
     }
 }
 
-type ResolveFunc<T> =
-    dyn FnOnce(&HashMap<&InternalName, LocatedType>) -> crate::validator::err::Result<T>;
-/// Represent a type that might be defined in terms of some common-type
-/// definitions which are not necessarily available in the current namespace.
-pub(crate) enum WithUnresolvedCommonTypeRefs<T> {
-    WithUnresolved(Box<ResolveFunc<T>>, Option<Loc>),
-    WithoutUnresolved(T, Option<Loc>),
-}
-
-impl<T: 'static> WithUnresolvedCommonTypeRefs<T> {
-    pub fn new(
-        f: impl FnOnce(&HashMap<&InternalName, LocatedType>) -> crate::validator::err::Result<T>
-            + 'static,
-        loc: Option<Loc>,
-    ) -> Self {
-        Self::WithUnresolved(Box::new(f), loc)
-    }
-
-    #[cfg(feature = "extended-schema")]
-    pub fn loc(&self) -> Option<&Loc> {
-        match self {
-            WithUnresolvedCommonTypeRefs::WithUnresolved(_, loc) => loc.as_ref(),
-            WithUnresolvedCommonTypeRefs::WithoutUnresolved(_, loc) => loc.as_ref(),
-        }
-    }
-
-    pub fn map<U: 'static>(
-        self,
-        f: impl FnOnce(T) -> U + 'static,
-    ) -> WithUnresolvedCommonTypeRefs<U> {
-        match self {
-            Self::WithUnresolved(_, ref loc) => {
-                let loc = loc.clone();
-                WithUnresolvedCommonTypeRefs::new(
-                    |common_type_defs| self.resolve_common_type_refs(common_type_defs).map(f),
-                    loc,
-                )
-            }
-            Self::WithoutUnresolved(v, loc) => {
-                WithUnresolvedCommonTypeRefs::WithoutUnresolved(f(v), loc)
-            }
-        }
-    }
-
-    /// Resolve references to common types by inlining their definitions from
-    /// the given `HashMap`.
-    ///
-    /// Be warned that `common_type_defs` should contain all definitions, from
-    /// all schema fragments.
-    /// If `self` references any type not in `common_type_defs`, this will
-    /// return a `TypeNotDefinedError`.
-    pub fn resolve_common_type_refs(
-        self,
-        common_type_defs: &HashMap<&InternalName, LocatedType>,
-    ) -> crate::validator::err::Result<T> {
-        match self {
-            WithUnresolvedCommonTypeRefs::WithUnresolved(f, _) => f(common_type_defs),
-            WithUnresolvedCommonTypeRefs::WithoutUnresolved(v, _) => Ok(v),
-        }
-    }
-}
-
-impl<T: 'static> From<T> for WithUnresolvedCommonTypeRefs<T> {
-    fn from(value: T) -> Self {
-        Self::WithoutUnresolved(value, None)
-    }
-}
-
-impl From<Type> for WithUnresolvedCommonTypeRefs<LocatedType> {
-    fn from(value: Type) -> Self {
-        Self::WithoutUnresolved(LocatedType::new(value), None)
-    }
-}
-
-impl<T: std::fmt::Debug> std::fmt::Debug for WithUnresolvedCommonTypeRefs<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WithUnresolvedCommonTypeRefs::WithUnresolved(_, _) => {
-                f.debug_tuple("WithUnresolved").finish()
-            }
-            WithUnresolvedCommonTypeRefs::WithoutUnresolved(v, _) => {
-                f.debug_tuple("WithoutUnresolved").field(v).finish()
-            }
-        }
-    }
-}
-
 impl TryInto<ValidatorNamespaceDef<ConditionalName, ConditionalName>>
     for json_schema::NamespaceDefinition<RawName>
 {
@@ -890,60 +803,63 @@ impl TryInto<ValidatorNamespaceDef<ConditionalName, ConditionalName>>
 pub(crate) fn try_jsonschema_type_into_validator_type(
     schema_ty: json_schema::Type<InternalName>,
     extensions: &Extensions<'_>,
-    loc: Option<Loc>,
-) -> crate::validator::err::Result<WithUnresolvedCommonTypeRefs<LocatedType>> {
+    common_type_defs: &HashMap<&InternalName, LocatedType>,
+) -> crate::validator::err::Result<LocatedType> {
     match schema_ty {
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::String,
-            ..
-        } => Ok(WithUnresolvedCommonTypeRefs::WithoutUnresolved(
-            LocatedType::new_with_loc(Type::primitive_string(), &loc),
             loc,
+        } => Ok(LocatedType::new_with_loc(
+            Type::primitive_string(),
+            loc.as_ref(),
         )),
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Long,
-            ..
-        } => Ok(WithUnresolvedCommonTypeRefs::WithoutUnresolved(
-            LocatedType::new_with_loc(Type::primitive_long(), &loc),
             loc,
+        } => Ok(LocatedType::new_with_loc(
+            Type::primitive_long(),
+            loc.as_ref(),
         )),
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Boolean,
-            ..
-        } => Ok(WithUnresolvedCommonTypeRefs::WithoutUnresolved(
-            LocatedType::new_with_loc(Type::primitive_boolean(), &loc),
             loc,
+        } => Ok(LocatedType::new_with_loc(
+            Type::primitive_boolean(),
+            loc.as_ref(),
         )),
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Set { element },
             ..
-        } => Ok(
-            try_jsonschema_type_into_validator_type(*element, extensions, loc)?.map(|vt| {
-                let (vt_ty, vt_loc) = vt.into_type_and_loc();
-                LocatedType::new_with_loc(Type::set(vt_ty.into()), &vt_loc)
-            }),
-        ),
+        } => {
+            let vt =
+                try_jsonschema_type_into_validator_type(*element, extensions, common_type_defs)?;
+            let (vt_ty, vt_loc) = vt.into_type_and_loc();
+            Ok(LocatedType::new_with_loc(
+                Type::set(vt_ty.into()),
+                vt_loc.as_ref(),
+            ))
+        }
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Record(rty),
-            ..
-        } => try_record_type_into_validator_type(rty, extensions, loc),
+            loc,
+        } => try_record_type_into_validator_type(rty, extensions, loc.as_ref(), common_type_defs),
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Entity { name },
-            ..
-        } => Ok(WithUnresolvedCommonTypeRefs::WithoutUnresolved(
-            LocatedType::new_with_loc(
-                Type::named_entity_reference(internal_name_to_entity_type(name)?),
-                &loc,
-            ),
             loc,
+        } => Ok(LocatedType::new_with_loc(
+            Type::named_entity_reference(internal_name_to_entity_type(name)?),
+            loc.as_ref(),
         )),
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::Extension { name },
-            ..
+            loc,
         } => {
             let extension_type_name = Name::unqualified_name(name);
             if extensions.ext_types().contains(&extension_type_name) {
-                Ok(Type::extension(extension_type_name).into())
+                Ok(LocatedType::new_with_loc(
+                    Type::extension(extension_type_name),
+                    loc.as_ref(),
+                ))
             } else {
                 let suggested_replacement = fuzzy_search(
                     &extension_type_name.to_string(),
@@ -961,53 +877,40 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
             }
         }
         json_schema::Type::CommonTypeRef { type_name, .. } => {
-            Ok(WithUnresolvedCommonTypeRefs::new(
-                move |common_type_defs| {
-                    common_type_defs
-                        .get(&type_name)
-                        .cloned()
-                        // We should always have `Some` here, because if the common type
-                        // wasn't defined, that error should have been caught earlier,
-                        // when the `json_schema::Type<InternalName>` was created by
-                        // resolving a `ConditionalName` into a fully-qualified
-                        // `InternalName`.
-                        // Nonetheless, instead of panicking if that internal
-                        // invariant is violated, it's easy to return this dynamic
-                        // error instead.
-                        .ok_or_else(|| CommonTypeInvariantViolationError { name: type_name }.into())
-                },
-                loc,
-            ))
+            common_type_defs
+                .get(&type_name)
+                .cloned()
+                // We should always have `Some` here, because if the common type
+                // wasn't defined, that error should have been caught earlier,
+                // when the `json_schema::Type<InternalName>` was created by
+                // resolving a `ConditionalName` into a fully-qualified
+                // `InternalName`.
+                // Nonetheless, instead of panicking if that internal
+                // invariant is violated, it's easy to return this dynamic
+                // error instead.
+                .ok_or_else(|| CommonTypeInvariantViolationError { name: type_name }.into())
         }
         json_schema::Type::Type {
             ty: json_schema::TypeVariant::EntityOrCommon { type_name },
-            ..
+            loc,
         } => {
-            let loc_clone = loc.clone();
-            Ok(WithUnresolvedCommonTypeRefs::new(
-                move |common_type_defs| {
-                    // First check if it's a common type, because in the edge case where
-                    // the name is both a valid common type name and a valid entity type
-                    // name, we give preference to the common type (see RFC 24).
-                    match common_type_defs.get(&type_name) {
-                        Some(def) => Ok(def.clone()),
-                        None => {
-                            // It wasn't a common type, so we assume it must be a valid
-                            // entity type. Otherwise, we would have had an error earlier,
-                            // when the `json_schema::Type<InternalName>` was created by
-                            // resolving a `ConditionalName` into a fully-qualified
-                            // `InternalName`.
-                            Ok(LocatedType::new_with_loc(
-                                Type::named_entity_reference(internal_name_to_entity_type(
-                                    type_name,
-                                )?),
-                                &loc,
-                            ))
-                        }
-                    }
-                },
-                loc_clone,
-            ))
+            // First check if it's a common type, because in the edge case where
+            // the name is both a valid common type name and a valid entity type
+            // name, we give preference to the common type (see RFC 24).
+            match common_type_defs.get(&type_name) {
+                Some(def) => Ok(def.clone()),
+                None => {
+                    // It wasn't a common type, so we assume it must be a valid
+                    // entity type. Otherwise, we would have had an error earlier,
+                    // when the `json_schema::Type<InternalName>` was created by
+                    // resolving a `ConditionalName` into a fully-qualified
+                    // `InternalName`.
+                    Ok(LocatedType::new_with_loc(
+                        Type::named_entity_reference(internal_name_to_entity_type(type_name)?),
+                        loc.as_ref(),
+                    ))
+                }
+            }
         }
     }
 }
@@ -1017,30 +920,24 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
 pub(crate) fn try_record_type_into_validator_type(
     rty: json_schema::RecordType<InternalName>,
     extensions: &Extensions<'_>,
-    loc: Option<Loc>,
-) -> crate::validator::err::Result<WithUnresolvedCommonTypeRefs<LocatedType>> {
+    loc: Option<&Loc>,
+    common_type_defs: &HashMap<&InternalName, LocatedType>,
+) -> crate::validator::err::Result<LocatedType> {
     if cfg!(not(feature = "partial-validate")) && rty.additional_attributes {
         Err(UnsupportedFeatureError(UnsupportedFeature::OpenRecordsAndEntities).into())
     } else {
-        #[cfg(feature = "extended-schema")]
-        let attr_loc = loc.clone();
-        #[cfg(not(feature = "extended-schema"))]
-        let attr_loc = None;
-        Ok(
-            parse_record_attributes(rty.attributes, extensions, attr_loc)?.map(move |attrs| {
-                LocatedType::new_with_loc(
-                    Type::record_with_attributes(
-                        attrs,
-                        if rty.additional_attributes {
-                            OpenTag::OpenAttributes
-                        } else {
-                            OpenTag::ClosedAttributes
-                        },
-                    ),
-                    &loc,
-                )
-            }),
-        )
+        let attrs = parse_record_attributes(rty.attributes, extensions, common_type_defs)?;
+        Ok(LocatedType::new_with_loc(
+            Type::record_with_attributes(
+                attrs,
+                if rty.additional_attributes {
+                    OpenTag::OpenAttributes
+                } else {
+                    OpenTag::ClosedAttributes
+                },
+            ),
+            loc,
+        ))
     }
 }
 
@@ -1051,46 +948,27 @@ pub(crate) fn try_record_type_into_validator_type(
 fn parse_record_attributes(
     attrs: impl IntoIterator<Item = (SmolStr, json_schema::TypeOfAttribute<InternalName>)>,
     extensions: &Extensions<'_>,
-    loc: Option<Loc>,
-) -> crate::validator::err::Result<WithUnresolvedCommonTypeRefs<Attributes>> {
-    let attrs_with_common_type_refs = attrs
+    common_type_defs: &HashMap<&InternalName, LocatedType>,
+) -> crate::validator::err::Result<Attributes> {
+    let attrs = attrs
         .into_iter()
         .map(|(attr, ty)| -> crate::validator::err::Result<_> {
             #[cfg(feature = "extended-schema")]
             let loc = ty.loc;
             #[cfg(not(feature = "extended-schema"))]
             let loc = None;
-            Ok((
-                attr,
-                (
-                    try_jsonschema_type_into_validator_type(ty.ty.clone(), extensions, loc)?,
-                    ty.required,
-                ),
-            ))
+
+            let attr_ty = try_jsonschema_type_into_validator_type(
+                ty.ty.clone(),
+                extensions,
+                common_type_defs,
+            )?;
+            #[cfg(feature = "extended-schema")]
+            let attr_ty = AttributeType::new_with_loc(attr_ty.ty.into(), ty.required, loc);
+            #[cfg(not(feature = "extended-schema"))]
+            let attr_ty = AttributeType::new(attr_ty.ty.into(), ty.required);
+            Ok((attr, attr_ty))
         })
         .collect::<crate::validator::err::Result<Vec<_>>>()?;
-
-    Ok(WithUnresolvedCommonTypeRefs::new(
-        |common_type_defs| {
-            attrs_with_common_type_refs
-                .into_iter()
-                .map(|(s, (attr_ty, is_req))| {
-                    #[cfg(feature = "extended-schema")]
-                    let loc = attr_ty.loc().cloned();
-                    attr_ty
-                        .resolve_common_type_refs(common_type_defs)
-                        .map(|ty| {
-                            #[cfg(feature = "extended-schema")]
-                            let ty_pair =
-                                (s, AttributeType::new_with_loc(ty.ty.into(), is_req, loc));
-                            #[cfg(not(feature = "extended-schema"))]
-                            let ty_pair = (s, AttributeType::new(ty.ty.into(), is_req));
-                            ty_pair
-                        })
-                })
-                .collect::<crate::validator::err::Result<Vec<_>>>()
-                .map(Attributes::with_attributes)
-        },
-        loc,
-    ))
+    Ok(Attributes::with_attributes(attrs))
 }


### PR DESCRIPTION
## Description of changes

Removes an needlessly complex layer of indirection when converting the JSON type representation to our internal representation. 

After #1060 we always resolve common type reference immediately after converting the JSON representation of a type to the internal representation. This was originally implemented as a two-step conversion so that we could do most of the conversion and report error prior to resolving common types, but we don't do that anymore, and it was probably more complicated than it needed to be in the first place. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
