### PR TITLE
Have cedar-wasm package inherit repository information from workspace

### DIFF
--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "cedar-wasm"
 version = "3.4.3"
 edition = "2021"
 rust-version = "1.76.0"  # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
+repository.workspace = true
 description = "Wasm bindings and typescript types for Cedar lib"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description of changes
Have cedar-wasm package inherit repository information from workspace. This is necessary for NPM trusted publishing to work.
See: https://github.com/cedar-policy/cedar/pull/2144

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.