### PR TITLE
Fix PolicySet::from_pst allowing mismatched key/id

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,6 +17,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Fixed `schema_to_json_with_resolved_types` to support converting schemas that use the `Action` entity type as an attribute type.
   Previously this was reported as an error; it now converts to a correct JSON schema. (#2400)
 - Added missing validation check when decoding a protobuf policy set that template-linked policy IDs do not collide with template IDs. (#2441)
+- `PolicySet::from_pst` now returns an error if a map key doesn't match the id of its corresponding template or policy, instead of silently accepting the malformed input (#2444).
 
 ### Added
 - Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2652,6 +2652,13 @@ impl PolicySet {
     pub fn from_pst(pst_set: pst::PolicySet) -> Result<Self, PolicySetError> {
         let mut set = Self::new();
         for (id, template) in pst_set.templates {
+            if id != template.id {
+                return Err(policy_set_errors::InconsistentPolicyId {
+                    map_key: id.into(),
+                    inner_id: template.id.into(),
+                }
+                .into());
+            }
             let ast_template: ast::Template = template.clone().try_into()?;
             set.ast.add_template(ast_template.clone())?;
             set.templates.insert(
@@ -2663,6 +2670,13 @@ impl PolicySet {
             );
         }
         for (id, static_policy) in pst_set.policies {
+            if &id != static_policy.id() {
+                return Err(policy_set_errors::InconsistentPolicyId {
+                    map_key: id.into(),
+                    inner_id: static_policy.id().clone().into(),
+                }
+                .into());
+            }
             let pst_policy = pst::Policy::Static(static_policy);
             let ast_policy: ast::Policy = pst_policy.clone().try_into()?;
             set.ast.add(ast_policy.clone())?;

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -810,6 +810,29 @@ pub mod policy_set_errors {
         #[from]
         pub(crate) inner: serde_json::Error,
     }
+
+    /// Error when a PST `PolicySet` map key doesn't match the inner
+    /// template/policy id
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(
+        "policy set map key `{map_key}` does not match the inner policy/template id `{inner_id}`"
+    )]
+    pub struct InconsistentPolicyId {
+        pub(crate) map_key: PolicyId,
+        pub(crate) inner_id: PolicyId,
+    }
+
+    impl InconsistentPolicyId {
+        /// Get the map key that was used in the PST `PolicySet`
+        pub fn map_key(&self) -> &PolicyId {
+            &self.map_key
+        }
+
+        /// Get the inner id from the template/policy
+        pub fn inner_id(&self) -> &PolicyId {
+            &self.inner_id
+        }
+    }
 }
 
 /// Potential errors when adding to a `PolicySet`.
@@ -873,6 +896,11 @@ pub enum PolicySetError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     PstConversion(#[from] pst::PstConstructionError),
+    /// Error when a PST `PolicySet` map key doesn't match the inner
+    /// template/policy id
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InconsistentPolicyId(#[from] policy_set_errors::InconsistentPolicyId),
 }
 
 #[doc(hidden)]

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -10651,18 +10651,23 @@ mod pst_api {
             pst::ResourceConstraint::Any,
             vec![],
         );
+        let inner_key = t.id.clone();
+        let outer_key = pst::PolicyID("fake_key".into());
         let mut templates = LinkedHashMap::new();
-        templates.insert(pst::PolicyID("fake_key".into()), t);
+        templates.insert(outer_key.clone(), t);
         let pst_set = pst::PolicySet {
             templates,
             policies: LinkedHashMap::new(),
             template_links: vec![],
         };
         let err = PolicySet::from_pst(pst_set).unwrap_err();
-        assert!(
-            matches!(err, PolicySetError::InconsistentPolicyId(_)),
-            "expected InconsistentPolicyId, got: {err}"
-        );
+        match &err {
+            PolicySetError::InconsistentPolicyId(e) => {
+                assert_eq!(e.map_key().to_string(), outer_key.to_string());
+                assert_eq!(e.inner_id().to_string(), inner_key.to_string());
+            }
+            _ => panic!("expected InconsistentPolicyId, got: {err}"),
+        }
         assert!(
             err.to_string().contains("fake_key"),
             "error should mention the map key: {err}"
@@ -10688,17 +10693,22 @@ mod pst_api {
         ))
         .unwrap();
         let mut policies = LinkedHashMap::new();
-        policies.insert(pst::PolicyID("outer_key".into()), sp);
+        let inner_key = sp.id().clone();
+        let outer_key = pst::PolicyID("outer_key".into());
+        policies.insert(outer_key.clone(), sp);
         let pst_set = pst::PolicySet {
             templates: LinkedHashMap::new(),
             policies,
             template_links: vec![],
         };
         let err = PolicySet::from_pst(pst_set).unwrap_err();
-        assert!(
-            matches!(err, PolicySetError::InconsistentPolicyId(_)),
-            "expected InconsistentPolicyId, got: {err}"
-        );
+        match &err {
+            PolicySetError::InconsistentPolicyId(e) => {
+                assert_eq!(e.map_key().to_string(), outer_key.to_string());
+                assert_eq!(e.inner_id().to_string(), inner_key.to_string());
+            }
+            _ => panic!("expected InconsistentPolicyId, got: {err}"),
+        }
         assert!(
             err.to_string().contains("outer_key"),
             "error should mention the map key: {err}"

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -10638,6 +10638,77 @@ mod pst_api {
         );
     }
 
+    // --- PolicySet from_pst error: template map key != inner id ---
+
+    #[test]
+    fn policy_set_from_pst_inconsistent_template_id() {
+        use linked_hash_map::LinkedHashMap;
+        let t = slotted_template(
+            "real_id",
+            pst::Effect::Permit,
+            pst::PrincipalConstraint::Eq(pst::EntityOrSlot::Slot(pst::SlotId::Principal)),
+            pst::ActionConstraint::Any,
+            pst::ResourceConstraint::Any,
+            vec![],
+        );
+        let mut templates = LinkedHashMap::new();
+        templates.insert(pst::PolicyID("fake_key".into()), t);
+        let pst_set = pst::PolicySet {
+            templates,
+            policies: LinkedHashMap::new(),
+            template_links: vec![],
+        };
+        let err = PolicySet::from_pst(pst_set).unwrap_err();
+        assert!(
+            matches!(err, PolicySetError::InconsistentPolicyId(_)),
+            "expected InconsistentPolicyId, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("fake_key"),
+            "error should mention the map key: {err}"
+        );
+        assert!(
+            err.to_string().contains("real_id"),
+            "error should mention the inner id: {err}"
+        );
+    }
+
+    // --- PolicySet from_pst error: policy map key != inner id ---
+
+    #[test]
+    fn policy_set_from_pst_inconsistent_policy_id() {
+        use linked_hash_map::LinkedHashMap;
+        let sp = pst::StaticPolicy::try_from(static_template(
+            "inner_id",
+            pst::Effect::Forbid,
+            pst::PrincipalConstraint::Any,
+            pst::ActionConstraint::Any,
+            pst::ResourceConstraint::Any,
+            vec![],
+        ))
+        .unwrap();
+        let mut policies = LinkedHashMap::new();
+        policies.insert(pst::PolicyID("outer_key".into()), sp);
+        let pst_set = pst::PolicySet {
+            templates: LinkedHashMap::new(),
+            policies,
+            template_links: vec![],
+        };
+        let err = PolicySet::from_pst(pst_set).unwrap_err();
+        assert!(
+            matches!(err, PolicySetError::InconsistentPolicyId(_)),
+            "expected InconsistentPolicyId, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("outer_key"),
+            "error should mention the map key: {err}"
+        );
+        assert!(
+            err.to_string().contains("inner_id"),
+            "error should mention the inner id: {err}"
+        );
+    }
+
     // --- PolicySet from_pst error: link references nonexistent template ---
 
     #[test]


### PR DESCRIPTION
Makes `PolicySet::from_pst` more strict by rejecting malformed inputs on map from policy ids to template.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
