### PR TITLE
changelog updates for 4.11.1

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+## 4.11.1
 
 ## 4.11.0
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,9 +16,11 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding.
 
+## [4.11.1] - Coming soon
+
 ### Fixed
 
-- Protobuf parsing for expression now error on encountering a `like` pattern element with multiple characters in a single `PatternElem::Char` isntead of dropping the extra characters.
+- Protobuf parsing for expression now error on encountering a `like` pattern element with multiple characters in a single `PatternElem::Char` instead of dropping the extra characters.
 - Slot identifiers are now checked for JSON policy templates using slots in `is Type in ?slot` scope constraints. Loading a JSON format policy using `principal is Type in ?resource` or `resource is Type in ?principal`. (#2351)
 
 ## [4.11.0] - 2026-05-18

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 4.11.0
 
+### Fixed
+
 - `isAuthorizedPartial` will now error when `preparsedSchemaName` is not found in cache, matching behavior for preparsed policy sets. (#2348)
 
 ## 4.10.0

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-### Fixed
+## 4.11.1
+
+## 4.11.0
 
 - `isAuthorizedPartial` will now error when `preparsedSchemaName` is not found in cache, matching behavior for preparsed policy sets. (#2348)
 


### PR DESCRIPTION
Updates the changelog in preparation of 4.11.1 (also, updates the cedar-wasm that wasn't updated for 4.11.0).