### PR TITLE
Fixed output in publish_wasm workflow

### DIFF
--- a/.github/workflows/publish_wasm.yml
+++ b/.github/workflows/publish_wasm.yml
@@ -81,7 +81,7 @@ jobs:
                       const version = tag.replace('v', '');
                       const [major, minor, _] = version.split('.');
                       const releaseBranch = `release/${major}.${minor}.x`;
-                      core.setOutput('branch_name', releaseBranch);
+                      core.setOutput('release_branch', releaseBranch);
 
             # Compute the tag that should be used for the NPM release by comparing the latest NPM release's
             # version against the version to be released by this workflow.


### PR DESCRIPTION
## Description of changes
Fixes incorrect core.setOutput key in publish_wasm.yml. This was the cause of failing publish GHA run: https://github.com/cedar-policy/cedar/actions/runs/28039979304. The key issue caused the default branch to be checked out for cedar-examples instead of the release branch.


## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
