### PR TITLE
fix try_validate bug where tc constructed after check_hierarchy_wf

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1228,7 +1228,6 @@ impl ValidatorSchema {
     // simpler checks tailored to that representation (and also cover tags,
     // which `check_for_undeclared` does not inspect).
     pub fn try_validate(mut self) -> std::result::Result<Self, SchemaError> {
-        self.check_hierarchy_wf()?;
         self.check_references_wf()?;
         self.check_extension_types_wf()?;
         self.check_decls_wf()?;
@@ -1237,6 +1236,9 @@ impl ValidatorSchema {
         compute_tc(&mut self.entity_types, false)
             .map_err(|e| EntityTypeTransitiveClosureError::from(Box::new(e)))?;
         compute_tc(&mut self.action_ids, true)?;
+        // Check hierarchy well-formedness AFTER transitive closure so that
+        // transitive descendants are included in the enum-in-hierarchy check.
+        self.check_hierarchy_wf()?;
         self.actions = Self::action_entities_iter(&self.action_ids)
             .map(|e| (e.uid().clone(), Arc::new(e)))
             .collect();
@@ -2311,6 +2313,51 @@ pub(crate) mod test {
         assert_matches!(
             schema.try_validate(),
             Err(SchemaError::ActionEntityTypeDeclared(_))
+        );
+    }
+
+    /// Regression test: enum entity types reachable only via transitive
+    /// descendants (A -> B -> EnumC) must be rejected by `try_validate`.
+    /// Before the fix, `check_hierarchy_wf` ran before `compute_tc`, so it
+    /// only saw direct descendants and missed transitive enum descendants.
+    #[test]
+    fn try_validate_rejects_transitive_enum_descendant() {
+        use crate::ast::Eid;
+
+        // Set up: A has direct descendant B, B has direct descendant EnumC.
+        // After TC, A should transitively have EnumC as a descendant.
+        let type_a = EntityType::from_normalized_str("A").unwrap();
+        let type_b = EntityType::from_normalized_str("B").unwrap();
+        let type_enum_c = EntityType::from_normalized_str("EnumC").unwrap();
+
+        let entity_a = ValidatorEntityType::new_standard(
+            type_a,
+            [type_b.clone()], // direct descendant: B only
+            Attributes::with_attributes([]),
+            OpenTag::ClosedAttributes,
+            None,
+            None,
+        );
+        let entity_b = ValidatorEntityType::new_standard(
+            type_b,
+            [type_enum_c.clone()], // direct descendant: EnumC
+            Attributes::with_attributes([]),
+            OpenTag::ClosedAttributes,
+            None,
+            None,
+        );
+        let entity_enum_c = ValidatorEntityType::new_enum(
+            type_enum_c.clone(),
+            [],
+            NonEmpty::new(Eid::new("val1")),
+            None,
+        );
+
+        let schema = ValidatorSchema::new([entity_a, entity_b, entity_enum_c], []);
+
+        assert_matches!(
+            schema.try_validate(),
+            Err(SchemaError::EnumEntityInHierarchy(_))
         );
     }
 


### PR DESCRIPTION
Small fix in the `try_validate` method of `ValidatorSchema` reordering the "well-formed hierarchy" and transitive closure computation order so that hierarchy is complete when checking well formedness.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
