### PR TITLE
fix entities validation

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -469,15 +469,14 @@ impl Entities {
     /// Validates the set of entities is well formed and returns it, otherwise returns
     /// an error.
     ///
-    /// If `skip_entities` is true, only collection-level invariants (TC and DAG) are
-    /// checked, assuming individual entities have already been validated.
-    pub fn try_validate(self, skip_entities: bool) -> std::result::Result<Self, EntitiesError> {
+    /// Checks collection-level invariants (TC and DAG) and entity-level validation.
+    pub fn try_validate(self) -> std::result::Result<Self, EntitiesError> {
         enforce_tc_and_dag(&self.entities)?;
-        if !skip_entities {
-            for entity in self.entities.values() {
-                entity.validate()?;
-            }
+
+        for entity in self.entities.values() {
+            entity.validate()?;
         }
+
         Ok(self)
     }
 }
@@ -2850,7 +2849,7 @@ mod entities_validate_test {
             std::iter::empty(),
         );
         let es = make_entities([parent, child]);
-        assert!(es.try_validate(false).is_ok());
+        assert!(es.try_validate().is_ok());
     }
 
     #[test]
@@ -2881,7 +2880,7 @@ mod entities_validate_test {
             ]),
             mode: Mode::default(),
         };
-        assert!(entities.try_validate(false).is_err());
+        assert!(entities.try_validate().is_err());
     }
 }
 

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -163,7 +163,7 @@ impl TryValidate for api::PolicySet {
 impl TryValidate for api::Entities {
     type Err = EntitiesError;
     fn try_validate(self) -> Result<api::Entities, EntitiesError> {
-        Ok(api::Entities(self.0.try_validate(true)?))
+        Ok(api::Entities(self.0.try_validate()?))
     }
 }
 


### PR DESCRIPTION
Some unintended consequence of https://github.com/cedar-policy/cedar/pull/2387 was that individual entities (and their ancestor relationship) wasn't validated for `Entities`. 
Fixes this and removes the option to skip the individual entities, which was an optimization for how the `try_validate` is called during protobuf decoding.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
