### PR TITLE
fix template and link id collisions silently ignored in protobuf

### DIFF
--- a/cedar-policy/protobuf_schema/core.proto
+++ b/cedar-policy/protobuf_schema/core.proto
@@ -32,7 +32,7 @@ message PolicySet {
     repeated TemplateBody templates = 1;
     // All static policies and template-linked policies are included here.
     // Static policies must appear exactly once, and the PolicyID of the static
-    // policy must be the same in this list and the above list.
+    // policy must be the same in this list and the templates list.
     repeated Policy links = 2;
 }
 
@@ -55,16 +55,16 @@ message Policy {
     // ID of the template associated with this policy.
     // For static policies, this is the ID of a zero-slot template.
     string template_id = 1;
-    // ID of this policy itself.
+    // ID of the linked policy.
     // For static policies, this is omitted/ignored; the ID of the policy is the
     // `template_id`.
     optional string link_id = 2;
     // Whether this policy is a static (false) or template-linked (true) policy
     bool is_template_link = 3;
-    // Value of the `?principal` slot.
+    // Value of the `?principal` slot for the linked policy.
     // Omitted/ignored for templates without the `?principal` slot.
     EntityUid principal_euid = 4;
-    // Value of the `?resource` slot.
+    // Value of the `?resource` slot for the linked policy.
     // Omitted/ignored for templates without the `?resource` slot.
     EntityUid resource_euid = 5;
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -486,7 +486,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                     // the policy id is the template id (see protobuf docs)
                     if !link_ids.insert(template_id.clone()) {
                         return Err(ProtobufConversionError::InvalidValue(format!(
-                            "duplicate link id `{template_id}`"
+                            "static policy id `{template_id}` conflicts with link"
                         )));
                     }
                     Ok((template_id, ast::LiteralPolicy::try_from(p)?))
@@ -600,6 +600,23 @@ mod test {
             link_id: None,
             is_template_link: false,
             principal_euid: None,
+            resource_euid: None,
+        }
+    }
+
+    /// A template-linked policy with the given template id and link id.
+    fn template_link(template_id: &str, link_id: &str) -> models::Policy {
+        models::Policy {
+            template_id: template_id.to_string(),
+            link_id: Some(link_id.to_string()),
+            is_template_link: true,
+            principal_euid: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "User".to_string(),
+                    path: vec![],
+                }),
+                eid: "alice".to_string(),
+            }),
             resource_euid: None,
         }
     }
@@ -1123,28 +1140,15 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with link")
         );
     }
 
     #[test]
     fn literal_policy_set_rejects_template_link_id_colliding_with_template_id() {
-        let euid = models::EntityUid {
-            ty: Some(models::Name {
-                id: "User".to_string(),
-                path: vec![],
-            }),
-            eid: "alice".to_string(),
-        };
         let bad = models::PolicySet {
             templates: vec![trivial_template_body("shared_id")],
-            links: vec![models::Policy {
-                template_id: "shared_id".to_string(),
-                link_id: Some("shared_id".to_string()),
-                is_template_link: true,
-                principal_euid: Some(euid),
-                resource_euid: None,
-            }],
+            links: vec![template_link("shared_id", "shared_id")],
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
@@ -1173,6 +1177,35 @@ mod test {
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("non-existent template")
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_duplicate_template_link_ids() {
+        let bad = models::PolicySet {
+            templates: vec![trivial_template_body("t")],
+            links: vec![
+                template_link("t", "same_link"),
+                template_link("t", "same_link"),
+            ],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_template_link_id_colliding_with_static_policy() {
+        // Static policy "X" is processed first (link_ids gets "X"),
+        // then a template-link with link_id "X" should fail.
+        let bad = models::PolicySet {
+            templates: vec![trivial_template_body("X"), trivial_template_body("T")],
+            links: vec![static_policy_link("X"), template_link("T", "X")],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
         );
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -437,7 +437,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
         let mut template_ids: HashSet<ast::PolicyID> = HashSet::new();
         let mut link_ids: HashSet<ast::PolicyID> = HashSet::new();
 
-        let templates = v
+        let templates_and_static_policies = v
             .templates
             .into_iter()
             .map(|tb| {
@@ -457,30 +457,44 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
             .map(|p| {
                 // per docs in core.proto, for static policies, `link_id` is omitted/ignored,
                 // and the ID of the policy is the `template_id`.
-                let id = if p.is_template_link {
-                    p.link_id
+                let template_id = ast::PolicyID::from_string(&p.template_id);
+                if !template_ids.contains(&template_id) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "link references non-existent template or policy `{template_id}`"
+                    )));
+                }
+                if p.is_template_link {
+                    let link_id = p
+                        .link_id
                         .as_ref()
-                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?
+                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?;
+                    let link_id = ast::PolicyID::from_string(link_id);
+                    if !link_ids.insert(link_id.clone()) {
+                        return Err(ProtobufConversionError::InvalidValue(format!(
+                            "duplicate link id `{link_id}`"
+                        )));
+                    }
+                    // Template ids and link ids must not conflict!
+                    if template_ids.contains(&link_id) {
+                        return Err(ProtobufConversionError::InvalidValue(format!(
+                            "link id `{link_id}` conflicts with a template id"
+                        )));
+                    }
+                    // the linked policy id is the link id
+                    Ok((link_id, ast::LiteralPolicy::try_from(p)?))
                 } else {
-                    &p.template_id
-                };
-                let id = ast::PolicyID::from_string(id);
-                if !link_ids.insert(id.clone()) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "duplicate link id `{id}`"
-                    )));
+                    // the policy id is the template id (see protobuf docs)
+                    if !link_ids.insert(template_id.clone()) {
+                        return Err(ProtobufConversionError::InvalidValue(format!(
+                            "duplicate link id `{template_id}`"
+                        )));
+                    }
+                    Ok((template_id, ast::LiteralPolicy::try_from(p)?))
                 }
-                // Template ids and links ids must not conflict!
-                if p.is_template_link && template_ids.contains(&id) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "link id `{id}` conflicts with a template id"
-                    )));
-                }
-                Ok((id, ast::LiteralPolicy::try_from(p)?))
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
-        Ok(Self::new(templates, links))
+        Ok(Self::new(templates_and_static_policies, links))
     }
 }
 
@@ -1101,7 +1115,7 @@ mod test {
     #[test]
     fn literal_policy_set_rejects_duplicate_link_ids() {
         let bad = models::PolicySet {
-            templates: vec![],
+            templates: vec![trivial_template_body("duplicate")],
             links: vec![
                 static_policy_link("duplicate"),
                 static_policy_link("duplicate"),
@@ -1148,5 +1162,17 @@ mod test {
         // This should succeed — static policies legitimately share an ID
         // between their template entry and link entry
         assert_matches!(ast::LiteralPolicySet::try_from(pset), Ok(_));
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_link_referencing_nonexistent_template() {
+        let bad = models::PolicySet {
+            templates: vec![trivial_template_body("real_template")],
+            links: vec![static_policy_link("nonexistent")],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("non-existent template")
+        );
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -444,7 +444,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                 let id = ast::PolicyID::from_string(&tb.id);
                 if !template_ids.insert(id.clone()) {
                     return Err(ProtobufConversionError::InvalidValue(format!(
-                        "duplicate template id `{id}`"
+                        "duplicate template_id `{id}` in `templates`"
                     )));
                 }
                 Ok((id, ast::Template::from(ast::TemplateBody::try_from(tb)?)))
@@ -460,7 +460,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                 let template_id = ast::PolicyID::from_string(&p.template_id);
                 if !template_ids.contains(&template_id) {
                     return Err(ProtobufConversionError::InvalidValue(format!(
-                        "link references non-existent template or policy `{template_id}`"
+                        "template_id `{template_id}` of link references non-existent template of `templates`"
                     )));
                 }
                 if p.is_template_link {
@@ -471,13 +471,13 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                     let link_id = ast::PolicyID::from_string(link_id);
                     if !link_ids.insert(link_id.clone()) {
                         return Err(ProtobufConversionError::InvalidValue(format!(
-                            "duplicate link id `{link_id}`"
+                            "link_id `{link_id}` conflicts with a policy id (link_id or template_id) in `links`"
                         )));
                     }
                     // Template ids and link ids must not conflict!
                     if template_ids.contains(&link_id) {
                         return Err(ProtobufConversionError::InvalidValue(format!(
-                            "link id `{link_id}` conflicts with a template id"
+                            "link_id `{link_id}` conflicts with a template_id in `templates`"
                         )));
                     }
                     // the linked policy id is the link id
@@ -486,7 +486,7 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                     // the policy id is the template id (see protobuf docs)
                     if !link_ids.insert(template_id.clone()) {
                         return Err(ProtobufConversionError::InvalidValue(format!(
-                            "static policy id `{template_id}` conflicts with link"
+                            "template_id `{template_id}` of a static link conflicts with a policy id (link_id or template_id) in `links`"
                         )));
                     }
                     Ok((template_id, ast::LiteralPolicy::try_from(p)?))
@@ -1125,7 +1125,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate template id")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate template_id")
         );
     }
 
@@ -1140,7 +1140,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with link")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }
 
@@ -1152,7 +1152,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template id")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template_id")
         );
     }
 
@@ -1176,7 +1176,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("non-existent template")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("references non-existent template")
         );
     }
 
@@ -1191,7 +1191,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }
 
@@ -1205,7 +1205,7 @@ mod test {
         };
         assert_matches!(
             ast::LiteralPolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -19,7 +19,7 @@
 use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::{ast, FromNormalizedStr};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 impl TryFrom<models::Policy> for ast::LiteralPolicy {
     type Error = ProtobufConversionError;
@@ -434,11 +434,19 @@ impl From<&ast::Effect> for models::Effect {
 impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
     type Error = ProtobufConversionError;
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
+        let mut template_ids: HashSet<ast::PolicyID> = HashSet::new();
+        let mut link_ids: HashSet<ast::PolicyID> = HashSet::new();
+
         let templates = v
             .templates
             .into_iter()
             .map(|tb| {
                 let id = ast::PolicyID::from_string(&tb.id);
+                if !template_ids.insert(id.clone()) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "duplicate template id `{id}`"
+                    )));
+                }
                 Ok((id, ast::Template::from(ast::TemplateBody::try_from(tb)?)))
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
@@ -457,6 +465,17 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
                     &p.template_id
                 };
                 let id = ast::PolicyID::from_string(id);
+                if !link_ids.insert(id.clone()) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "duplicate link id `{id}`"
+                    )));
+                }
+                // Template ids and links ids must not conflict!
+                if p.is_template_link && template_ids.contains(&id) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "link id `{id}` conflicts with a template id"
+                    )));
+                }
                 Ok((id, ast::LiteralPolicy::try_from(p)?))
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
@@ -526,6 +545,48 @@ mod test {
             // `Ord` contract because there could exist two template-bodies that
             // return `Ordering::Equal` but are not equal with `Eq`
             self.id.cmp(&other.id)
+        }
+    }
+
+    /// A `PrincipalOrResourceConstraint` model matching any principal/resource.
+    fn principal_or_resource_constraint_any() -> models::PrincipalOrResourceConstraint {
+        models::PrincipalOrResourceConstraint {
+            data: Some(models::principal_or_resource_constraint::Data::Any(
+                models::principal_or_resource_constraint::Any::Unit.into(),
+            )),
+        }
+    }
+
+    /// An `ActionConstraint` model matching any action.
+    fn action_constraint_any() -> models::ActionConstraint {
+        models::ActionConstraint {
+            data: Some(models::action_constraint::Data::Any(
+                models::action_constraint::Any::Unit.into(),
+            )),
+        }
+    }
+
+    /// A minimal `TemplateBody` model with the given id and unconstrained scope.
+    fn trivial_template_body(id: &str) -> models::TemplateBody {
+        models::TemplateBody {
+            id: id.to_string(),
+            annotations: Default::default(),
+            effect: models::Effect::Permit.into(),
+            principal_constraint: Some(principal_or_resource_constraint_any()),
+            action_constraint: Some(action_constraint_any()),
+            resource_constraint: Some(principal_or_resource_constraint_any()),
+            non_scope_constraints: None,
+        }
+    }
+
+    /// A static policy link (not a template-linked policy) with the given id.
+    fn static_policy_link(id: &str) -> models::Policy {
+        models::Policy {
+            template_id: id.to_string(),
+            link_id: None,
+            is_template_link: false,
+            principal_euid: None,
+            resource_euid: None,
         }
     }
 
@@ -869,16 +930,8 @@ mod test {
             annotations: Default::default(),
             effect: models::Effect::Permit.into(),
             principal_constraint: None,
-            action_constraint: Some(models::ActionConstraint {
-                data: Some(models::action_constraint::Data::Any(
-                    models::action_constraint::Any::Unit.into(),
-                )),
-            }),
-            resource_constraint: Some(models::PrincipalOrResourceConstraint {
-                data: Some(models::principal_or_resource_constraint::Data::Any(
-                    models::principal_or_resource_constraint::Any::Unit.into(),
-                )),
-            }),
+            action_constraint: Some(action_constraint_any()),
+            resource_constraint: Some(principal_or_resource_constraint_any()),
             non_scope_constraints: None,
         };
         assert_matches!(
@@ -893,21 +946,9 @@ mod test {
             id: "t".to_string(),
             annotations: [("".to_string(), "v".to_string())].into_iter().collect(),
             effect: models::Effect::Permit.into(),
-            principal_constraint: Some(models::PrincipalOrResourceConstraint {
-                data: Some(models::principal_or_resource_constraint::Data::Any(
-                    models::principal_or_resource_constraint::Any::Unit.into(),
-                )),
-            }),
-            action_constraint: Some(models::ActionConstraint {
-                data: Some(models::action_constraint::Data::Any(
-                    models::action_constraint::Any::Unit.into(),
-                )),
-            }),
-            resource_constraint: Some(models::PrincipalOrResourceConstraint {
-                data: Some(models::principal_or_resource_constraint::Data::Any(
-                    models::principal_or_resource_constraint::Any::Unit.into(),
-                )),
-            }),
+            principal_constraint: Some(principal_or_resource_constraint_any()),
+            action_constraint: Some(action_constraint_any()),
+            resource_constraint: Some(principal_or_resource_constraint_any()),
             non_scope_constraints: None,
         };
         assert_matches!(
@@ -1029,27 +1070,7 @@ mod test {
     #[test]
     fn literal_policy_set_try_from_link_missing_link_id() {
         let bad = models::PolicySet {
-            templates: vec![models::TemplateBody {
-                id: "t".to_string(),
-                annotations: Default::default(),
-                effect: models::Effect::Permit.into(),
-                principal_constraint: Some(models::PrincipalOrResourceConstraint {
-                    data: Some(models::principal_or_resource_constraint::Data::Any(
-                        models::principal_or_resource_constraint::Any::Unit.into(),
-                    )),
-                }),
-                action_constraint: Some(models::ActionConstraint {
-                    data: Some(models::action_constraint::Data::Any(
-                        models::action_constraint::Any::Unit.into(),
-                    )),
-                }),
-                resource_constraint: Some(models::PrincipalOrResourceConstraint {
-                    data: Some(models::principal_or_resource_constraint::Data::Any(
-                        models::principal_or_resource_constraint::Any::Unit.into(),
-                    )),
-                }),
-                non_scope_constraints: None,
-            }],
+            templates: vec![trivial_template_body("t")],
             links: vec![models::Policy {
                 template_id: "t".to_string(),
                 link_id: None,
@@ -1062,5 +1083,70 @@ mod test {
             ast::LiteralPolicySet::try_from(bad),
             Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
         );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_duplicate_template_ids() {
+        let template = trivial_template_body("duplicate");
+        let bad = models::PolicySet {
+            templates: vec![template.clone(), template], // twice!
+            links: vec![],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate template id")
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_duplicate_link_ids() {
+        let bad = models::PolicySet {
+            templates: vec![],
+            links: vec![
+                static_policy_link("duplicate"),
+                static_policy_link("duplicate"),
+            ],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate link id")
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_template_link_id_colliding_with_template_id() {
+        let euid = models::EntityUid {
+            ty: Some(models::Name {
+                id: "User".to_string(),
+                path: vec![],
+            }),
+            eid: "alice".to_string(),
+        };
+        let bad = models::PolicySet {
+            templates: vec![trivial_template_body("shared_id")],
+            links: vec![models::Policy {
+                template_id: "shared_id".to_string(),
+                link_id: Some("shared_id".to_string()),
+                is_template_link: true,
+                principal_euid: Some(euid),
+                resource_euid: None,
+            }],
+        };
+        assert_matches!(
+            ast::LiteralPolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template id")
+        );
+    }
+
+    #[test]
+    fn literal_policy_set_allows_static_policy_sharing_template_and_link_id() {
+        // Static policies are expected to have the same ID in both templates and links
+        let pset = models::PolicySet {
+            templates: vec![trivial_template_body("static_policy")],
+            links: vec![static_policy_link("static_policy")],
+        };
+        // This should succeed — static policies legitimately share an ID
+        // between their template entry and link entry
+        assert_matches!(ast::LiteralPolicySet::try_from(pset), Ok(_));
     }
 }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -332,8 +332,6 @@ impl From<&types::AttributeType> for models::AttributeType {
 mod test {
     use std::sync::Arc;
 
-    use crate::Schema;
-
     use super::models;
     use super::ProtobufConversionError;
     use cedar_policy_core::validator::types::{


### PR DESCRIPTION
Fixes silent dropping of duplicate link id / template id when converting from `proto::model::PolicySet` to `ast::LiteralPolicySet`. 
Also:
- refactors the checks to have the separate branch on whether it's a static policy or true template link at the top,
- adds checks that referenced policies exists (I think this would be caught downstream)
- some rewording of the protobuf doc for clarity.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
