### PR TITLE
Optimize schema type shadowing check

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -21,7 +21,7 @@
 //! computed to obtain a `descendants` relation.
 
 use crate::{
-    ast::{Eid, Entity, EntityType, EntityUID, Id, InternalName, Name, UnreservedId},
+    ast::{Entity, EntityType, EntityUID, InternalName, Name, UnreservedId},
     entities::{err::EntitiesError, Entities, TCComputation},
     extensions::Extensions,
     parser::Loc,

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -21,7 +21,7 @@
 //! computed to obtain a `descendants` relation.
 
 use crate::{
-    ast::{Entity, EntityType, EntityUID, InternalName, Name, UnreservedId},
+    ast::{Eid, Entity, EntityType, EntityUID, Id, InternalName, Name, UnreservedId},
     entities::{err::EntitiesError, Entities, TCComputation},
     extensions::Extensions,
     parser::Loc,
@@ -1276,37 +1276,45 @@ impl AllDefs {
     ///
     /// [RFC 70]: https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md
     pub fn rfc_70_shadowing_checks(&self) -> Result<()> {
+        // Definitions which cannot be shadowed according to the RFC 70 rules.
+        // RFC 70 specifies that shadowing an entity typename with a common typename is OK, including in the empty namespace.
+        // do not throw an error if the shadowing name is something like `__cedar::String` "shadowing" an empty-namespace declaration of `String`
+        let illegal_shadowings: HashMap<_, _> = self
+            .entity_and_common_names()
+            .filter(|name| !name.is_unqualified() && !name.is_reserved())
+            .map(|n| (n.basename(), n))
+            .collect();
+
         for unqualified_name in self
             .entity_and_common_names()
             .filter(|name| name.is_unqualified())
         {
-            // `unqualified_name` is a definition in the empty namespace
-            if let Some(name) = self.entity_and_common_names().find(|name| {
-                !name.is_unqualified() // RFC 70 specifies that shadowing an entity typename with a common typename is OK, including in the empty namespace
-                && !name.is_reserved() // do not throw an error if the shadowing name is something like `__cedar::String` "shadowing" an empty-namespace declaration of `String`
-                && name.basename() == unqualified_name.basename()
-            }) {
+            if let Some(&shadowing) = illegal_shadowings.get(unqualified_name.basename()) {
                 return Err(TypeShadowingError {
                     shadowed_def: unqualified_name.clone(),
-                    shadowing_def: name.clone(),
+                    shadowing_def: shadowing.clone(),
                 }
                 .into());
             }
         }
+
+        // Action definitions which cannot be shadowed.
+        let illegal_action_shadowings: HashMap<_, _> = self
+            .action_defs
+            .iter()
+            .filter(|euid| !euid.entity_type().as_ref().is_unqualified())
+            .map(|euid| (euid.eid(), euid))
+            .collect();
+
         for unqualified_action in self
             .action_defs
             .iter()
             .filter(|euid| euid.entity_type().as_ref().is_unqualified())
         {
-            // `unqualified_action` is a definition in the empty namespace
-            if let Some(action) = self.action_defs.iter().find(|euid| {
-                !euid.entity_type().as_ref().is_unqualified() // do not throw an error for an action "shadowing" itself
-                // we do not need to check that the basenames are the same, because we assume they are both `Action`
-                && euid.eid() == unqualified_action.eid()
-            }) {
+            if let Some(&shadowing) = illegal_action_shadowings.get(unqualified_action.eid()) {
                 return Err(ActionShadowingError {
                     shadowed_def: unqualified_action.clone(),
-                    shadowing_def: action.clone(),
+                    shadowing_def: shadowing.clone(),
                 }
                 .into());
             }


### PR DESCRIPTION
## Description of changes

while working on adding a depth guard for schema parsing, I noticed very slow performance parsing large schemas.

I traced this to the `rfc_70_shadowing_checks` function which runs an O(n^2) check to detect any illegal shadowing entity and common types. For a schema with 20000 type declarations, parsing speeds up from about 8s to 0.7s. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
