### PR TITLE
Remove redundant `resolve_type` pass

### DIFF
--- a/cedar-language-server/src/schema/fold.rs
+++ b/cedar-language-server/src/schema/fold.rs
@@ -184,6 +184,13 @@ mod test {
         (0, 3)
     );
 
+    assert_schema_folding_ranges!(
+        common_type_chain,
+        "type T0 = T1;\ntype T1 = Long;",
+        (0, 0),
+        (1, 1)
+    );
+
     #[test]
     #[traced_test]
     fn json_schema_returns_none() {

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -33,7 +33,7 @@ use nonempty::NonEmpty;
 #[cfg(feature = "extended-schema")]
 use smol_str::SmolStr;
 use smol_str::ToSmolStr;
-use std::collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{hash_map::Entry, BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -1483,73 +1483,6 @@ impl<'a> CommonTypeResolver<'a> {
         }
     }
 
-    // Substitute common type references in `ty` according to `resolve_table`.
-    // Resolved types will still have the source loc of `ty`, unless `ty` is
-    // exactly a common type reference, in which case they will have the source
-    // loc of the definition of that reference.
-    fn resolve_type(
-        resolve_table: &HashMap<&InternalName, json_schema::Type<InternalName>>,
-        ty: json_schema::Type<InternalName>,
-    ) -> Result<json_schema::Type<InternalName>> {
-        match ty {
-            json_schema::Type::CommonTypeRef { type_name, .. } => resolve_table
-                .get(&type_name)
-                .ok_or_else(|| CommonTypeInvariantViolationError { name: type_name }.into())
-                .cloned(),
-            json_schema::Type::Type {
-                ty: json_schema::TypeVariant::EntityOrCommon { type_name },
-                loc,
-            } => match resolve_table.get(&type_name) {
-                Some(def) => Ok(def.clone().with_loc(loc)),
-
-                None => Ok(json_schema::Type::Type {
-                    ty: json_schema::TypeVariant::Entity { name: type_name },
-                    loc,
-                }),
-            },
-            json_schema::Type::Type {
-                ty: json_schema::TypeVariant::Set { element },
-                loc,
-            } => Ok(json_schema::Type::Type {
-                ty: json_schema::TypeVariant::Set {
-                    element: Box::new(Self::resolve_type(resolve_table, *element)?),
-                },
-                loc,
-            }),
-            json_schema::Type::Type {
-                ty:
-                    json_schema::TypeVariant::Record(json_schema::RecordType {
-                        attributes,
-                        additional_attributes,
-                    }),
-                loc,
-            } => Ok(json_schema::Type::Type {
-                ty: json_schema::TypeVariant::Record(json_schema::RecordType {
-                    attributes: BTreeMap::from_iter(
-                        attributes
-                            .into_iter()
-                            .map(|(attr, attr_ty)| -> Result<_> {
-                                Ok((
-                                    attr,
-                                    json_schema::TypeOfAttribute {
-                                        required: attr_ty.required,
-                                        ty: Self::resolve_type(resolve_table, attr_ty.ty)?,
-                                        annotations: attr_ty.annotations,
-                                        #[cfg(feature = "extended-schema")]
-                                        loc: attr_ty.loc,
-                                    },
-                                ))
-                            })
-                            .partition_nonempty::<Vec<_>>()?,
-                    ),
-                    additional_attributes,
-                }),
-                loc,
-            }),
-            _ => Ok(ty),
-        }
-    }
-
     // Resolve common type references, returning a map from (fully-qualified)
     // [`InternalName`] of a common type to its [`Type`] definition
     fn resolve(
@@ -1560,8 +1493,6 @@ impl<'a> CommonTypeResolver<'a> {
             SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError { ty: n })
         })?;
 
-        let mut resolve_table: HashMap<&InternalName, json_schema::Type<InternalName>> =
-            HashMap::new();
         let mut tys: HashMap<&'a InternalName, LocatedType> = HashMap::new();
 
         for &name in sorted_names.iter() {
@@ -1570,13 +1501,8 @@ impl<'a> CommonTypeResolver<'a> {
                 reason = "`name.basename()` should be an existing common type id"
             )]
             let ty = self.defs.get(name).unwrap();
-            let substituted_ty = Self::resolve_type(&resolve_table, ty.clone())?;
-            resolve_table.insert(name, substituted_ty.clone());
-            let validator_type = try_jsonschema_type_into_validator_type(
-                substituted_ty,
-                extensions,
-                &HashMap::new(),
-            )?;
+            let validator_type =
+                try_jsonschema_type_into_validator_type(ty.clone(), extensions, &tys)?;
 
             tys.insert(name, validator_type);
         }

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -156,6 +156,16 @@ impl LocatedType {
         }
     }
 
+    /// Replace `self.loc` with `_loc`. No-op if the `extend-schema` feature is
+    /// not enabled.
+    pub fn with_loc(self, _loc: Option<&Loc>) -> Self {
+        Self {
+            #[cfg(feature = "extended-schema")]
+            loc: _loc.cloned(),
+            ..self
+        }
+    }
+
     /// Deconstruct this `LocatedType` into the type and location where the type
     /// is defined. If `extend-schema` is not enabled, then the location
     /// returned by this function is always `None`.
@@ -817,12 +827,11 @@ impl ValidatorSchema {
         compute_tc(&mut action_ids, true)?;
 
         #[cfg(feature = "extended-schema")]
-        let common_type_validators = common_types
+        let located_common_types = common_types
             .clone()
             .into_iter()
-            .filter(|ct| {
+            .filter(|(ct_name, _)| {
                 // Only collect common types that are not primitives and have location data
-                let ct_name = ct.0.clone();
                 ct_name.loc().is_some() && !Type::is_primitive(ct_name.basename().as_ref())
             })
             .map(|ct| LocatedCommonType::new(ct.0, ct.1))
@@ -846,7 +855,7 @@ impl ValidatorSchema {
             entity_types,
             action_ids,
             #[cfg(feature = "extended-schema")]
-            common_type_validators,
+            located_common_types,
             #[cfg(feature = "extended-schema")]
             validator_namespaces,
         ))

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -156,7 +156,7 @@ impl LocatedType {
         }
     }
 
-    /// Replace `self.loc` with `_loc`. No-op if the `extend-schema` feature is
+    /// Replace `self.loc` with `loc`. No-op if the `extended-schema` feature is
     /// not enabled.
     pub fn with_loc(self, _loc: Option<&Loc>) -> Self {
         Self {

--- a/cedar-policy-core/src/validator/schema/namespace_def.rs
+++ b/cedar-policy-core/src/validator/schema/namespace_def.rs
@@ -876,10 +876,10 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
                 ))
             }
         }
-        json_schema::Type::CommonTypeRef { type_name, .. } => {
+        json_schema::Type::CommonTypeRef { type_name, loc } => {
             common_type_defs
                 .get(&type_name)
-                .cloned()
+                .map(|def| def.clone().with_loc(loc.as_ref()))
                 // We should always have `Some` here, because if the common type
                 // wasn't defined, that error should have been caught earlier,
                 // when the `json_schema::Type<InternalName>` was created by
@@ -897,9 +897,10 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
             // First check if it's a common type, because in the edge case where
             // the name is both a valid common type name and a valid entity type
             // name, we give preference to the common type (see RFC 24).
-            match common_type_defs.get(&type_name) {
-                Some(def) => Ok(def.clone()),
-                None => {
+            common_type_defs
+                .get(&type_name)
+                .map(|def| Ok(def.clone().with_loc(loc.as_ref())))
+                .unwrap_or_else(|| {
                     // It wasn't a common type, so we assume it must be a valid
                     // entity type. Otherwise, we would have had an error earlier,
                     // when the `json_schema::Type<InternalName>` was created by
@@ -909,8 +910,7 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
                         Type::named_entity_reference(internal_name_to_entity_type(type_name)?),
                         loc.as_ref(),
                     ))
-                }
-            }
+                })
         }
     }
 }


### PR DESCRIPTION
## Description of changes

This function was substituting common type references at the `json_schema::Type` level before converting with `try_jsonschema_type_into_validator_type`, but that function also substitutes common types, so there's no reason to do it in a separate pass. 

The `resolve_types` function was doing something to update source locations on common type references that the main `try_jsonschema_type_into_validator_type` didn't. There was only one test asserting that the changed happened, but no tests that showed why we wanted it. I traced it to type definition range folding in the LSP and added a test showing that the behavior is preserved. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
