### PR TITLE
Added check that template-linked policy IDs don't collide with template IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 cedar-policy-core = { version = "=4.11.0", path = "../cedar-policy-core", features = ["tolerant-ast", "extended-schema"] }
 cedar-policy-formatter = { version = "=4.11.0", path = "../cedar-policy-formatter", features = ["tolerant-ast"] }
 cedar-policy = { version = "=4.11.0", path = "../cedar-policy", features = ["tolerant-ast"]}
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 itertools = "0.15.0"
 miette = "7.4.0"
 ropey = "1.6.1"

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -115,7 +115,7 @@ impl TryFrom<LiteralPolicySet> for PolicySet {
             let template = link.template().id();
             // Check that template-linked policy IDs do not collide with template IDs.
             // This is enforced when using `ast::policy_set::PolicySet::link` to construct a
-            // policy set incrementally.
+            // policy set incrementally and should also be enforced here.
             if !link.is_static() && templates.contains_key(link_id) {
                 return Err(ReificationError::Linking(LinkingError::PolicyIdConflict {
                     id: link_id.clone(),

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -113,6 +113,14 @@ impl TryFrom<LiteralPolicySet> for PolicySet {
         }
         for (link_id, link) in &links {
             let template = link.template().id();
+            // Check that template-linked policy IDs do not collide with template IDs.
+            // This is enforced when using `ast::policy_set::PolicySet::link` to construct a
+            // policy set incrementally.
+            if !link.is_static() && templates.contains_key(link_id) {
+                return Err(ReificationError::Linking(LinkingError::PolicyIdConflict {
+                    id: link_id.clone(),
+                }));
+            }
             match template_to_links_map.entry(template.clone()) {
                 Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
                 Entry::Vacant(_) => return Err(ReificationError::NoSuchTemplate(template.clone())),
@@ -1421,6 +1429,38 @@ mod policy_set_validate_test {
             Err(PolicySetValidationError::LinkToSlotlessTemplate { link_id, template_id })
                 if link_id == PolicyID::from_string("link1")
                 && template_id == PolicyID::from_string("no_slots")
+        );
+    }
+
+    #[test]
+    fn link_id_conflicts_with_template_id_rejected() {
+        let id = PolicyID::from_string("t");
+        let t = Template::new(
+            id.clone(),
+            None,
+            Annotations::new(),
+            Effect::Permit,
+            PrincipalConstraint::is_eq_slot(),
+            ActionConstraint::Eq(action_euid()),
+            ResourceConstraint::any(),
+            None,
+        );
+        let mut values = HashMap::new();
+        values.insert(
+            SlotId::principal(),
+            EntityUID::with_eid_and_type("User", "alice").unwrap(),
+        );
+        let literal = LiteralPolicySet::new(
+            [(id.clone(), t.clone())],
+            [(
+                id.clone(),
+                LiteralPolicy::template_linked_policy(id.clone(), id, values),
+            )],
+        );
+        assert_matches!(
+            PolicySet::try_from(literal),
+            Err(ReificationError::Linking(LinkingError::PolicyIdConflict { id }))
+                if id == PolicyID::from_string("t")
         );
     }
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,7 +16,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - Fixed `schema_to_json_with_resolved_types` to support converting schemas that use the `Action` entity type as an attribute type.
   Previously this was reported as an error; it now converts to a correct JSON schema. (#2400)
-- Added missing validation check when decoding a protobuf policy set that template-linked policy IDs don't collide with template IDs. (#2441)
+- Added missing validation check when decoding a protobuf policy set that template-linked policy IDs do not collide with template IDs. (#2441)
 
 ### Added
 - Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - Fixed `schema_to_json_with_resolved_types` to support converting schemas that use the `Action` entity type as an attribute type.
   Previously this was reported as an error; it now converts to a correct JSON schema. (#2400)
+- Added missing validation check when decoding a protobuf policy set that template-linked policy IDs don't collide with template IDs. (#2441)
 
 ### Added
 - Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).


### PR DESCRIPTION
## Description of changes
Added check during conversion from `ast::policy_set::LiteralPolicySet` to `ast::policy_set::PolicySet` that template-linked policy IDs don't collide with template IDs.

## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.