### PR TITLE
Extract workspace version fix to script ; apply to wasm publish

### DIFF
--- a/.github/scripts/check-crate-version.py
+++ b/.github/scripts/check-crate-version.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Check that a crate's version matches the expected version."""
+"""Usage: check-crate-version.py <crate-dir> <expected-version>
+
+Checks that a crate's version matches the expected version.
+If the crate inherits its version from the workspace (version.workspace = true),
+reads the version from the workspace Cargo.toml instead.
+"""
 import sys
 import tomllib
 from pathlib import Path
@@ -29,7 +34,9 @@ def main():
     if pkg_version is None:
         fail(f"No version field in {crate_toml}")
 
+    # First check for `version.workspace = true` in crate `Cargo.toml`.
     if isinstance(pkg_version, dict) and pkg_version.get("workspace") is True:
+        # Uses workspace version, so get version from workspace `Cargo.toml`
         workspace_toml = crate_dir.parent / "Cargo.toml"
         if not workspace_toml.exists():
             fail(f"{workspace_toml} not found")
@@ -40,6 +47,7 @@ def main():
             fail(f"No workspace.package.version in {workspace_toml}")
         source = str(workspace_toml)
     else:
+        # Does not use workspace version. Get version form caret `Cargo.toml`
         version = pkg_version
         source = str(crate_toml)
 

--- a/.github/scripts/check-crate-version.py
+++ b/.github/scripts/check-crate-version.py
@@ -47,7 +47,7 @@ def main():
             fail(f"No workspace.package.version in {workspace_toml}")
         source = str(workspace_toml)
     else:
-        # Does not use workspace version. Get version form caret `Cargo.toml`
+        # Does not use workspace version. Get version from crate `Cargo.toml`
         version = pkg_version
         source = str(crate_toml)
 

--- a/.github/scripts/check-crate-version.py
+++ b/.github/scripts/check-crate-version.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Check that a crate's version matches the expected version."""
+import sys
+import tomllib
+from pathlib import Path
+
+
+def fail(msg):
+    print(f"::error::{msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <crate-dir> <expected-version>", file=sys.stderr)
+        sys.exit(1)
+
+    crate_dir = Path(sys.argv[1])
+    expected = sys.argv[2]
+
+    crate_toml = crate_dir / "Cargo.toml"
+    if not crate_toml.exists():
+        fail(f"{crate_toml} not found")
+
+    with open(crate_toml, "rb") as f:
+        crate_data = tomllib.load(f)
+
+    pkg_version = crate_data.get("package", {}).get("version")
+    if pkg_version is None:
+        fail(f"No version field in {crate_toml}")
+
+    if isinstance(pkg_version, dict) and pkg_version.get("workspace") is True:
+        workspace_toml = crate_dir.parent / "Cargo.toml"
+        if not workspace_toml.exists():
+            fail(f"{workspace_toml} not found")
+        with open(workspace_toml, "rb") as f:
+            workspace_data = tomllib.load(f)
+        version = workspace_data.get("workspace", {}).get("package", {}).get("version")
+        if version is None:
+            fail(f"No workspace.package.version in {workspace_toml}")
+        source = str(workspace_toml)
+    else:
+        version = pkg_version
+        source = str(crate_toml)
+
+    if version != expected:
+        fail(f"{crate_dir} version mismatch: expected '{expected}' but {source} has '{version}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,6 +152,15 @@ jobs:
               with:
                   ref: refs/tags/${{ inputs.target == 'cli' && inputs.cli_tag || inputs.tag }}
                   fetch-depth: 0
+            # Main is checked out into a subdirectory so the latest scripts
+            # are available.  sparse-checkout ensures no Cargo.toml from main is
+            # present, so a bug in the script can't accidentally validate main's
+            # version.
+            - name: Checkout main (for scripts)
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  sparse-checkout: .github/scripts
+                  path: __main
             - name: Validate cli_tag points to same commit as tag
               if: inputs.target == 'all'
               run: |
@@ -164,60 +173,29 @@ jobs:
               env:
                   TAG: ${{ inputs.tag }}
                   CLI_TAG: ${{ inputs.cli_tag }}
-            - name: Configure rust toolchain
-              run: rustup update stable && rustup default stable
-            - name: Install toml-cli
-              run: cargo install toml-cli --locked
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: ">=3.11" # needs tomllib, in stdlib from 3.11
 
             # For all targets, we validate the core version in the code for the given tag
             - name: Validate core version against Cargo.toml for given tag
-              run: |
-                  ACTUAL=$(toml get --raw Cargo.toml workspace.package.version 2>/dev/null || true)
-                  if [[ -z "$ACTUAL" ]]; then
-                      ACTUAL=$(toml get --raw ./cedar-policy-core/Cargo.toml package.version 2>/dev/null || true)
-                  fi
-                  if [[ -z "$ACTUAL" ]]; then
-                      echo "::error::Could not find core version in workspace or crate Cargo.toml"
-                      exit 1
-                  fi
-                  if [[ "$ACTUAL" != "$CORE_VERSION" ]]; then
-                      echo "::error::core_version mismatch: input '$CORE_VERSION' but Cargo.toml has '$ACTUAL'"
-                      exit 1
-                  fi
+              run: python3 __main/.github/scripts/check-crate-version.py cedar-policy-core "$CORE_VERSION"
               env:
                   CORE_VERSION: ${{ inputs.core_version }}
 
             # For symcc and all targets, we validate the symcc version for the given tag
             - name: Validate symcc version against Cargo.toml for given tag
               if: inputs.target == 'symcc' || inputs.target == 'all'
-              run: |
-                  ACTUAL=$(toml get --raw ./cedar-policy-symcc/Cargo.toml package.version)
-                  if [[ "$ACTUAL" != "$SYMCC_VERSION" ]]; then
-                      echo "::error::symcc_version mismatch: input '$SYMCC_VERSION' but Cargo.toml has '$ACTUAL'"
-                      exit 1
-                  fi
+              run: python3 __main/.github/scripts/check-crate-version.py cedar-policy-symcc "$SYMCC_VERSION"
               env:
                   SYMCC_VERSION: ${{ inputs.symcc_version }}
 
             # For now, cli_version is the same as core_version (they share the workspace version).
             # We still additionally validate the cli version for the given tag.
-            # Note: cedar-policy-cli inherits its version from the workspace (version.workspace = true),
-            # so we validate against the workspace version in the root Cargo.toml.
             - name: Validate cli version against Cargo.toml
               if: inputs.target == 'cli' || inputs.target == 'all'
-              run: |
-                  ACTUAL=$(toml get --raw Cargo.toml workspace.package.version 2>/dev/null || true)
-                  if [[ -z "$ACTUAL" ]]; then
-                      ACTUAL=$(toml get --raw ./cedar-policy-cli/Cargo.toml package.version 2>/dev/null || true)
-                  fi
-                  if [[ -z "$ACTUAL" ]]; then
-                      echo "::error::Could not find cli version in workspace or crate Cargo.toml"
-                      exit 1
-                  fi
-                  if [[ "$ACTUAL" != "$CLI_VERSION" ]]; then
-                      echo "::error::cli_version mismatch: input '$CLI_VERSION' but Cargo.toml has '$ACTUAL'"
-                      exit 1
-                  fi
+              run: python3 __main/.github/scripts/check-crate-version.py cedar-policy-cli "$CLI_VERSION"
               env:
                   CLI_VERSION: ${{ inputs.cli_version }}
     publish-core:

--- a/.github/workflows/publish_wasm.yml
+++ b/.github/workflows/publish_wasm.yml
@@ -42,12 +42,21 @@ jobs:
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
               with:
                   ref: refs/tags/${{ inputs.tag }}
-            - name: Configure rust toolchain
-              run: rustup update stable && rustup default stable
-            - name: Install toml-cli
-              run: cargo install toml-cli --locked
+            # Main is checked out into a subdirectory so the latest scripts
+            # are available.  sparse-checkout ensures no Cargo.toml from main is
+            # present, so a bug in the script can't accidentally validate main's
+            # version.
+            - name: Checkout main (for scripts)
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  sparse-checkout: .github/scripts
+                  path: __main
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: ">=3.11" # needs tomllib, in stdlib from 3.11
             - name: Validate workspace version
-              run: test "v$(toml get --raw Cargo.toml workspace.package.version)" = "$TAG_NAME"
+              run: python3 __main/.github/scripts/check-crate-version.py cedar-wasm "${TAG_NAME#v}"
               env:
                   TAG_NAME: ${{ inputs.tag }}
 


### PR DESCRIPTION
## Description of changes

Follow up to #2423, applying the same fix to publish_wasm.yml after extracting the version checking logic into a script.

Other changes:

*  I've also changed the exact checking logic in this PR: it now looks _first_ at the crate Cargo.toml and then checks the workspace only if it sees `package.version.workspace`. This lets the same script apply to checking the symcc version, and it should cleanly generalize to checking the CLI version if that diverges.
* In order to use script on older branches without backporting the script we need to check out the `main` branch. I think that's setup properly.
* I dropped the toml-cli install from crates.io in favor of using the builtin python toml library. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
