### PR TITLE
Fix wrong TC algorithm called when `enforce_dag=False`

### DIFF
--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -63,15 +63,13 @@ where
     K: Clone + Eq + Hash + Debug + Display,
     V: TCNode<K>,
 {
+    // Always use the SCC-based algorithm which correctly handles cycles.
+    // The single-pass algorithm is only correct for DAGs and produces
+    // incomplete results when the graph contains cycles of length >= 3.
+    cyclic_tc(nodes);
     if enforce_dag {
-        // Single-pass SCC-based algorithm: computes exact TC even for cyclic
-        // graphs, then checks for self-loops to detect cycles.
-        cyclic_tc(nodes);
         return enforce_dag_from_tc(nodes);
     }
-    // DAG assumed — single scan per node is sufficient.
-    let all_node_ids = nodes.keys().map(K::clone).collect::<Vec<K>>();
-    compute_tc_internal(all_node_ids.into_iter(), nodes, HashSet::new(), false);
     Ok(())
 }
 
@@ -1214,6 +1212,28 @@ mod tests {
         }
     }
 
+    /// Verify that `compute_tc(..., false)` produces the same result as
+    /// `cyclic_tc` on cyclic graphs (regression: the old single-pass algorithm
+    /// produced incomplete closures for cycles of length >= 3).
+    #[test]
+    fn compute_tc_no_dag_matches_cyclic_tc_on_cycles() {
+        for (name, base) in &cyclic_test_graphs() {
+            let mut via_compute = fresh_copy(base);
+            compute_tc(&mut via_compute, false)
+                .unwrap_or_else(|_| panic!("compute_tc failed on '{name}'"));
+
+            let mut via_cyclic = fresh_copy(base);
+            cyclic_tc(&mut via_cyclic);
+
+            let snap_compute = snapshot(&via_compute);
+            let snap_cyclic = snapshot(&via_cyclic);
+            assert_eq!(
+                snap_compute, snap_cyclic,
+                "compute_tc(false) differs from cyclic_tc on '{name}'"
+            );
+        }
+    }
+
     #[test]
     fn self_loop_with_grandchild() {
         let mut a = Entity::with_uid(EntityUID::with_eid("A"));
@@ -1624,6 +1644,41 @@ mod tests {
                 vec!["A", "B", "E"],
             ),
         ]
+    }
+
+    /// Regression test: `compute_tc` with `enforce_dag=false` on a cycle of
+    /// length >= 3 must produce a complete transitive closure (every node in
+    /// the cycle can reach every other node). Before the fix, the single-pass
+    /// DFS algorithm produced incomplete, non-deterministic results for such
+    /// cycles.
+    #[test]
+    fn cycle_length_3_enforce_dag_false() {
+        // A -> B -> C -> A (cycle of length 3)
+        let mut a = Entity::with_uid(EntityUID::with_eid("A"));
+        a.add_parent(EntityUID::with_eid("B"));
+        let mut b = Entity::with_uid(EntityUID::with_eid("B"));
+        b.add_parent(EntityUID::with_eid("C"));
+        let mut c = Entity::with_uid(EntityUID::with_eid("C"));
+        c.add_parent(EntityUID::with_eid("A"));
+        let mut entities = HashMap::from([
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+        ]);
+        // With enforce_dag=false, compute_tc must not error (cycles allowed)
+        compute_tc(&mut entities, false).expect("compute_tc should succeed with enforce_dag=false");
+        // Every node in the cycle must be able to reach every other node
+        let a = &entities[&EntityUID::with_eid("A")];
+        let b = &entities[&EntityUID::with_eid("B")];
+        let c = &entities[&EntityUID::with_eid("C")];
+        assert!(a.is_descendant_of(&EntityUID::with_eid("B")));
+        assert!(a.is_descendant_of(&EntityUID::with_eid("C")));
+        assert!(b.is_descendant_of(&EntityUID::with_eid("A")));
+        assert!(b.is_descendant_of(&EntityUID::with_eid("C")));
+        assert!(c.is_descendant_of(&EntityUID::with_eid("A")));
+        assert!(c.is_descendant_of(&EntityUID::with_eid("B")));
+        // enforce_tc must pass (TC is complete)
+        assert!(enforce_tc(&entities).is_ok());
     }
 
     /// Runs all `repair_tc` test cases, comparing repair result against a

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -19,6 +19,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding.
 
+### Fixed
+
+- Fixed transitive closure computation for schemas with cyclic entity type hierarchies of length ≥ 3 (introduced in 4.11.0).
+
 ## [4.11.1] - 2026-06-09
 
 Cedar Language Version: 4.5


### PR DESCRIPTION
## Description of changes

Fix incomplete transitive closure for cyclic entity type hierarchies (introduced in #2317, in 4.11.x).

The fix replaces the single-pass algorithm with cyclic_tc (SCC-based), which correctly handles cycles, which need to be handled even when the DAG does not need to be enforced. The DAG enforcement check remains conditional on the enforce_dag parameter.
Bug does not affect authorization, only validation, non-deterministically for schemas having cycles in the entity type hierarchy with length >= 3. 

(incidentally, found by fuzzing the protobuf schema decoding from bytes)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
