### PR TITLE
Minor TPE docs improvements

### DIFF
--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -399,7 +399,12 @@ impl PartialEntities {
     }
 }
 
-/// A partial version of [`crate::Response`].
+/// A response to a partial authorization request.
+///
+/// Most callers will want to first check if a concrete authorization decision was reached using
+/// [`TpeResponse::decision`] before inspecting the unevaluated policies with
+/// [`TpeResponse::residual_policies`] or resuming evaluation after providing
+/// the missing parts of the request with [`TpeResponse::reauthorize`].
 #[doc = include_str!("../../experimental_warning.md")]
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
@@ -413,7 +418,16 @@ impl<'a> AsRef<tpe::response::Response<'a>> for TpeResponse<'a> {
 }
 
 impl TpeResponse<'_> {
-    /// Attempt to get the authorization decision
+    /// Get the authorization decision, if TPE reached a concrete decision.
+    ///
+    /// This function can return three possible values:
+    /// * `Some(Decision::Allow)`, when there was enough information in the
+    ///    partial request to concretely decide that the request should be allowed.
+    /// * `Some(Decision::Deny)`, when there was enough information to decide
+    ///    that the request should be denied.
+    /// * `None`, when the partial request did _not_ provide enough information to reach an
+    ///    authorization decision. In this case you can use [`TpeResponse::reauthorize`] to provide
+    ///    the missing parts of the request and reach a concrete decision.
     pub fn decision(&self) -> Option<Decision> {
         self.0.decision()
     }
@@ -437,7 +451,7 @@ impl TpeResponse<'_> {
     /// Get the permit policies that did not reach a concrete value or error for the partial request.
     ///
     /// This function only returns the `PolicyId`s for residual policies.
-    /// To access the residual policy conditions, use [`TpeResponse::nontrivial_residual_policies`].
+    /// To access the residual policy conditions, use [`TpeResponse::residual_policies`].
     ///
     /// These policies could be determining policies _if_ the eventual
     /// concrete authorization decision is `Allow` _and_ they are satisfied by
@@ -705,11 +719,11 @@ impl EntityLoader for TestEntityLoader<'_> {
 impl PolicySet {
     /// Perform type-aware partial evaluation on this [`PolicySet`].
     ///
-    /// If successful, the result is a [`TpeResponse`] containing residual
-    /// policies ready for re-authorization. Use [`TpeResponse::residual_policies()`]
-    /// to get the residuals as [`Policy`] objects, then call [`Policy::to_pst()`]
-    /// to convert them to [`crate::pst::Policy`] for structured inspection of the residual
-    /// expression tree.
+    /// If successful, the result is a [`TpeResponse`] containing the authorization decision, if
+    /// one was reached, and residual policies ready for re-authorization. Use [`TpeResponse::decision`]
+    /// to check the decision and [`TpeResponse::residual_policies`] to get the residuals as
+    /// [`Policy`] objects. You can then call [`Policy::to_pst`] to convert them to [`pst::Policy`](crate::pst::Policy)
+    /// for structured inspection of the residual expression tree.
     #[doc = include_str!("../../experimental_warning.md")]
     pub fn tpe<'a>(
         &self,


### PR DESCRIPTION
## Description of changes

Fixes on place where docs referenced deprecated `nontrivial_residual_policies`. Also expands docs on `decision` and top level docs on `TpeResponse` struct

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
