### PR TITLE
CLI error when authorizing with missing link file

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,10 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+### Changed
+
+- The `authorize` command will now error if used with the `--template-linked` argument will now error if the link file does not exist.
+
 ## 4.11.1
 
 ## 4.11.0

--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ### Changed
 
-- The `authorize` command will now error if used with the `--template-linked` argument will now error if the link file does not exist.
+- The `authorize` command with the `--template-linked` argument will now error if the link file does not exist.
 
 ## 4.11.1
 

--- a/cedar-policy-cli/src/command/link.rs
+++ b/cedar-policy-cli/src/command/link.rs
@@ -22,7 +22,7 @@ use miette::{miette, IntoDiagnostic, Result};
 use serde::Deserialize;
 
 use crate::{
-    create_slot_env, load_links_from_file, parse_slot_id, CedarExitCode, PoliciesArgs,
+    create_slot_env, load_links_from_file_or_empty, parse_slot_id, CedarExitCode, PoliciesArgs,
     TemplateLinked,
 };
 
@@ -80,7 +80,7 @@ pub fn link(args: &LinkArgs) -> CedarExitCode {
 }
 
 fn link_inner(args: &LinkArgs) -> Result<()> {
-    let mut policies = args.policies.get_policy_set()?;
+    let mut policies = args.policies.get_policy_set_allow_missing_links()?;
     let slotenv = create_slot_env(&args.arguments.data)?;
     policies.link(
         PolicyId::new(&args.template_id),
@@ -109,7 +109,7 @@ fn link_inner(args: &LinkArgs) -> Result<()> {
 
 /// Add a single template-linked policy to the linked file
 fn update_template_linked_file(path: impl AsRef<Path>, new_linked: TemplateLinked) -> Result<()> {
-    let mut template_linked = load_links_from_file(path.as_ref())?;
+    let mut template_linked = load_links_from_file_or_empty(path.as_ref())?;
     template_linked.push(new_linked);
     write_template_linked_file(&template_linked, path.as_ref())
 }

--- a/cedar-policy-cli/src/utils/links.rs
+++ b/cedar-policy-cli/src/utils/links.rs
@@ -19,12 +19,26 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, str::FromStr};
 
-/// Iterate over links in the template-linked file and add them to the set
+/// Iterate over links in the template-linked file and add them to the set.
+/// Returns an error if the file does not exist.
 pub(crate) fn add_template_links_to_set(
     path: impl AsRef<Path>,
     policy_set: &mut PolicySet,
 ) -> Result<()> {
-    for template_linked in load_links_from_file(path)? {
+    add_links_to_set(&load_links_from_file(path)?, policy_set)
+}
+
+/// Like `add_template_links_to_set`, but tolerates a missing file (treats it
+/// as empty). Used by the `link` command which creates the file if needed.
+pub(crate) fn add_template_links_to_set_if_exists(
+    path: impl AsRef<Path>,
+    policy_set: &mut PolicySet,
+) -> Result<()> {
+    add_links_to_set(&load_links_from_file_or_empty(path)?, policy_set)
+}
+
+fn add_links_to_set(links: &[TemplateLinked], policy_set: &mut PolicySet) -> Result<()> {
+    for template_linked in links {
         let slot_env = create_slot_env(&template_linked.args)?;
         policy_set.link(
             PolicyId::new(&template_linked.template_id),
@@ -89,14 +103,11 @@ impl From<TemplateLinked> for LiteralTemplateLinked {
     }
 }
 
-/// Given a file containing template links, return a `Vec` of those links
+/// Given a file containing template links, return a `Vec` of those links.
+/// Returns an error if the file does not exist.
 pub(crate) fn load_links_from_file(path: impl AsRef<Path>) -> Result<Vec<TemplateLinked>> {
     let f = match std::fs::File::open(&path) {
         Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // If the file doesn't exist, then give back the empty entity set
-            return Ok(vec![]);
-        }
         Err(e) => {
             return Err(miette::miette!(
                 "failed to open links file '{}': {}",
@@ -119,6 +130,15 @@ pub(crate) fn load_links_from_file(path: impl AsRef<Path>) -> Result<Vec<Templat
             .into_diagnostic()
             .wrap_err("Deserialization error")
     }
+}
+
+/// Like `load_links_from_file`, but returns an empty vec if the file does
+/// not exist. Used by the `link` command which creates the file if needed.
+pub(crate) fn load_links_from_file_or_empty(path: impl AsRef<Path>) -> Result<Vec<TemplateLinked>> {
+    path.as_ref()
+        .exists()
+        .then(|| load_links_from_file(path))
+        .unwrap_or_else(|| Ok(vec![]))
 }
 
 pub(crate) fn parse_slot_id<S: AsRef<str>>(s: S) -> Result<SlotId, String> {

--- a/cedar-policy-cli/src/utils/policies.rs
+++ b/cedar-policy-cli/src/utils/policies.rs
@@ -19,7 +19,9 @@ use clap::{Args, ValueEnum};
 use miette::{miette, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
 use std::{path::Path, str::FromStr};
 
-use crate::{add_template_links_to_set, read_from_file_or_stdin};
+use crate::{
+    add_template_links_to_set, add_template_links_to_set_if_exists, read_from_file_or_stdin,
+};
 
 /// This struct contains the arguments that together specify an input policy or policy set.
 #[derive(Args, Debug)]
@@ -38,14 +40,30 @@ pub struct PoliciesArgs {
 impl PoliciesArgs {
     /// Turn this `PoliciesArgs` into the appropriate `PolicySet` object
     pub(crate) fn get_policy_set(&self) -> Result<PolicySet> {
-        let mut pset = match self.policy_format {
-            PolicyFormat::Cedar => read_cedar_policy_set(self.policies_file.as_ref()),
-            PolicyFormat::Json => read_json_policy_set(self.policies_file.as_ref()),
-        }?;
+        let mut pset = self.get_static_policies_and_templates()?;
         if let Some(links_filename) = self.template_linked_file.as_ref() {
             add_template_links_to_set(links_filename, &mut pset)?;
         }
         Ok(pset)
+    }
+
+    /// Like `get_policy_set`, but allows a missing template-linked file. Used
+    /// by the `link` command which creates the file if needed.
+    pub(crate) fn get_policy_set_allow_missing_links(&self) -> Result<PolicySet> {
+        let mut pset = self.get_static_policies_and_templates()?;
+        if let Some(links_filename) = self.template_linked_file.as_ref() {
+            add_template_links_to_set_if_exists(links_filename, &mut pset)?;
+        }
+        Ok(pset)
+    }
+
+    /// Read static policies and templates  from `self.policies_file`.
+    /// Does _not_ load template links.
+    fn get_static_policies_and_templates(&self) -> Result<PolicySet> {
+        match self.policy_format {
+            PolicyFormat::Cedar => read_cedar_policy_set(self.policies_file.as_ref()),
+            PolicyFormat::Json => read_json_policy_set(self.policies_file.as_ref()),
+        }
     }
 }
 

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -2084,3 +2084,47 @@ fn link_file_cant_read() {
     });
     assert!(!output.status.success());
 }
+
+#[test]
+fn auth_link_file_does_not_exist() {
+    // linking into a file that does not exist should create it
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let entities = dir.path().join("entities.json");
+    std::fs::write(&entities, r#"[]"#).unwrap();
+    let linked = dir.path().join("linked");
+    assert!(
+        !linked.exists(),
+        "trying to test behavior when file doesn't exist"
+    );
+    let output = cargo::cargo_bin_cmd!("cedar")
+        .env("NO_COLOR", "1")
+        .arg("authorize")
+        .arg("--template-linked")
+        .arg(&linked)
+        .arg("--entities")
+        .arg(entities)
+        .arg("--principal")
+        .arg(r#"User::"bob""#)
+        .arg("--action")
+        .arg(r#"Action::"view""#)
+        .arg("--resource")
+        .arg(r#"Photo::"VacationPhoto94.jpg""#)
+        .write_stdin("permit(principal == ?principal, action, resource);")
+        .output()
+        .expect("failed to run cedar");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut settings = insta::Settings::clone_current();
+    settings.add_filter(r"/tmp/[^ ']+/linked", "[TEMPDIR]/linked");
+    settings.bind(|| {
+        insta::assert_snapshot!(stdout, @r###"
+
+        × failed to open links file '[TEMPDIR]/linked': No such file or
+        │ directory (os error 2)
+        "###);
+    });
+    assert!(!output.status.success());
+    assert!(
+        !linked.exists(),
+        "authorize shouldn't create the missing link file"
+    );
+}

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -2087,7 +2087,7 @@ fn link_file_cant_read() {
 
 #[test]
 fn auth_link_file_does_not_exist() {
-    // linking into a file that does not exist should create it
+    // authorizing with a link file that does not exist should error
     let dir = tempfile::tempdir().expect("failed to create tempdir");
     let entities = dir.path().join("entities.json");
     std::fs::write(&entities, r#"[]"#).unwrap();


### PR DESCRIPTION
## Description of changes

Follow up to #2347. As noted there, `authorize` should probably not treat a missing links file as empty

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
