### PR TITLE
adding decode_unchecked API and refactoring validation

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,7 +17,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ### Changed
 
-- The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding. The previous, unvalidated behavior is available with `Entities::decode_unchecked` for trusted encoded data.
+- The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding. The previous, unvalidated behavior is available via the new `decode_unchecked` methods (e.g., `Entities::decode_unchecked`) for trusted encoded data.
 
 ## [4.11.1] - Coming soon
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,7 +17,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ### Changed
 
-- The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding.
+- The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding. The previous, unvalidated behavior is available with `Entities::decode_unchecked` for trusted encoded data.
 
 ## [4.11.1] - Coming soon
 

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -128,8 +128,8 @@ impl traits::Protobuf for api::Entities {
             .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid: {e}")).into())
     }
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
-        // Skip TC computation for trusted data
         let msg = models::Entities::decode(buf)?;
+        // Skip TC computation for trusted data
         let core_entities = entities_model_to_api(
             msg,
             cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
+use crate::proto::entities::entities_model_to_api;
+
 use super::super::api;
 use super::{ast::ProtobufConversionError, models, traits};
+use prost::Message as _;
+use traits::TryValidate as _;
 
 /// Macro that implements `From<A>` and `TryFrom<B>` for types where
 /// one conversion direction is infallible, the other is not. This is typically the case where
@@ -88,12 +92,12 @@ impl TryFrom<models::PolicySet> for api::PolicySet {
 /// Macro that implements `traits::Protobuf` for cases where `From<>` and `TryFrom<>`
 /// conversions exist between the api type `$api` and the protobuf model type `$model`
 macro_rules! standard_protobuf_impl {
-    ( $api:ty, $model:ty ) => {
+    ( $api:ty, $model:ty) => {
         impl traits::Protobuf for $api {
             fn encode(&self) -> Vec<u8> {
                 traits::encode_to_vec::<$model>(self)
             }
-            fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+            fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
                 traits::try_decode::<$model, _, _>(buf)
             }
         }
@@ -103,7 +107,6 @@ macro_rules! standard_protobuf_impl {
 // standard implementations of `traits::Protobuf`
 
 standard_protobuf_impl!(api::Entity, models::Entity);
-standard_protobuf_impl!(api::Entities, models::Entities);
 standard_protobuf_impl!(api::Schema, models::Schema);
 standard_protobuf_impl!(api::EntityTypeName, models::Name);
 standard_protobuf_impl!(api::EntityNamespace, models::Name);
@@ -113,12 +116,34 @@ standard_protobuf_impl!(api::Request, models::Request);
 
 // nonstandard implementations of `traits::Protobuf`
 
+impl traits::Protobuf for api::Entities {
+    fn encode(&self) -> Vec<u8> {
+        traits::encode_to_vec::<models::Entities>(self)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+        // Uses the standard TryFrom path which computes TC via ComputeNow
+        let entities: Self = traits::try_decode::<models::Entities, _, _>(buf)?;
+        entities
+            .try_validate()
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid: {e}")).into())
+    }
+    fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+        // Skip TC computation for trusted data
+        let msg = models::Entities::decode(buf)?;
+        let core_entities = entities_model_to_api(
+            msg,
+            cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
+        )?;
+        Ok(api::Entities(core_entities))
+    }
+}
+
 impl traits::Protobuf for api::PolicySet {
     fn encode(&self) -> Vec<u8> {
         traits::encode_to_vec::<models::PolicySet>(self)
     }
-    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
-        traits::try_decode::<models::PolicySet, _, Self>(buf)
+    fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
+        traits::try_decode::<models::PolicySet, _, Self>(buf) // TODO
     }
 }
 
@@ -383,5 +408,116 @@ mod test {
             crate::Entity::decode(&buf[..]),
             Err(crate::proto::traits::DecodeError::Conversion(_))
         );
+    }
+
+    /// Roundtrip via `decode_unchecked` — should produce the same result as `decode`
+    /// for well-formed data.
+    #[test]
+    fn roundtrip_decode_unchecked_entities() {
+        use crate::proto::traits::Protobuf;
+
+        let entities = crate::Entities::from_json_str(
+            r#"[
+                {"uid": {"type": "User", "id": "alice"}, "attrs": {"age": 25}, "parents": [{"type": "Group", "id": "admins"}]},
+                {"uid": {"type": "Group", "id": "admins"}, "attrs": {}, "parents": []}
+            ]"#,
+            None,
+        )
+        .expect("Failed to parse entities");
+
+        let buf = entities.encode();
+        let checked = crate::Entities::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::Entities::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
+    }
+
+    #[test]
+    fn roundtrip_decode_unchecked_policy_set() {
+        use crate::proto::traits::Protobuf;
+
+        let pset = crate::PolicySet::from_str(
+            r#"
+            permit(principal == User::"alice", action, resource);
+            forbid(principal, action, resource) when { context.restricted };
+            "#,
+        )
+        .expect("Failed to parse policy set");
+
+        let buf = pset.encode();
+        let checked = crate::PolicySet::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::PolicySet::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
+    }
+
+    #[test]
+    fn roundtrip_decode_unchecked_schema() {
+        use crate::proto::traits::Protobuf;
+
+        let (schema, _) = crate::Schema::from_cedarschema_str(
+            r#"
+            entity User;
+            entity Document {
+                owner: User,
+            };
+            action Read appliesTo { principal: User, resource: Document };
+            "#,
+        )
+        .expect("Failed to parse schema");
+
+        let buf = schema.encode();
+        let checked = crate::Schema::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::Schema::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        // Schema doesn't impl PartialEq, so compare via re-encoding
+        similar_asserts::assert_eq!(checked.encode(), unchecked.encode());
+    }
+
+    #[test]
+    fn roundtrip_decode_unchecked_template() {
+        use crate::proto::traits::Protobuf;
+
+        let template = crate::Template::from_str(
+            r#"permit(principal == ?principal, action, resource);"#,
+        )
+        .expect("Failed to parse template");
+
+        let buf = template.encode();
+        let checked = crate::Template::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::Template::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
+    }
+
+    #[test]
+    fn roundtrip_decode_unchecked_entity() {
+        use crate::proto::traits::Protobuf;
+
+        let entity = crate::Entity::from_json_value(
+            serde_json::json!({"uid": {"type": "User", "id": "bob"}, "attrs": {"active": true}, "parents": []}),
+            None,
+        )
+        .expect("Failed to parse entity");
+
+        let buf = entity.encode();
+        let checked = crate::Entity::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::Entity::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
+    }
+
+    #[test]
+    fn roundtrip_decode_unchecked_request() {
+        use crate::proto::traits::Protobuf;
+
+        let request = crate::Request::new(
+            crate::EntityUid::from_strs("User", "alice"),
+            crate::EntityUid::from_strs("Action", "read"),
+            crate::EntityUid::from_strs("Document", "doc1"),
+            crate::Context::empty(),
+            None,
+        )
+        .expect("Failed to create request");
+
+        let buf = request.encode();
+        let checked = crate::Request::decode(&buf[..]).expect("decode failed");
+        let unchecked = crate::Request::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -143,7 +143,9 @@ impl traits::Protobuf for api::PolicySet {
         traits::encode_to_vec::<models::PolicySet>(self)
     }
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
-        traits::try_decode::<models::PolicySet, _, Self>(buf) // TODO
+        // TODO: find a way to skip additional validation on PolicySet, currently validation happens
+        // once for decode_unchecked and twice for decode
+        traits::try_decode::<models::PolicySet, _, Self>(buf)
     }
 }
 

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -149,6 +149,7 @@ impl traits::Protobuf for api::PolicySet {
 
 #[cfg(test)]
 mod test {
+    use crate::proto::traits::Protobuf;
     use cool_asserts::assert_matches;
     use prost::Message as _;
     use std::{collections::HashMap, str::FromStr};
@@ -172,6 +173,14 @@ mod test {
     fn roundtrip_policies_text(text: &str) {
         let pset = crate::PolicySet::from_str(text).expect("Failed to parse policy set");
         roundtrip_policies(pset);
+    }
+
+    /// [`decode`] and [`decode_unchecked`] should produce the same data when they don't fail.
+    fn decode_eq_decode_unchecked<T: Protobuf + PartialEq>(x: T) {
+        let buf = x.encode();
+        let checked = T::decode(&buf[..]).expect("decode failed");
+        let unchecked = T::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
     }
 
     #[test]
@@ -410,12 +419,8 @@ mod test {
         );
     }
 
-    /// Roundtrip via `decode_unchecked` — should produce the same result as `decode`
-    /// for well-formed data.
     #[test]
     fn roundtrip_decode_unchecked_entities() {
-        use crate::proto::traits::Protobuf;
-
         let entities = crate::Entities::from_json_str(
             r#"[
                 {"uid": {"type": "User", "id": "alice"}, "attrs": {"age": 25}, "parents": [{"type": "Group", "id": "admins"}]},
@@ -424,17 +429,11 @@ mod test {
             None,
         )
         .expect("Failed to parse entities");
-
-        let buf = entities.encode();
-        let checked = crate::Entities::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::Entities::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
+        decode_eq_decode_unchecked::<crate::Entities>(entities);
     }
 
     #[test]
     fn roundtrip_decode_unchecked_policy_set() {
-        use crate::proto::traits::Protobuf;
-
         let pset = crate::PolicySet::from_str(
             r#"
             permit(principal == User::"alice", action, resource);
@@ -442,70 +441,30 @@ mod test {
             "#,
         )
         .expect("Failed to parse policy set");
-
-        let buf = pset.encode();
-        let checked = crate::PolicySet::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::PolicySet::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
-    }
-
-    #[test]
-    fn roundtrip_decode_unchecked_schema() {
-        use crate::proto::traits::Protobuf;
-
-        let (schema, _) = crate::Schema::from_cedarschema_str(
-            r#"
-            entity User;
-            entity Document {
-                owner: User,
-            };
-            action Read appliesTo { principal: User, resource: Document };
-            "#,
-        )
-        .expect("Failed to parse schema");
-
-        let buf = schema.encode();
-        let checked = crate::Schema::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::Schema::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        // Schema doesn't impl PartialEq, so compare via re-encoding
-        similar_asserts::assert_eq!(checked.encode(), unchecked.encode());
+        decode_eq_decode_unchecked::<crate::PolicySet>(pset);
     }
 
     #[test]
     fn roundtrip_decode_unchecked_template() {
-        use crate::proto::traits::Protobuf;
+        let template =
+            crate::Template::from_str(r#"permit(principal == ?principal, action, resource);"#)
+                .expect("Failed to parse template");
 
-        let template = crate::Template::from_str(
-            r#"permit(principal == ?principal, action, resource);"#,
-        )
-        .expect("Failed to parse template");
-
-        let buf = template.encode();
-        let checked = crate::Template::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::Template::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
+        decode_eq_decode_unchecked::<crate::Template>(template);
     }
 
     #[test]
     fn roundtrip_decode_unchecked_entity() {
-        use crate::proto::traits::Protobuf;
-
         let entity = crate::Entity::from_json_value(
             serde_json::json!({"uid": {"type": "User", "id": "bob"}, "attrs": {"active": true}, "parents": []}),
             None,
         )
         .expect("Failed to parse entity");
-
-        let buf = entity.encode();
-        let checked = crate::Entity::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::Entity::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
+        decode_eq_decode_unchecked::<crate::Entity>(entity);
     }
 
     #[test]
     fn roundtrip_decode_unchecked_request() {
-        use crate::proto::traits::Protobuf;
-
         let request = crate::Request::new(
             crate::EntityUid::from_strs("User", "alice"),
             crate::EntityUid::from_strs("Action", "read"),
@@ -514,10 +473,6 @@ mod test {
             None,
         )
         .expect("Failed to create request");
-
-        let buf = request.encode();
-        let checked = crate::Request::decode(&buf[..]).expect("decode failed");
-        let unchecked = crate::Request::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
+        decode_eq_decode_unchecked::<crate::Request>(request);
     }
 }

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -198,7 +198,7 @@ impl TryFrom<models::Entity> for ast::Entity {
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
-        Self::new_with_attr_partial_value(
+        Ok(Self::new_with_attr_partial_value(
             ast::EntityUID::try_from(
                 v.uid
                     .ok_or_else(|| ProtobufConversionError::missing("uid"))?,
@@ -207,9 +207,7 @@ impl TryFrom<models::Entity> for ast::Entity {
             HashSet::new(),
             ancestors,
             tags,
-        )
-        .try_validate()
-        .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid entity: {e}")))
+        ))
     }
 }
 
@@ -404,8 +402,7 @@ impl TryFrom<models::Expr> for ast::Expr {
                 })?
             }
         };
-        expr.try_validate()
-            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid expression: {e}")))
+        Ok(expr)
     }
 }
 

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -18,29 +18,39 @@
 
 use super::ast::ProtobufConversionError;
 use super::models;
-use cedar_policy_core::{ast, entities, extensions};
+use cedar_policy_core::{
+    ast,
+    entities::{self, TCComputation},
+    extensions,
+};
 
 impl TryFrom<models::Entities> for entities::Entities {
     type Error = ProtobufConversionError;
 
     fn try_from(v: models::Entities) -> Result<Self, Self::Error> {
-        let entities: Vec<ast::Entity> = v
-            .entities
-            .into_iter()
-            .map(ast::Entity::try_from)
-            .collect::<Result<_, _>>()?;
-
-        // This API does not assume that the transitive closure has already been computed.
-        // A different API that does not perform validation could skip tc computation.
-        entities::Entities::from_entities(
-            entities,
-            None::<&entities::NoEntitiesSchema>,
-            entities::TCComputation::ComputeNow,
-            extensions::Extensions::all_available(),
-        )
-        .and_then(|v| v.try_validate(true))
-        .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid entities: {e}")))
+        entities_model_to_api(v, TCComputation::ComputeNow)
     }
+}
+
+pub(crate) fn entities_model_to_api(
+    model: models::Entities,
+    tc_mode: TCComputation,
+) -> Result<entities::Entities, ProtobufConversionError> {
+    let entities: Vec<ast::Entity> = model
+        .entities
+        .into_iter()
+        .map(ast::Entity::try_from)
+        .collect::<Result<_, _>>()?;
+
+    // This API does not assume that the transitive closure has already been computed.
+    // A different API that does not perform validation could skip tc computation.
+    entities::Entities::from_entities(
+        entities,
+        None::<&entities::NoEntitiesSchema>,
+        tc_mode,
+        extensions::Extensions::all_available(),
+    )
+    .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid entities: {e}")))
 }
 
 impl From<&entities::Entities> for models::Entities {

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -33,8 +33,8 @@ impl TryFrom<models::Entities> for entities::Entities {
     }
 }
 
-/// [`entities_model_to_api`] converts the [`model::Entities`] to the public API type
-/// [`entities::Entities`], with the given [`TCComputation`] mode.
+/// [`entities_model_to_api`] converts the [`models::Entities`] protobuf model to the core [`entities::Entities`]
+/// type, with the given [`TCComputation`] mode.
 pub(crate) fn entities_model_to_api(
     model: models::Entities,
     tc_mode: TCComputation,

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -28,10 +28,13 @@ impl TryFrom<models::Entities> for entities::Entities {
     type Error = ProtobufConversionError;
 
     fn try_from(v: models::Entities) -> Result<Self, Self::Error> {
+        // The TryFrom does not assume that the transitive closure has already been computed.
         entities_model_to_api(v, TCComputation::ComputeNow)
     }
 }
 
+/// [`entities_model_to_api`] converts the [`model::Entities`] to the public API type
+/// [`entities::Entities`], with the given [`TCComputation`] mode.
 pub(crate) fn entities_model_to_api(
     model: models::Entities,
     tc_mode: TCComputation,
@@ -42,8 +45,6 @@ pub(crate) fn entities_model_to_api(
         .map(ast::Entity::try_from)
         .collect::<Result<_, _>>()?;
 
-    // This API does not assume that the transitive closure has already been computed.
-    // A different API that does not perform validation could skip tc computation.
     entities::Entities::from_entities(
         entities,
         None::<&entities::NoEntitiesSchema>,

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -101,10 +101,7 @@ impl From<&ast::Policy> for models::Policy {
 impl TryFrom<models::TemplateBody> for ast::Template {
     type Error = ProtobufConversionError;
     fn try_from(v: models::TemplateBody) -> Result<Self, Self::Error> {
-        let template = ast::Template::from(ast::TemplateBody::try_from(v)?)
-            .try_validate()
-            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid template: {e}")))?;
-        Ok(template)
+        Ok(ast::Template::from(ast::TemplateBody::try_from(v)?))
     }
 }
 
@@ -490,11 +487,6 @@ impl TryFrom<models::PolicySet> for ast::PolicySet {
         let literal = ast::LiteralPolicySet::try_from(pset)?;
         ast::PolicySet::try_from(literal)
             .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}")))
-            .and_then(|ps| {
-                ps.try_validate().map_err(|e| {
-                    ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}"))
-                })
-            })
     }
 }
 

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -58,8 +58,22 @@ pub trait TryValidate: Sized {
     fn try_validate(self) -> Result<Self, Self::Err>;
 }
 
+mod private {
+    use crate::api;
+    pub trait Sealed {}
+    impl Sealed for api::PolicySet {}
+    impl Sealed for api::Entities {}
+    impl Sealed for api::Entity {}
+    impl Sealed for api::Schema {}
+    impl Sealed for api::EntityTypeName {}
+    impl Sealed for api::EntityNamespace {}
+    impl Sealed for api::Template {}
+    impl Sealed for api::Expression {}
+    impl Sealed for api::Request {}
+}
+
 /// Trait allowing serializing and deserializing in protobuf format.
-pub trait Protobuf: Sized + TryValidate {
+pub trait Protobuf: Sized + TryValidate + private::Sealed {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
     fn encode(&self) -> Vec<u8>;
     /// Decode the binary data in `buf`, producing something of type `Self`

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
+use cedar_policy_core::{
+    ast::{ExprValidationError, Infallible, PolicySetValidationError, TemplateValidationError},
+    entities::err::EntitiesError,
+    validator::SchemaError,
+};
+use itertools::Either;
+
+use crate::{api, PolicySetError};
+
 use super::ast::ProtobufConversionError;
 
 /// Error type for protobuf decoding failures
@@ -41,7 +50,7 @@ impl From<ProtobufConversionError> for DecodeError {
 }
 
 /// Trait allowing serializing and deserializing in protobuf format
-pub trait Protobuf: Sized {
+pub trait Protobuf: Sized + TryValidate {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
     fn encode(&self) -> Vec<u8>;
     /// Decode the binary data in `buf`, producing something of type `Self`
@@ -51,7 +60,23 @@ pub trait Protobuf: Sized {
     /// Will return [`DecodeError::Proto`] when the input buffer does not
     /// contain a valid protobuf message, or [`DecodeError::Conversion`] when
     /// the message is well-formed but cannot be converted into the target type.
-    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError>;
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError> {
+        Self::decode_unchecked(buf)?
+            .try_validate()
+            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid: {e}")).into())
+    }
+
+    /// Decode the binary data in `buf`, producing something of type `Self`,
+    /// but with fewer checks than the [`decode`] function. This is useful for performance
+    /// if you can guarantee the binary data is the result of [`encode`] of the same
+    /// implementation.
+    ///
+    /// # Errors
+    ///
+    /// Will return [`DecodeError::Proto`] when the input buffer does not
+    /// contain a valid protobuf message, or [`DecodeError::Conversion`] when
+    /// the message is well-formed but cannot be converted into the target type.
+    fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError>;
 }
 
 /// Encode `thing` into `buf` using the protobuf format `M`
@@ -73,7 +98,7 @@ pub(crate) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
     thing.into().encode_to_vec()
 }
 
-use std::default::Default;
+use std::{default::Default, fmt::Display};
 
 /// Decode something of type `T` from `buf` using the protobuf format `M`
 #[expect(
@@ -98,4 +123,83 @@ pub(crate) fn try_decode<
     M::decode(buf)?
         .try_into()
         .map_err(|e: E| DecodeError::Conversion(e.into()))
+}
+
+pub(crate) trait TryValidate: Sized {
+    type Err: Display;
+    // Validate the structure according to its internal invariants.
+    fn try_validate(self) -> Result<Self, Self::Err>;
+}
+
+impl TryValidate for api::PolicySet {
+    type Err = Either<PolicySetError, PolicySetValidationError>;
+    fn try_validate(self) -> Result<Self, Self::Err> {
+        self.ast
+            .try_validate()
+            .map_err(Either::Right)
+            .and_then(|o| o.try_into().map_err(Either::Left))
+    }
+}
+
+impl TryValidate for api::Entities {
+    type Err = EntitiesError;
+    fn try_validate(self) -> Result<api::Entities, EntitiesError> {
+        Ok(api::Entities(self.0.try_validate(true)?))
+    }
+}
+
+impl TryValidate for api::Entity {
+    type Err = EntitiesError;
+    fn try_validate(self) -> Result<api::Entity, EntitiesError> {
+        Ok(api::Entity(self.0.try_validate()?))
+    }
+}
+
+impl TryValidate for api::Schema {
+    type Err = SchemaError;
+    fn try_validate(self) -> Result<Self, SchemaError> {
+        Ok(api::Schema(self.0.try_validate()?))
+    }
+}
+
+impl TryValidate for api::Template {
+    type Err = TemplateValidationError;
+    fn try_validate(self) -> Result<Self, TemplateValidationError> {
+        Ok(api::Template {
+            ast: self.ast.try_validate()?,
+            ..self
+        })
+    }
+}
+
+impl TryValidate for api::Expression {
+    type Err = ExprValidationError;
+    fn try_validate(self) -> Result<Self, ExprValidationError> {
+        Ok(api::Expression(self.0.try_validate()?))
+    }
+}
+
+impl TryValidate for api::Request {
+    type Err = Infallible;
+    fn try_validate(self) -> Result<Self, Infallible> {
+        // We don't actually do any additional validation on requests, the structural validation enforced
+        // by types and the existing conversion is sufficient.
+        Ok(self)
+    }
+}
+
+impl TryValidate for api::EntityTypeName {
+    type Err = Infallible;
+    fn try_validate(self) -> Result<Self, Infallible> {
+        // EntityTypeName also doesn't need additional validation
+        Ok(self)
+    }
+}
+
+impl TryValidate for api::EntityNamespace {
+    type Err = Infallible;
+    fn try_validate(self) -> Result<Self, Infallible> {
+        // EntityNamespace also doesn't need additional validation
+        Ok(self)
+    }
 }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -77,10 +77,10 @@ pub trait Protobuf: Sized + TryValidate {
     }
 
     /// Decode the binary data in `buf`, producing something of type `Self`,
-    /// but without the additional validation that the [`decode`] method performs on the resulting
-    /// `Self`.
+    /// but without the additional validation that the [`Self::decode`] method performs on the
+    /// resulting `Self`.
     /// This is useful for performance if you can guarantee the binary data is the result of
-    /// [`encode`] of the same implementation.
+    /// [`Self::encode`] of the same implementation.
     ///
     /// # Errors
     ///

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -49,7 +49,16 @@ impl From<ProtobufConversionError> for DecodeError {
     }
 }
 
-/// Trait allowing serializing and deserializing in protobuf format
+/// A trait for objects that have a `try_validate` method returning `self` if the object is
+/// valid.
+pub trait TryValidate: Sized {
+    /// The type of errors returned by the validation method.
+    type Err: Display;
+    /// A validation method that returns the object itself, or an error if it is invalid.
+    fn try_validate(self) -> Result<Self, Self::Err>;
+}
+
+/// Trait allowing serializing and deserializing in protobuf format.
 pub trait Protobuf: Sized + TryValidate {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
     fn encode(&self) -> Vec<u8>;
@@ -58,8 +67,9 @@ pub trait Protobuf: Sized + TryValidate {
     /// # Errors
     ///
     /// Will return [`DecodeError::Proto`] when the input buffer does not
-    /// contain a valid protobuf message, or [`DecodeError::Conversion`] when
-    /// the message is well-formed but cannot be converted into the target type.
+    /// contain a valid protobuf message. Returns [`DecodeError::Conversion`] when
+    /// the message is well-formed but cannot be converted into the target type or the
+    /// validation on the target type failed.
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError> {
         Self::decode_unchecked(buf)?
             .try_validate()
@@ -67,9 +77,10 @@ pub trait Protobuf: Sized + TryValidate {
     }
 
     /// Decode the binary data in `buf`, producing something of type `Self`,
-    /// but with fewer checks than the [`decode`] function. This is useful for performance
-    /// if you can guarantee the binary data is the result of [`encode`] of the same
-    /// implementation.
+    /// but without the additional validation that the [`decode`] method performs on the resulting
+    /// `Self`.
+    /// This is useful for performance if you can guarantee the binary data is the result of
+    /// [`encode`] of the same implementation.
     ///
     /// # Errors
     ///
@@ -123,12 +134,6 @@ pub(crate) fn try_decode<
     M::decode(buf)?
         .try_into()
         .map_err(|e: E| DecodeError::Conversion(e.into()))
-}
-
-pub(crate) trait TryValidate: Sized {
-    type Err: Display;
-    // Validate the structure according to its internal invariants.
-    fn try_validate(self) -> Result<Self, Self::Err>;
 }
 
 impl TryValidate for api::PolicySet {

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -37,7 +37,7 @@ impl From<&cedar_policy_core::validator::ValidatorSchema> for models::Schema {
 impl TryFrom<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Schema) -> Result<Self, Self::Error> {
-        Self::new(
+        Ok(Self::new(
             v.entity_decls
                 .into_iter()
                 .map(cedar_policy_core::validator::ValidatorEntityType::try_from)
@@ -46,9 +46,7 @@ impl TryFrom<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
                 .into_iter()
                 .map(cedar_policy_core::validator::ValidatorActionId::try_from)
                 .collect::<Result<Vec<_>, _>>()?,
-        )
-        .try_validate()
-        .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid schema: {e}")))
+        ))
     }
 }
 


### PR DESCRIPTION
## Description of changes

Adds a new `<target type>::decode_unchecked` API to `protobuf` implems, with a refactoring of where the validation occurs to make it more obvious.

This makes a "breaking change" on the experimental `protobufs` feature by sealing the `Protobuf` trait (and adding methods). As we stabilize this, I think it's a good idea, in order to allow adding methods in the future without breaking.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).


I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
