### PR TITLE
clippy warning cleanup in core and api crates

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -165,6 +165,13 @@ impl Clause {
 impl TryFrom<cst::Policy> for Policy {
     type Error = ParseErrors;
     fn try_from(policy: cst::Policy) -> Result<Policy, ParseErrors> {
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destrcutring match when `tolerant-ast` is enabled"
+            )
+        )]
         let policy = match policy {
             cst::Policy::Policy(policy_impl) => policy_impl,
             #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -256,6 +256,13 @@ impl Node<Option<cst::Policy>> {
     /// well, which will become templates with 0 slots
     pub fn to_policy_template(&self, id: ast::PolicyID) -> Result<ast::Template> {
         let policy = self.try_as_inner()?;
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destructuring match when `tolerant-ast` is enabled"
+            )
+        )]
         let policy = match policy {
             cst::Policy::Policy(policy_impl) => policy_impl,
             #[cfg(feature = "tolerant-ast")]
@@ -1277,6 +1284,13 @@ impl Node<Option<cst::Expr>> {
     ) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let expr_opt = self.try_as_inner()?;
 
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destructuring match when `tolerant-ast` is enabled"
+            )
+        )]
         let expr = match expr_opt {
             cst::Expr::Expr(expr_impl) => expr_impl,
             #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -202,6 +202,13 @@ impl Node<Option<cst::Expr>> {
     ) -> Result<T> {
         let expr_opt = self.try_as_inner()?;
 
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destructuring match when `tolerant-ast` is enabled"
+            )
+        )]
         let expr = match expr_opt {
             cst::Expr::Expr(expr_impl) => expr_impl,
             #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -58,6 +58,13 @@ impl fmt::Display for Policies {
 }
 impl fmt::Display for Policy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destrucuring match when `toleran-ast` is enabled"
+            )
+        )]
         let policy = match self {
             Policy::Policy(p) => p,
             #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -106,7 +106,7 @@ where
     if enforce_dag {
         // TC is correct by construction (same as compute_tc). Only need to
         // check for self-loops, and only on nodes whose edges were modified.
-        return enforce_dag_from_tc_for(&nodes_to_fix, nodes);
+        return enforce_dag_from_tc_for(nodes_to_fix, nodes);
     }
     Ok(())
 }

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -161,6 +161,13 @@ impl LocatedType {
     /// Replace `self.loc` with `loc`. No-op if the `extended-schema` feature is
     /// not enabled.
     pub fn with_loc(self, _loc: Option<&Loc>) -> Self {
+        #[cfg_attr(
+            not(feature = "extended-schema"),
+            expect(
+                clippy::unnecessary_struct_initialization,
+                reason = "changes loc when extended-schema is enabled"
+            )
+        )]
         Self {
             #[cfg(feature = "extended-schema")]
             loc: _loc.cloned(),

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -873,6 +873,13 @@ impl Doc for Node<Option<Ident>> {
 impl Doc for Node<Option<Policy>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let policy = self.as_inner()?;
+        #[cfg_attr(
+            not(feature = "tolerant-ast"),
+            expect(
+                clippy::infallible_destructuring_match,
+                reason = "this is not a destructuring match when `tolerant-ast` is enabled"
+            )
+        )]
         let policy = match policy {
             Policy::Policy(policy_impl) => policy_impl,
             #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -133,7 +133,7 @@ impl traits::Protobuf for api::Entities {
             msg,
             cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
         )?;
-        Ok(api::Entities(core_entities))
+        Ok(Self(core_entities))
     }
 }
 

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -54,6 +54,11 @@ pub trait TryValidate: Sized {
     /// The type of errors returned by the validation method.
     type Err: Display;
     /// A validation method that returns the object itself, or an error if it is invalid.
+    ///
+    /// # Errors
+    ///
+    /// Will return errors when the implementing structure is invalid, according to its own
+    ///  invariants.
     fn try_validate(self) -> Result<Self, Self::Err>;
 }
 
@@ -152,35 +157,35 @@ pub(crate) fn try_decode<
 impl TryValidate for api::PolicySet {
     type Err = PolicySetValidationError;
     fn try_validate(self) -> Result<Self, Self::Err> {
-        self.ast.try_validate().map(|o| o.into())
+        self.ast.try_validate().map(Into::into)
     }
 }
 
 impl TryValidate for api::Entities {
     type Err = EntitiesError;
-    fn try_validate(self) -> Result<api::Entities, EntitiesError> {
-        Ok(api::Entities(self.0.try_validate()?))
+    fn try_validate(self) -> Result<Self, EntitiesError> {
+        Ok(Self(self.0.try_validate()?))
     }
 }
 
 impl TryValidate for api::Entity {
     type Err = EntitiesError;
-    fn try_validate(self) -> Result<api::Entity, EntitiesError> {
-        Ok(api::Entity(self.0.try_validate()?))
+    fn try_validate(self) -> Result<Self, EntitiesError> {
+        Ok(Self(self.0.try_validate()?))
     }
 }
 
 impl TryValidate for api::Schema {
     type Err = SchemaError;
     fn try_validate(self) -> Result<Self, SchemaError> {
-        Ok(api::Schema(self.0.try_validate()?))
+        Ok(Self(self.0.try_validate()?))
     }
 }
 
 impl TryValidate for api::Template {
     type Err = TemplateValidationError;
     fn try_validate(self) -> Result<Self, TemplateValidationError> {
-        Ok(api::Template {
+        Ok(Self {
             ast: self.ast.try_validate()?,
             ..self
         })
@@ -190,7 +195,7 @@ impl TryValidate for api::Template {
 impl TryValidate for api::Expression {
     type Err = ExprValidationError;
     fn try_validate(self) -> Result<Self, ExprValidationError> {
-        Ok(api::Expression(self.0.try_validate()?))
+        Ok(Self(self.0.try_validate()?))
     }
 }
 

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -192,13 +192,11 @@ impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEnti
                 // enumerated entity types must have no attributes or tags.
                 if !v.attributes.is_empty() {
                     Err(ProtobufConversionError::InvalidValue(format!(
-                        "enum type {} should not have attributes",
-                        name
+                        "enum type {name} should not have attributes"
                     )))
                 } else if v.tags.is_some() {
                     Err(ProtobufConversionError::InvalidValue(format!(
-                        "enum type {} should not have tags",
-                        name
+                        "enum type {name} should not have tags"
                     )))
                 } else {
                     Ok(Self::new_enum(


### PR DESCRIPTION
`cargo clippy` and `cargo clippy --all-features` run warning-free on `cedar-policy` and `cedar-policy-core`.
Actual clippy-satisfying code changes are in the proto feature only.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
