### PR TITLE
add validation of template maps in LiteralPolicySet conversion

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -854,6 +854,14 @@ pub enum ReificationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Linking(#[from] LinkingError),
+    /// The outer map key does not match the policy's own ID
+    #[error("policy set map key `{key}` does not match the policy's own id `{policy_id}`")]
+    PolicyIdMismatch {
+        /// The outer map key used in `LiteralPolicySet.links`
+        key: PolicyID,
+        /// The policy's own ID (from `LiteralPolicy::id()`)
+        policy_id: PolicyID,
+    },
 }
 
 impl LiteralPolicy {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -104,7 +104,15 @@ impl TryFrom<LiteralPolicySet> for PolicySet {
         let links = pset
             .links
             .into_iter()
-            .map(|(id, literal)| literal.reify(&templates).map(|linked| (id, linked)))
+            .map(|(id, literal)| {
+                if *literal.id() != id {
+                    return Err(ReificationError::PolicyIdMismatch {
+                        key: id,
+                        policy_id: literal.id().clone(),
+                    });
+                }
+                literal.reify(&templates).map(|linked| (id, linked))
+            })
             .collect::<Result<LinkedHashMap<PolicyID, Policy>, ReificationError>>()?;
 
         let mut template_to_links_map = LinkedHashMap::new();
@@ -1461,6 +1469,57 @@ mod policy_set_validate_test {
             PolicySet::try_from(literal),
             Err(ReificationError::Linking(LinkingError::PolicyIdConflict { id }))
                 if id == PolicyID::from_string("t")
+        );
+    }
+
+    #[test]
+    fn outer_key_mismatch_static_policy_rejected() {
+        let t = valid_template("policy1");
+        let literal = LiteralPolicySet::new(
+            [(t.id().clone(), t)],
+            [(
+                PolicyID::from_string("wrong_key"),
+                LiteralPolicy::static_policy(PolicyID::from_string("policy1")),
+            )],
+        );
+        assert_matches!(
+            PolicySet::try_from(literal),
+            Err(ReificationError::PolicyIdMismatch { key, policy_id })
+                if key == PolicyID::from_string("wrong_key")
+                && policy_id == PolicyID::from_string("policy1")
+        );
+    }
+
+    #[test]
+    fn outer_key_mismatch_linked_policy_rejected() {
+        let id = PolicyID::from_string("t");
+        let t = Template::new(
+            id.clone(),
+            None,
+            Annotations::new(),
+            Effect::Permit,
+            PrincipalConstraint::is_eq_slot(),
+            ActionConstraint::Eq(action_euid()),
+            ResourceConstraint::any(),
+            None,
+        );
+        let mut values = HashMap::new();
+        values.insert(
+            SlotId::principal(),
+            EntityUID::with_eid_and_type("User", "alice").unwrap(),
+        );
+        let literal = LiteralPolicySet::new(
+            [(id.clone(), t)],
+            [(
+                PolicyID::from_string("wrong_key"),
+                LiteralPolicy::template_linked_policy(id, PolicyID::from_string("link1"), values),
+            )],
+        );
+        assert_matches!(
+            PolicySet::try_from(literal),
+            Err(ReificationError::PolicyIdMismatch { key, policy_id })
+                if key == PolicyID::from_string("wrong_key")
+                && policy_id == PolicyID::from_string("link1")
         );
     }
 }


### PR DESCRIPTION
Adds a check that the ids in template maps are consistent in LiteralPolicySet conversion, similar to https://github.com/cedar-policy/cedar/pull/2444 which deals with PST. 

This is only an internal conversion reachable from protobuf decoding, and there is no bug reachable from that path (given the map construction). This is only adding validation in case we start using LiteralPolicySet somewhere else. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
