### PR TITLE
add expression validation in template

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1403,7 +1403,7 @@ impl<T: Clone + Default> ExprBuilder<T> {
 }
 
 /// Error returned by [`Expr::try_validate`] for internal invariant violations.
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, Diagnostic, PartialEq, Eq)]
 #[error("invalid expression: {0}")]
 pub struct ExprValidationError(String);
 

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -352,9 +352,10 @@ impl Template {
     /// and if not, returns an error.
     ///
     /// This will check the following invariants:
-    /// - slots do not appear in conditions
-    /// - action constraints only references Action entity types
-    /// - the slot cache is correct
+    /// - slots do not appear in conditions,
+    /// - action constraints only references Action entity types,
+    /// - the slot cache is correct,
+    /// - the condition is a valid expression.
     ///
     /// This function is meant to cover gaps between parsed templates and other ways to construct
     /// templates. This is *not* doing any semantic validation beyond the checks mentioned.
@@ -402,6 +403,10 @@ impl Template {
                 return Err(TemplateValidationError::SlotCacheMismatch);
             }
         }
+        // Invariant: expressions must be valid (e.g., known extension functions)
+        if let Some(expr) = self.body.non_scope_constraints() {
+            expr.clone().try_validate()?;
+        }
         Ok(self)
     }
 }
@@ -420,6 +425,10 @@ pub enum TemplateValidationError {
     /// Slot cache does not match the slots in the condition
     #[error("template slot cache is inconsistent with condition expression")]
     SlotCacheMismatch,
+    /// Invalid expression in conditions (e.g., unknown extension function)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidExpression(#[from] ExprValidationError),
 }
 
 impl From<TemplateBody> for Template {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -1400,4 +1400,27 @@ mod policy_set_validate_test {
             Err(PolicySetValidationError::InvalidTemplate { id, .. }) if id == PolicyID::from_string("slotty")
         );
     }
+
+    #[test]
+    fn link_with_no_slots_rejected() {
+        let t = valid_template("no_slots");
+        let literal = LiteralPolicySet::new(
+            [(t.id().clone(), t)],
+            [(
+                PolicyID::from_string("link1"),
+                LiteralPolicy::template_linked_policy(
+                    PolicyID::from_string("no_slots"),
+                    PolicyID::from_string("link1"),
+                    HashMap::new(),
+                ),
+            )],
+        );
+        let pset = PolicySet::try_from(literal).expect("failed to construct policy set");
+        assert_matches!(
+            pset.try_validate(),
+            Err(PolicySetValidationError::LinkToSlotlessTemplate { link_id, template_id })
+                if link_id == PolicyID::from_string("link1")
+                && template_id == PolicyID::from_string("no_slots")
+        );
+    }
 }

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -674,10 +674,30 @@ impl PolicySet {
         Ok(set)
     }
 
-    /// Validate that the [`PolicySet`] is well-formed according to the invariants of
-    /// [`PolicySet`]. This is useful when the [`PolicySet`] has been constructed directly
+    /// Validate that the [`PolicySet`] is well-formed, on top of the invariants guaranteed by the
+    /// public methods. This is useful when the [`PolicySet`] has been constructed directly
     /// from Rust code, without going through the Cedar or JSON syntax parsers.
+    ///
+    /// Checks the following invariants:
+    /// - individual [`Template`] are valid,
+    /// - every non-static link references a template with at least one slot.
+    ///
+    /// This assumes the [`PolicySet`] has been constructed with the public API methods
+    /// (e.g. [`PolicySet::add`]), which ensure the invariants documented for [`self.templates`],
+    /// [`self.links`] and [`self.template_to_links_map`] hold.
     pub fn try_validate(self) -> Result<Self, PolicySetValidationError> {
+        for (link_id, policy) in &self.links {
+            if !policy.is_static() {
+                // Check it's a real template
+                if policy.template().slots().count() == 0 {
+                    return Err(PolicySetValidationError::LinkToSlotlessTemplate {
+                        link_id: link_id.clone(),
+                        template_id: policy.template().id().clone(),
+                    });
+                }
+            }
+        }
+
         for (id, template) in &self.templates {
             template.as_ref().clone().try_validate().map_err(|error| {
                 PolicySetValidationError::InvalidTemplate {
@@ -701,6 +721,14 @@ pub enum PolicySetValidationError {
         /// The validation error
         #[source]
         error: TemplateValidationError,
+    },
+    /// A non-static link references a template with no slots
+    #[error("link `{link_id}` references template `{template_id}` which has no slots")]
+    LinkToSlotlessTemplate {
+        /// [`PolicyID`] of the link
+        link_id: PolicyID,
+        /// [`PolicyID`] of the template that has no slots
+        template_id: PolicyID,
     },
 }
 

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -679,7 +679,7 @@ impl PolicySet {
     /// from Rust code, without going through the Cedar or JSON syntax parsers.
     ///
     /// Checks the following invariants:
-    /// - individual [`Template`] are valid,
+    /// - each individual [`Template`] is valid,
     /// - every non-static link references a template with at least one slot.
     ///
     /// This assumes the [`PolicySet`] has been constructed with the public API methods


### PR DESCRIPTION
## Description of changes

Adds expression validation in the `Template` validation, after https://github.com/cedar-policy/cedar/pull/2387 moved validation to be explicit after decoding rather than implicit via the `TryFrom` trait.

Also adds an additional validation step in `PolicySet` to check for well-formedness of the policies: absence of slots must match absence of links.

For context, the `try_validate` methods are called by the protobuf's `decode` function to ensure the decoded internal representation satisify invariants that are typically guaranteed by the parsing paths.
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
