### PR TITLE
adding validation step in schema's try_validate

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1132,15 +1132,8 @@ impl ValidatorSchema {
             }
         }
         // Check actions: appliesTo references declared entity types, and
-        // descendants reference declared actions, and action entity types have
-        // basename `Action`
+        // descendants reference declared actions.
         for action in self.action_ids.values() {
-            if !action.name().entity_type().is_action() {
-                return Err(InvalidActionTypeError {
-                    uid: action.name().clone(),
-                }
-                .into());
-            }
             for ety in action.principals().chain(action.resources()) {
                 if !self.entity_types.contains_key(ety) {
                     undeclared_entities.push(ety.clone());
@@ -1179,6 +1172,8 @@ impl ValidatorSchema {
         Ok(())
     }
 
+    /// Check that all the extension types appearing in the types of the schema are known extension
+    /// types.
     fn check_extension_types_wf(&self) -> std::result::Result<(), SchemaError> {
         let extensions = Extensions::all_available();
         let valid_ext_types: HashSet<_> = extensions.ext_types().collect();
@@ -1189,6 +1184,31 @@ impl ValidatorSchema {
                         UnknownExtensionTypeError::new_with_suggestion(name.clone(), extensions),
                     ));
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// Checks that declarations are well-formed:
+    /// - [`self.entity_types`] does not declare actions,
+    /// - [`self.action_ids`] declares only actions.
+    fn check_decls_wf(&self) -> std::result::Result<(), SchemaError> {
+        for (et, _) in self.entity_types.iter() {
+            // An `*::Action` should not be in entity_types, including `Action`.
+            if et.is_action() {
+                return Err(SchemaError::ActionEntityTypeDeclared(
+                    ActionEntityTypeDeclaredError {},
+                ));
+            }
+        }
+        // An action should be an `*::Action`, otherwise it's invalid
+        // Not that the rfc_70 shadowing checks in `try_validate` will check that
+        // the `Action` entity type is not redeclared.
+        for (at, _) in self.action_ids.iter() {
+            if !at.is_action() {
+                return Err(SchemaError::InvalidActionType(InvalidActionTypeError {
+                    uid: at.clone(),
+                }));
             }
         }
         Ok(())
@@ -1211,6 +1231,7 @@ impl ValidatorSchema {
         self.check_hierarchy_wf()?;
         self.check_references_wf()?;
         self.check_extension_types_wf()?;
+        self.check_decls_wf()?;
         // Recompute transitive closure for entity types and actions,
         // which also detects cycles in the action hierarchy.
         compute_tc(&mut self.entity_types, false)
@@ -2271,6 +2292,26 @@ pub(crate) mod test {
             schema,
             Err(SchemaError::ActionEntityTypeDeclared(_))
         ));
+    }
+
+    #[test]
+    fn try_validate_rejects_action_entity_type() {
+        let action_type = EntityType::from_normalized_str("Action").unwrap();
+        let schema = ValidatorSchema::new(
+            [ValidatorEntityType::new_standard(
+                action_type,
+                [],
+                Attributes::with_attributes([]),
+                OpenTag::ClosedAttributes,
+                None,
+                None,
+            )],
+            [],
+        );
+        assert_matches!(
+            schema.try_validate(),
+            Err(SchemaError::ActionEntityTypeDeclared(_))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Adds validation in `try_validate` of `Schema`: entity types should not be actions and actions should be action types in the `ValidatorSchema` structure (one of the checks moved from being in the hierarchy check to being in the top-level defs check).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
