### PR TITLE
Rewrite TPE evaluator tests to use `insta` inline snapshots

### DIFF
--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -23,6 +23,9 @@ pub mod request;
 pub mod residual;
 pub mod response;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 use std::{collections::HashMap, sync::Arc};
 
 use crate::ast::PolicyID;

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -728,12 +728,12 @@ mod tests {
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
-        // principal -> principal because its eid is unknown
+        // principal -> User::"foo"
         assert_snapshot!(
             interpret_typed_str_to_str("principal"),
             @r#"User::"foo""#
         );
-        // resource -> E::""
+        // resource -> resource because its eid is unknown
         assert_snapshot!(
             interpret_typed_str_to_str("resource"),
             @"resource"

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -644,61 +644,99 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashSet};
+    use std::str::FromStr;
 
-    use crate::ast::{Expr, SlotEnv, UnwrapInfallible};
+    use crate::ast::{Expr, SlotEnv};
+    use crate::parser::parse_expr;
     use crate::tpe::err::ExprToResidualError;
+    use crate::validator::typecheck::Typechecker;
     use crate::validator::types::Type;
+    use crate::validator::{ValidationMode, ValidatorSchema};
     use crate::{
-        ast::{
-            BinaryOp, Eid, EntityUID, ExprBuilder, Literal, Pattern, PatternElem, UnaryOp, Value,
-            ValueKind, Var,
-        },
+        ast::{EntityUID, ExprBuilder, Value, Var},
         expr_builder::ExprBuilder as _,
         extensions::Extensions,
-        FromNormalizedStr,
     };
-    use cool_asserts::{assert_matches, assertion_failure};
     use insta::assert_snapshot;
-    use itertools::Itertools;
 
     use crate::{
         ast,
         tpe::entities::{PartialEntities, PartialEntity},
         tpe::request::{PartialEntityUID, PartialRequest},
-        tpe::residual::{Residual, ResidualKind},
+        tpe::residual::Residual,
     };
 
     use super::Evaluator;
 
-    #[track_caller]
-    fn action() -> EntityUID {
-        r#"Action::"a""#.parse().unwrap()
+    fn schema() -> ValidatorSchema {
+        ValidatorSchema::from_cedarschema_str(r#"
+            entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
+            entity Organization;
+            entity Document in Organization;
+            action get appliesTo { principal: [User], resource: [Document] };"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0
     }
 
     #[track_caller]
-    fn dummy_uid() -> EntityUID {
-        r#"E::"""#.parse().unwrap()
+    fn parse_typed_expr(
+        expr_str: &str,
+        request: &PartialRequest,
+        schema: &ValidatorSchema,
+    ) -> Expr<Option<Type>> {
+        let expr = parse_expr(expr_str).unwrap();
+        let policy_id = crate::ast::PolicyID::from_string("test");
+
+        let env = request
+            .find_request_env(&schema)
+            .unwrap()
+            .link_slot_env(&SlotEnv::new());
+
+        let mut type_errors = HashSet::new();
+        let typechecker = Typechecker::new(schema, ValidationMode::Strict);
+        let ans =
+            typechecker.typecheck_expr_with_request_env(&env, &expr, &policy_id, &mut type_errors);
+        if !type_errors.is_empty() {
+            println!("got {} type errors", type_errors.len());
+            for e in type_errors {
+                println!("{:?}", miette::Report::new(e));
+            }
+            panic!("unexpected type error in expression")
+        }
+        ans.into_typed_expr()
+            .expect("expected typechecking to produce a typed expression")
+    }
+
+    fn concrete_euid(euid: &str) -> PartialEntityUID {
+        EntityUID::from_str(euid).unwrap().into()
+    }
+
+    fn unknown_euid(ty: &str) -> PartialEntityUID {
+        PartialEntityUID {
+            ty: ty.parse().unwrap(),
+            eid: None,
+        }
     }
 
     fn typed_req() -> PartialRequest {
         // Request matches schema in parse_typed_expr
         PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "User".parse().unwrap(),
-                eid: Some(Eid::Eid("foo".into())),
-            },
-            PartialEntityUID {
-                ty: "Document".parse().unwrap(),
-                eid: None,
-            },
+            concrete_euid(r#"User::"foo""#),
+            unknown_euid("Document"),
             r#"Action::"get""#.parse().unwrap(),
             None,
         )
     }
 
     #[track_caller]
-    fn interpret_typed_str_to_str(evaluator: &Evaluator<'_>, expr_str: &str) -> String {
-        let expr = super::super::residual::test::parse_typed_expr(expr_str, &SlotEnv::new());
+    fn interpret_typed_str_to_str(
+        evaluator: &Evaluator<'_>,
+        expr_str: &str,
+        schema: &ValidatorSchema,
+    ) -> String {
+        let expr = parse_typed_expr(expr_str, evaluator.request, schema);
         interpret_expr_to_str(evaluator, &expr)
     }
 
@@ -722,61 +760,32 @@ mod tests {
 
     #[test]
     fn test_var() {
-        let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
-            None,
-        );
         let eval = Evaluator {
-            request: &req,
+            request: &typed_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
+        let schema = schema();
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         // principal -> principal because its eid is unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().var(Var::Principal)).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Var(Var::Principal),
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("principal"),
+            @r#"User::"foo""#
         );
         // resource -> E::""
-        assert_matches!(
-            eval.interpret_expr(&builder().var(Var::Resource)).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::EntityUID(uid)),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(uid.as_ref(), &dummy_uid());
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("resource"),
+            @"resource"
         );
         // action is always known
-        assert_matches!(
-            eval.interpret_expr(&builder().var(Var::Action)).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::EntityUID(uid)),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(uid.as_ref(), &action());
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("action"),
+            @r#"Action::"get""#
         );
         // context is always unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().var(Var::Context)).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Var(Var::Context),
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("context"),
+            @"context"
         );
     }
 
@@ -792,43 +801,45 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
+        let schema = schema();
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         // Note: The test expressions are in the same order as the match statements
 
         // "false && <any>" => "false"
         assert_snapshot!(
             // Note: principal is concrete, and thus can the residual be simplified.
-            interpret_typed_str_to_str(&eval, "principal != principal && principal.foo"),
+            interpret_typed_str_to_str("principal != principal && principal.foo"),
             @r#"false"#
         );
         // "true && <any>" => "<any>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal == principal && principal.foo"),
+            interpret_typed_str_to_str("principal == principal && principal.foo"),
             @r#"User::"foo".foo"#
         );
         // "<error> && <residual>" => "<error>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "(9223372036854775807 * 2 == 0) && principal.foo"),
+            interpret_typed_str_to_str("(9223372036854775807 * 2 == 0) && principal.foo"),
             @r#"error()"#
         );
         // "<residual> && true" => "<residual>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo && true"),
+            interpret_typed_str_to_str("principal.foo && true"),
             @r#"User::"foo".foo"#
         );
         // "<error-free> && false" => "false"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "resource == resource && 41 == 42"),
+            interpret_typed_str_to_str("resource == resource && 41 == 42"),
             @r#"false"#
         );
         // note: resource is unknown, and we haven't (yet) implemented a simplifying algorithm for this,
         // so it yields an error-free residual, hence the previous test makes sense
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "resource == resource"),
+            interpret_typed_str_to_str("resource == resource"),
             @r#"resource == resource"#
         );
         // "<non-error-free> && false" cannot be fully simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.num + 1 == 100 && 41 == 42"),
+            interpret_typed_str_to_str("principal.num + 1 == 100 && 41 == 42"),
             @r#"(((User::"foo".num) + 1) == 100) && false"#
         );
         // "<residual> && <nonbool>" => "<residual> && <error>"
@@ -841,17 +852,17 @@ mod tests {
         );
         // The "<residual> && <residual>" case cannot be simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo && principal.num == 100"),
+            interpret_typed_str_to_str("principal.foo && principal.num == 100"),
             @r#"(User::"foo".foo) && ((User::"foo".num) == 100)"#
         );
         // "<residual> && <error>" cannot be simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo && (9223372036854775807 * 2 == 0)"),
+            interpret_typed_str_to_str("principal.foo && (9223372036854775807 * 2 == 0)"),
             @r#"(User::"foo".foo) && (error())"#
         );
         // "<error> && <any>" => "<error>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "(9223372036854775807 * 2 == 0) && false"),
+            interpret_typed_str_to_str("(9223372036854775807 * 2 == 0) && false"),
             @"error()"
         );
     }
@@ -863,43 +874,45 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
+        let schema = schema();
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         // Note: The test expressions are in the same order as the match statements
 
         // "true || <any>" => "true"
         assert_snapshot!(
             // Note: principal is concrete, and thus can the residual be simplified.
-            interpret_typed_str_to_str(&eval, "principal == principal || principal.foo"),
+            interpret_typed_str_to_str("principal == principal || principal.foo"),
             @r#"true"#
         );
         // "false || <any>" => "<any>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal != principal || principal.foo"),
+            interpret_typed_str_to_str("principal != principal || principal.foo"),
             @r#"User::"foo".foo"#
         );
         // "<error> || <residual>" => "<error>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "(9223372036854775807 * 2 == 0) || principal.foo"),
+            interpret_typed_str_to_str("(9223372036854775807 * 2 == 0) || principal.foo"),
             @r#"error()"#
         );
         // "<residual> || false" => "<residual>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo || false"),
+            interpret_typed_str_to_str("principal.foo || false"),
             @r#"User::"foo".foo"#
         );
         // "<error-free> || true" => "true"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "resource == resource || 42 == 42"),
+            interpret_typed_str_to_str("resource == resource || 42 == 42"),
             @r#"true"#
         );
         // note: resource is unknown, and we haven't (yet) implemented a simplifying algorithm for this,
         // so it yields an error-free residual, hence the previous test makes sense
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "resource == resource"),
+            interpret_typed_str_to_str("resource == resource"),
             @r#"resource == resource"#
         );
         // "<non-error-free> || true" cannot be fully simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.num + 1 == 100 || 42 == 42"),
+            interpret_typed_str_to_str("principal.num + 1 == 100 || 42 == 42"),
             @r#"(((User::"foo".num) + 1) == 100) || true"#
         );
         // "<residual> || <nonbool>" => "<residual> || <error>"
@@ -912,17 +925,17 @@ mod tests {
         );
         // The "<residual> || <residual>" case cannot be simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo || principal.num == 100"),
+            interpret_typed_str_to_str("principal.foo || principal.num == 100"),
             @r#"(User::"foo".foo) || ((User::"foo".num) == 100)"#
         );
         // "<residual> || <error>" cannot be simplified
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "principal.foo || (9223372036854775807 * 2 == 0)"),
+            interpret_typed_str_to_str("principal.foo || (9223372036854775807 * 2 == 0)"),
             @r#"(User::"foo".foo) || (error())"#
         );
         // "<error> || <any>" => "<error>"
         assert_snapshot!(
-            interpret_typed_str_to_str(&eval, "(9223372036854775807 * 2 == 0) || true"),
+            interpret_typed_str_to_str("(9223372036854775807 * 2 == 0) || true"),
             @"error()"
         );
     }
@@ -930,12 +943,9 @@ mod tests {
     #[test]
     fn test_ite() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -943,71 +953,32 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().ite(
-                builder().is_eq(builder().var(Var::Action), builder().var(Var::Action)),
-                builder().var(Var::Principal),
-                builder().val(2)
-            ))
-            .unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Var(Var::Principal),
-                ..
-            }
+        let schema = schema();
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str("if (action == action) then principal else 2"),
+            @"principal"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().ite(
-                builder().is_eq(builder().var(Var::Principal), builder().var(Var::Principal)),
-                builder().var(Var::Principal),
-                builder().val(2)
-            )).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::If { test_expr, then_expr, else_expr },
-                ..
-            } => {
-                assert_matches!(test_expr.as_ref(), Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::Eq, .. }, .. });
-                assert_matches!(then_expr.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-                assert_matches!(else_expr.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::Long(2)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("if (principal == principal) then principal else User::\"alice\""),
+            @r#"if (principal == principal) then principal else User::"alice""#
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().ite(
-                builder().val(false),
-                builder().var(Var::Principal),
-                builder().val(2)
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Long(2)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("if false then principal else 2"),
+            @"2"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().ite(
-                builder().is_eq(
-                    builder().mul(builder().val(i64::MAX), builder().val(2)),
-                    builder().val(0)
-                ),
-                builder().var(Var::Principal),
-                builder().val(2)
-            ))
-            .unwrap(),
-            Residual::Error(_),
+        assert_snapshot!(
+            interpret_typed_str_to_str(&"if (9223372036854775807 * 2) == 0 then principal else User::\"alice\""), @"error()"
         );
     }
 
     #[test]
     fn test_is() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"a""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1015,60 +986,46 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().is_entity_type(
-                builder().var(Var::Resource),
-                dummy_uid().entity_type().clone()
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E, User { baz : E }; action a appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str("resource is User"),
+            @"false"
         );
-        // Note that the Lean model evaluates it to `principal is E`
-        assert_matches!(
-            eval.interpret_expr(&builder().is_entity_type(
-                builder().var(Var::Principal),
-                dummy_uid().entity_type().clone()
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("resource is E"),
+            @"true"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().is_entity_type(
-                builder().get_attr(builder().var(Var::Resource), "baz".parse().unwrap()),
-                dummy_uid().entity_type().clone()
-            ))
-            .unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Is { expr, entity_type } ,
-                ..
-            } => {
-                assert_matches!(expr.as_ref(), Residual::Partial { kind: ResidualKind::GetAttr { .. }, .. });
-                assert_eq!(&entity_type, dummy_uid().entity_type());
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str("principal is User"),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("principal is E"),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("principal.baz is E"),
+            @"(principal.baz) is E"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("principal.baz is Document"),
+            @"(principal.baz) is Document"
         );
     }
 
     #[test]
     fn test_like() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("E"),
+            unknown_euid("E"),
+            r#"Action::"a""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1076,38 +1033,34 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().like(
-                builder().val("aaa"),
-                Pattern::from(vec![PatternElem::Char('a'), PatternElem::Wildcard])
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { s : String }; action a appliesTo {principal: E, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#""aaa" like "a*""#),
+            @"true"
         );
-        // Note that this expression is not valid input
-        assert_matches!(
-            eval.interpret_expr(&builder().like(builder().var(Var::Principal), Pattern::from(vec![PatternElem::Char('a'), PatternElem::Wildcard]))).unwrap(),
-           Residual::Partial { kind: ResidualKind::Like { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#""aaa" like "b*""#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.s like "b*""#),
+            @r#"(principal.s) like "b*""#
         );
     }
 
     #[test]
     fn test_unary_app() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("E"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"a""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1115,48 +1068,45 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().unary_app(UnaryOp::Neg, builder().val(42)))
-                .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Long(-42)),
-                    ..
-                },
-                ..
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { l : Long , b: Bool }; action a appliesTo {principal: E, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"-(42)"#),
+            @"(-42)"
         );
-        // This is not a valid input
-        assert_matches!(
-            eval.interpret_expr(&builder().unary_app(UnaryOp::Neg, builder().var(Var::Principal))).unwrap(),
-            Residual::Partial { kind: ResidualKind::UnaryApp { op: UnaryOp::Neg, arg }, .. } => {
-                assert_matches!(arg.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"-(principal.l)"#),
+            @"-(principal.l)"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().unary_app(UnaryOp::Neg, builder().val(i64::MIN)))
-                .unwrap(),
-            Residual::Error(_),
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"!(false)"#),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"!(principal.b)"#),
+            @"!(principal.b)"
         );
     }
 
     #[test]
     fn test_get_attr() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("E"),
+            concrete_euid(r#"User::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let entities = PartialEntities::from_entities_unchecked(
             [
                 (
-                    dummy_uid(),
+                    r#"User::"""#.parse().unwrap(),
                     PartialEntity {
-                        uid: dummy_uid(),
+                        uid: r#"User::"""#.parse().unwrap(),
                         attrs: Some(BTreeMap::from_iter([(
                             "s".parse().unwrap(),
                             Value::from("bar"),
@@ -1182,76 +1132,49 @@ mod tests {
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().get_attr(builder().var(Var::Resource), "s".parse().unwrap())).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::String(s)),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(s, "bar");
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { s: String }; entity User { s: String }; action get appliesTo {principal: E, resource: User};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.s"#),
+            @r#""bar""#
         );
-
         // When LHS is unknown, the entire expression is
-        assert_matches!(
-            eval.interpret_expr(&builder().get_attr(
-                builder().var(Var::Principal),
-                "s".parse().unwrap()
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::GetAttr { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.s"#),
+            @"principal.s"
         );
         // When LHS is not in the entities, the entire expression is unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().get_attr(
-                builder().val(EntityUID::from_normalized_str(r#"E::"f""#).unwrap()),
-                "s".parse().unwrap()
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::GetAttr { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"f".s"#),
+            @r#"E::"f".s"#
         );
         // When LHS is in the entities, but its attributes are `None`, the
         // entire expression is unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().get_attr(
-                builder().val(EntityUID::from_normalized_str(r#"E::"e""#).unwrap()),
-                "s".parse().unwrap()
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::GetAttr { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
-        );
-        assert_matches!(
-            eval.interpret_expr(
-                &builder().get_attr(builder().var(Var::Resource), "baz".parse().unwrap())
-            )
-            .unwrap(),
-            Residual::Error(_),
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"e".s"#),
+            @r#"E::"e".s"#
         );
     }
 
     #[test]
     fn test_has_attr() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("E"),
+            concrete_euid(r#"User::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let entities = PartialEntities::from_entities_unchecked(
             [
                 (
-                    dummy_uid(),
+                    r#"User::"""#.parse().unwrap(),
                     PartialEntity {
-                        uid: dummy_uid(),
+                        uid: r#"User::"""#.parse().unwrap(),
                         attrs: Some(BTreeMap::from_iter([(
                             "s".parse().unwrap(),
                             Value::from("bar"),
@@ -1277,89 +1200,54 @@ mod tests {
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(
-                &builder().has_attr(builder().var(Var::Resource), "s".parse().unwrap())
-            )
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { s: String }; entity User { s: String }; action get appliesTo {principal: E, resource: User};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource has s"#),
+            @"true"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().has_attr(builder().var(Var::Principal), "s".parse().unwrap())).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::HasAttr { expr, .. },
-                ..
-            } => {
-                assert_matches!(expr.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource has other"#),
+            @"false"
         );
-        // When LHS is not in the entities, the entire expression is unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().has_attr(
-                builder().val(EntityUID::from_normalized_str(r#"E::"f""#).unwrap()),
-                "s".parse().unwrap()
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::HasAttr { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal has s"#),
+            @"principal has s"
         );
-        // When LHS is in the entities, but its attributes are `None`, the
-        // entire expression is unknown
-        assert_matches!(
-            eval.interpret_expr(&builder().has_attr(
-                builder().val(EntityUID::from_normalized_str(r#"E::"e""#).unwrap()),
-                "s".parse().unwrap()
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::HasAttr { expr, .. }, .. } => {
-                assert_matches!(expr.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal has other"#),
+            @"principal has other"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"f" has s"#),
+            @r#"E::"f" has s"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"e" has s"#),
+            @r#"E::"e" has s"#
         );
 
-        assert_matches!(
-            eval.interpret_expr(&builder().has_attr(
-                builder().record([("s".into(), builder().val(0))]).unwrap(),
-                "s".parse().unwrap()
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: 0} has s"#),
+            @"true"
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().has_attr(
-                builder().record([("s".into(), builder().val(0))]).unwrap(),
-                "t".parse().unwrap()
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(false)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: 0} has t"#),
+            @"false"
         );
     }
 
     #[test]
     fn test_set() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1367,53 +1255,32 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().set(
-                [builder().var(Var::Resource)]
-            )).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Set(s),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(Vec::from_iter(s.iter().cloned()), vec![Value::from(dummy_uid())]);
-            }
-        );
-        assert_matches!(
-            eval.interpret_expr(&builder().set(
-                [builder().var(Var::Principal),
-                builder().var(Var::Resource),]
-            )).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Set(s),
-                ..
-            } => {
-                assert_matches!(s.as_ref().as_slice(), [Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. }, Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. }]);
-            }
-        );
 
-        // Error is propagated
-        assert_matches!(
-            eval.interpret_expr(&builder().set([
-                builder().neg(builder().val(i64::MIN)),
-                builder().var(Var::Resource),
-            ]))
-            .unwrap(),
-            Residual::Error(_)
-        )
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[resource]"#),
+            @r#"[Document::""]"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[principal]"#),
+            @"[principal]"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[principal, User::"alice"]"#),
+            @r#"[principal, User::"alice"]"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[0, -(-9223372036854775808)]"#),
+            @"error()"
+        );
     }
 
     #[test]
     fn test_record() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1421,62 +1288,27 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(&builder().record(
-                [(
-                    "s".into(),
-                    builder().var(Var::Resource),
-                )]
-            ).unwrap()).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Record(m),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(m.get("s"), Some(&Value::from(dummy_uid())));
-            }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: resource}"#),
+            @r#"{s: Document::""}"#
         );
-        assert_matches!(
-            eval.interpret_expr(&builder().record(
-                [(
-                    "s".into(),
-                    builder().var(Var::Principal),
-                )]
-            ).unwrap()).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::Record(m),
-                ..
-            } => {
-                assert_matches!(m.as_ref().get("s"), Some(Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. }));
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: principal}"#),
+            @"{s: principal}"
         );
-
-        // Error is propagated
-        assert_matches!(
-            eval.interpret_expr(
-                &builder()
-                    .record([
-                        ("s".into(), builder().neg(builder().val(i64::MIN)),),
-                        ("".into(), builder().var(Var::Resource),)
-                    ])
-                    .unwrap()
-            )
-            .unwrap(),
-            Residual::Error(_)
-        )
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: -(-9223372036854775808), "": resource}"#),
+            @"error()"
+        );
     }
 
     #[test]
     fn test_call() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1484,69 +1316,28 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        assert_matches!(
-            eval.interpret_expr(
-                &builder()
-                    .call_extension_fn("decimal".parse().unwrap(), [builder().val("0.0")])
-                    .unwrap_infallible()
-            )
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::ExtensionValue(_),
-                    ..
-                },
-                ..
-            }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"decimal("0.0")"#),
+            @r#"decimal("0.0000")"#
         );
-        // not a valid input
-        assert_matches!(
-            eval.interpret_expr(&builder().call_extension_fn(
-                "decimal".parse().unwrap(),
-                [builder().var(Var::Principal)]
-            ).unwrap_infallible()).unwrap(),
-            Residual::Partial {
-                kind: ResidualKind::ExtensionFunctionApp { fn_name, args, .. },
-                ..
-            } => {
-                assert_eq!(fn_name.to_string(), "decimal");
-                assert_matches!(args.as_ref().as_slice(), [Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. }]);
-            }
-        );
-
-        // Error is propagated
-        assert_matches!(
-            eval.interpret_expr(
-                &builder()
-                    .call_extension_fn(
-                        "decimal".parse().unwrap(),
-                        [builder().neg(builder().val(i64::MIN))]
-                    )
-                    .unwrap_infallible()
-            )
-            .unwrap(),
-            Residual::Error(_)
-        )
     }
 
     #[test]
     fn test_binary_app() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         // not valid entities
         let entities = PartialEntities::from_entities_unchecked(
             [
                 (
-                    dummy_uid(),
+                    r#"User::"""#.parse().unwrap(),
                     PartialEntity {
-                        uid: dummy_uid(),
+                        uid: r#"User::"""#.parse().unwrap(),
                         attrs: None,
                         ancestors: Some(HashSet::from_iter([r#"E::"e""#.parse().unwrap()])),
                         tags: Some(BTreeMap::from_iter([(
@@ -1572,204 +1363,84 @@ mod tests {
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Eq,
-                builder().var(Var::Resource),
-                builder().val(dummy_uid())
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E; entity User in E tags String; action get appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource == E::"""#),
+            @"true"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Eq,
-                builder().var(Var::Principal),
-                builder().val(dummy_uid())
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::Eq, arg1, .. }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource == User::"""#),
+            @"false"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Add,
-                builder().val(i64::MAX),
-                builder().val(i64::MAX)
-            ))
-            .unwrap(),
-            Residual::Error(_)
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal == User::"""#),
+            @r#"principal == User::"""#
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Add,
-                builder().val(1),
-                builder().val(1)
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Long(2)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal == E::"""#),
+            @r#"principal == E::"""#
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Contains,
-                builder().set([builder().val(dummy_uid())]),
-                builder().var(Var::Resource)
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"9223372036854775807 + 9223372036854775807"#),
+            @"error()"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::Contains,
-                builder().set([builder().val(dummy_uid())]),
-                builder().var(Var::Principal)
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::Contains, arg2, .. }, .. } => {
-                assert_matches!(arg2.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"1 + 1"#),
+            @"2"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::In,
-                builder().val(EntityUID::from_normalized_str(r#"E::"e""#).unwrap()),
-                builder().var(Var::Resource)
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(false)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[E::""].contains(resource)"#),
+            @"true"
         );
-
-        assert_matches!(
-            eval.interpret_expr(
-                &builder().binary_app(
-                    BinaryOp::In,
-                    builder().val(EntityUID::from_normalized_str(r#"E::"""#).unwrap()),
-                    builder().set([
-                        builder().val(EntityUID::from_normalized_str(r#"E::"e""#).unwrap()),
-                    ])
-                )
-            )
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[User::""].contains(principal)"#),
+            @r#"[User::""].contains(principal)"#
         );
-
-        // LHS of `in` has unknown ancestors
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::In,
-                builder().val(EntityUID::from_normalized_str(r#"E::"f""#).unwrap()),
-                builder().var(Var::Resource)
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::In, arg1, arg2 }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-                assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"e" in resource"#),
+            @"false"
         );
-
-        // LHS of `in` is not in the entities
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::In,
-                builder().val(EntityUID::from_normalized_str(r#"E::"a""#).unwrap()),
-                builder().var(Var::Resource)
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::In, arg1, arg2 }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-                assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"" in E::"e""#),
+            @r#"E::"" in E::"e""#
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::HasTag,
-                builder().var(Var::Resource),
-                builder().val("s")
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"f" in resource"#),
+            @r#"E::"f" in E::"""#
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::GetTag,
-                builder().var(Var::Resource),
-                builder().val("s")
-            )).unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::String(s)),
-                    ..
-                },
-                ..
-            } => {
-                assert_eq!(s, "bar");
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"a" in resource"#),
+            @r#"E::"a" in E::"""#
         );
-
-        // LHS of hasTag/getTag has unknown tags
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::HasTag,
-                builder().val(EntityUID::from_normalized_str(r#"E::"e""#).unwrap()),
-                builder().val("s")
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::HasTag, arg1, .. }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"".hasTag("s")"#),
+            @"true"
         );
-
-        // LHS of hasTag/getTag is not in the entities
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::HasTag,
-                builder().val(EntityUID::from_normalized_str(r#"E::"a""#).unwrap()),
-                builder().val("s")
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::HasTag, arg1, .. }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.hasTag("s")"#),
+            @r#"principal.hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.hasTag("s")"#),
+            @r#"E::"".hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"foo".hasTag("s")"#),
+            @r#"User::"foo".hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"e".hasTag("s")"#),
+            @r#"E::"e".hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"".hasTag("s") && User::"".getTag("s") == "bar" "#),
+            @"true"
         );
     }
 
@@ -1777,12 +1448,9 @@ mod tests {
     #[test]
     fn test_set_ops() {
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1790,75 +1458,22 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::ContainsAll,
-                builder().set([builder().val(true), builder().val(false)]),
-                builder().set([builder().val(true), builder().val(true)])
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[true, false].containsAll([false, true])"#),
+            @"true"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::ContainsAll,
-                builder().set([builder().val(true), builder().binary_app(BinaryOp::Eq, builder().var(Var::Principal), builder().var(Var::Resource))]),
-                builder().set([builder().val(true), builder().val(true)])
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::ContainsAll, arg1, arg2 }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Partial { kind: ResidualKind::Set(s), ..} => {
-                    assert_matches!(s.as_slice(), [Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::Bool(true)), .. }, .. }, Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::Eq, arg1, arg2 }, .. }] => {
-                        assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-                        assert_matches!(arg1.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-                    })
-                } );
-                assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Set(s), .. }, .. } => {
-                    assert_eq!(s.iter().collect_vec(), [&Value::from(true)]);
-                });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[true, false].containsAll([false, principal == User::"alice"])"#),
+            @r#"[false, true].containsAll([false, principal == User::"alice"])"#
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::ContainsAny,
-                builder().set([builder().val(true), builder().val(false)]),
-                builder().set([builder().val(true), builder().val(true)])
-            ))
-            .unwrap(),
-            Residual::Concrete {
-                value: Value {
-                    value: ValueKind::Lit(Literal::Bool(true)),
-                    ..
-                },
-                ..
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[true, false].containsAny([false])"#),
+            @"true"
         );
-
-        assert_matches!(
-            eval.interpret_expr(&builder().binary_app(
-                BinaryOp::ContainsAny,
-                builder().set([builder().val(true), builder().binary_app(BinaryOp::Eq, builder().var(Var::Principal), builder().var(Var::Resource))]),
-                builder().set([builder().val(true), builder().val(true)])
-            )).unwrap(),
-            Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::ContainsAny, arg1, arg2 }, .. } => {
-                assert_matches!(arg1.as_ref(), Residual::Partial { kind: ResidualKind::Set(s), ..} => {
-                    assert_matches!(s.as_slice(), [Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::Bool(true)), .. }, .. }, Residual::Partial { kind: ResidualKind::BinaryApp { op: BinaryOp::Eq, arg1, arg2 }, .. }] => {
-                        assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Lit(Literal::EntityUID(_)), .. }, .. });
-                        assert_matches!(arg1.as_ref(), Residual::Partial { kind: ResidualKind::Var(Var::Principal), .. });
-                    })
-                } );
-                assert_matches!(arg2.as_ref(), Residual::Concrete { value: Value { value: ValueKind::Set(s), .. }, .. } => {
-                    assert_eq!(s.iter().collect_vec(), [&Value::from(true)]);
-                });
-            }
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[true].containsAny([principal == User::"alice"])"#),
+            @r#"[true].containsAny([principal == User::"alice"])"#
         );
     }
 
@@ -1873,12 +1488,9 @@ mod tests {
         // direct datetime or the offset from the Unix Epoch, depending on where the term
         // originated from.
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1886,22 +1498,11 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let residual = eval
-            .interpret_expr(
-                &builder()
-                    .call_extension_fn("datetime".parse().unwrap(), [builder().val("6640-02-11")])
-                    .unwrap_infallible(),
-            )
-            .unwrap();
-        // Convert to Expr and check the top-level function is "offset"
-        let expr: crate::ast::Expr = residual.into();
-        assert_matches!(expr.expr_kind(), crate::ast::ExprKind::ExtensionFunctionApp { fn_name, .. } => {
-            assert_eq!(fn_name.to_string(), "offset");
-        });
-        // String representation
-        assert_eq!(
-            expr.to_string(),
-            r#"(datetime("1970-01-01")).offset(duration("147374467200000ms"))"#
+
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"datetime("6640-02-11")"#),
+            @r#"(datetime("1970-01-01")).offset(duration("147374467200000ms"))"#
         );
     }
 
@@ -1909,12 +1510,9 @@ mod tests {
     fn test_decimal_residual_normalization() {
         // decimal("0.0") should be normalized to decimal("0.0000") (4-digit padded)
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1922,27 +1520,20 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let residual = eval
-            .interpret_expr(
-                &builder()
-                    .call_extension_fn("decimal".parse().unwrap(), [builder().val("0.0")])
-                    .unwrap_infallible(),
-            )
-            .unwrap();
-        let expr: crate::ast::Expr = residual.into();
-        assert_eq!(expr.to_string(), r#"decimal("0.0000")"#);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"decimal("0.0")"#),
+            @r#"decimal("0.0000")"#
+        );
     }
 
     #[test]
     fn test_ip_residual_normalization() {
         // ip("::1") should be normalized to include the prefix: ip("::1/128")
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1950,27 +1541,20 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let residual = eval
-            .interpret_expr(
-                &builder()
-                    .call_extension_fn("ip".parse().unwrap(), [builder().val("::1")])
-                    .unwrap_infallible(),
-            )
-            .unwrap();
-        let expr: crate::ast::Expr = residual.into();
-        assert_eq!(expr.to_string(), r#"ip("::1/128")"#);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"ip("::1")"#),
+            @r#"ip("::1/128")"#
+        );
     }
 
     #[test]
     fn test_duration_residual_normalization() {
         // duration("1d") should be normalized to duration("86400000ms")
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            dummy_uid().into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"Document::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -1978,15 +1562,11 @@ mod tests {
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let residual = eval
-            .interpret_expr(
-                &builder()
-                    .call_extension_fn("duration".parse().unwrap(), [builder().val("1d")])
-                    .unwrap_infallible(),
-            )
-            .unwrap();
-        let expr: crate::ast::Expr = residual.into();
-        assert_eq!(expr.to_string(), r#"duration("86400000ms")"#);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"duration("1d")"#),
+            @r#"duration("86400000ms")"#
+        );
     }
 
     #[test]
@@ -2016,12 +1596,9 @@ mod tests {
         // Principal is unknown so that the overall expression stays partial,
         // making the datetime value appear in the residual.
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            entity_uid.into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -2029,42 +1606,18 @@ mod tests {
             entities: &entities,
             extensions: Extensions::all_available(),
         };
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { dt: datetime }; entity User; action get appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
 
-        // Retrieve the datetime attribute from the known entity (resource).
-        let residual = eval
-            .interpret_expr(
-                &builder().get_attr(builder().var(Var::Resource), "dt".parse().unwrap()),
-            )
-            .unwrap();
-
-        let expr: Expr = residual.into();
-        {
-            use crate::pst::{BinaryOp, Expr, UnaryOp};
-            // expression matches (datetime(..).offset(duration(...))"#,
-            match Expr::try_from(expr).unwrap() {
-                Expr::BinaryOp {
-                    op: BinaryOp::Offset,
-                    left,
-                    right,
-                } => {
-                    assert_matches!(
-                        left.as_ref(),
-                        Expr::UnaryOp {
-                            op: UnaryOp::Datetime,
-                            ..
-                        }
-                    );
-                    assert_matches!(
-                        right.as_ref(),
-                        Expr::UnaryOp {
-                            op: UnaryOp::Duration,
-                            ..
-                        }
-                    );
-                }
-                _ => assertion_failure!("toplevel op should be offset"),
-            }
-        }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.dt"#),
+            @r#"(datetime("1970-01-01")).offset(duration("1790812800000ms"))"#
+        );
     }
 
     #[test]
@@ -2094,12 +1647,9 @@ mod tests {
         );
 
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            entity_uid.into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -2108,49 +1658,18 @@ mod tests {
             extensions: Extensions::all_available(),
         };
 
-        // Retrieve resource.rec — a record whose "dt" field holds the datetime.
-        // The record is concrete, so it becomes a Residual::Concrete.
-        // When converted to Expr, the datetime inside must use the canonical form.
-        let residual = eval
-            .interpret_expr(
-                &builder().get_attr(builder().var(Var::Resource), "rec".parse().unwrap()),
-            )
-            .unwrap();
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { rec: { dt: datetime } }; entity User; action get appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
 
-        let expr: Expr = residual.into();
-        {
-            use crate::pst::{BinaryOp, Expr, UnaryOp};
-            // The record should have a single field "dt" whose value is in canonical form.
-            match Expr::try_from(expr).unwrap() {
-                Expr::Record(fields) => {
-                    let dt_expr = fields.get("dt").expect("record should have 'dt' field");
-                    match dt_expr.as_ref() {
-                        Expr::BinaryOp {
-                            op: BinaryOp::Offset,
-                            left,
-                            right,
-                        } => {
-                            assert_matches!(
-                                left.as_ref(),
-                                Expr::UnaryOp {
-                                    op: UnaryOp::Datetime,
-                                    ..
-                                }
-                            );
-                            assert_matches!(
-                                right.as_ref(),
-                                Expr::UnaryOp {
-                                    op: UnaryOp::Duration,
-                                    ..
-                                }
-                            );
-                        }
-                        _ => assertion_failure!("dt field should be offset(datetime, duration)"),
-                    }
-                }
-                _ => assertion_failure!("toplevel should be a record"),
-            }
-        }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.rec"#),
+            @r#"{dt: (datetime("1970-01-01")).offset(duration("1790812800000ms"))}"#
+        );
     }
 
     #[test]
@@ -2180,12 +1699,9 @@ mod tests {
         );
 
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            entity_uid.into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -2194,31 +1710,18 @@ mod tests {
             extensions: Extensions::all_available(),
         };
 
-        let residual = eval
-            .interpret_expr(&builder().get_attr(builder().var(Var::Resource), "s".parse().unwrap()))
-            .unwrap();
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { s: Set<datetime> }; entity User; action get appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
 
-        let expr: Expr = residual.into();
-        {
-            use crate::pst::{BinaryOp, Expr};
-            match Expr::try_from(expr).unwrap() {
-                Expr::Set(elems) => {
-                    assert_eq!(elems.len(), 2);
-                    // At least one element should be the normalized datetime.
-                    let has_normalized = elems.iter().any(|e| {
-                        matches!(
-                            e.as_ref(),
-                            Expr::BinaryOp {
-                                op: BinaryOp::Offset,
-                                ..
-                            }
-                        )
-                    });
-                    assert!(has_normalized, "set should contain a normalized datetime");
-                }
-                _ => assertion_failure!("toplevel should be a set"),
-            }
-        }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.s"#),
+            @r#"[1, (datetime("1970-01-01")).offset(duration("1790812800000ms"))]"#
+        );
     }
 
     #[test]
@@ -2255,12 +1758,9 @@ mod tests {
         );
 
         let req = PartialRequest::new_unchecked(
-            PartialEntityUID {
-                ty: "E".parse().unwrap(),
-                eid: None,
-            },
-            entity_uid.into(),
-            action(),
+            unknown_euid("User"),
+            concrete_euid(r#"E::"""#),
+            r#"Action::"get""#.parse().unwrap(),
             None,
         );
         let eval = Evaluator {
@@ -2269,35 +1769,17 @@ mod tests {
             extensions: Extensions::all_available(),
         };
 
-        let residual = eval
-            .interpret_expr(
-                &builder().get_attr(builder().var(Var::Resource), "rec".parse().unwrap()),
-            )
-            .unwrap();
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity E { rec: { a: Long, dt: datetime, z: Long } }; entity User; action get appliesTo {principal: User, resource: E};"#,
+            &Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
 
-        let expr: Expr = residual.into();
-        {
-            use crate::pst::{BinaryOp, Expr, UnaryOp};
-            match Expr::try_from(expr).unwrap() {
-                Expr::Record(fields) => {
-                    assert_eq!(fields.len(), 3);
-                    assert_matches!(fields.get("a").unwrap().as_ref(), Expr::Literal(_));
-                    assert_matches!(fields.get("z").unwrap().as_ref(), Expr::Literal(_));
-                    let dt_expr = fields.get("dt").expect("record should have 'dt' field");
-                    assert_matches!(
-                        dt_expr.as_ref(),
-                        Expr::BinaryOp {
-                            op: BinaryOp::Offset,
-                            left,
-                            right,
-                        } => {
-                            assert_matches!(left.as_ref(), Expr::UnaryOp { op: UnaryOp::Datetime, .. });
-                            assert_matches!(right.as_ref(), Expr::UnaryOp { op: UnaryOp::Duration, .. });
-                        }
-                    );
-                }
-                _ => assertion_failure!("toplevel should be a record"),
-            }
-        }
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.rec"#),
+            @r#"{a: 1, dt: (datetime("1970-01-01")).offset(duration("1790812800000ms")), z: 2}"#
+        );
     }
 }

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -644,7 +644,6 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
-    use std::str::FromStr;
     use std::sync::Arc;
 
     use crate::ast::{Expr, SlotEnv};

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -645,6 +645,7 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
 mod tests {
     use std::collections::{BTreeMap, HashSet};
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use crate::ast::{Expr, SlotEnv};
     use crate::parser::parse_expr;
@@ -653,7 +654,7 @@ mod tests {
     use crate::validator::types::Type;
     use crate::validator::{ValidationMode, ValidatorSchema};
     use crate::{
-        ast::{EntityUID, ExprBuilder, Value, Var},
+        ast::{Context, EntityUID, ExprBuilder, Value, Var},
         expr_builder::ExprBuilder as _,
         extensions::Extensions,
     };
@@ -661,23 +662,28 @@ mod tests {
 
     use crate::{
         ast,
-        tpe::entities::{PartialEntities, PartialEntity},
+        tpe::entities::PartialEntities,
         tpe::request::{PartialEntityUID, PartialRequest},
         tpe::residual::Residual,
     };
 
     use super::Evaluator;
 
+    #[track_caller]
+    fn parse_schema(src: &str) -> ValidatorSchema {
+        ValidatorSchema::from_cedarschema_str(src, &Extensions::all_available())
+            .unwrap()
+            .0
+    }
+
     fn schema() -> ValidatorSchema {
-        ValidatorSchema::from_cedarschema_str(r#"
+        parse_schema(
+            r#"
             entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
             entity Organization;
             entity Document in Organization;
             action get appliesTo { principal: [User], resource: [Document] };"#,
-            &Extensions::all_available(),
         )
-        .unwrap()
-        .0
     }
 
     #[track_caller]
@@ -722,12 +728,14 @@ mod tests {
 
     fn typed_req() -> PartialRequest {
         // Request matches schema in parse_typed_expr
-        PartialRequest::new_unchecked(
+        PartialRequest::new(
             concrete_euid(r#"User::"foo""#),
-            unknown_euid("Document"),
             r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("Document"),
             None,
+            &schema(),
         )
+        .unwrap()
     }
 
     #[track_caller]
@@ -786,6 +794,37 @@ mod tests {
         assert_snapshot!(
             interpret_typed_str_to_str("context"),
             @"context"
+        );
+    }
+
+    #[test]
+    fn test_known_context() {
+        let schema = parse_schema(
+            r#"entity E; action a appliesTo {principal: E, resource: E, context: {l: Long}};"#,
+        );
+        let eval = Evaluator {
+            request: &PartialRequest::new(
+                unknown_euid(r#"E"#),
+                r#"Action::"a""#.parse().unwrap(),
+                unknown_euid("E"),
+                Some(Arc::new(BTreeMap::from([(
+                    "l".parse().unwrap(),
+                    Value::from(0),
+                )]))),
+                &schema,
+            )
+            .unwrap(),
+            entities: &PartialEntities::new(),
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str("context"),
+            @"{l: 0}"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("context.l"),
+            @"0"
         );
     }
 
@@ -942,56 +981,73 @@ mod tests {
 
     #[test]
     fn test_ite() {
-        let req = PartialRequest::new_unchecked(
+        let schema = schema();
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("Document"),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = schema();
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
-
         assert_snapshot!(
-            interpret_typed_str_to_str("if (action == action) then principal else 2"),
+            interpret_typed_str_to_str("if true then principal else 2"),
             @"principal"
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str("if (principal == principal) then principal else User::\"alice\""),
-            @r#"if (principal == principal) then principal else User::"alice""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str("if false then principal else 2"),
             @"2"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(&"if (9223372036854775807 * 2) == 0 then principal else User::\"alice\""), @"error()"
+            interpret_typed_str_to_str(r#"if (principal == User::"alice") then Document::"A" else Document::"B""#),
+            @r#"if (principal == User::"alice") then Document::"A" else Document::"B""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(&r#"if (9223372036854775807 * 2) == 0 then principal else User::"alice""#),
+            @"error()"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("if true then (9223372036854775807 * 2) else 0"),
+            @"error()"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("if false then (9223372036854775807 * 2) else 0"),
+            @"0"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("if true then 0 else (9223372036854775807 * 2)"),
+            @"0"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("if false then 0 else (9223372036854775807 * 2)"),
+            @"error()"
         );
     }
 
     #[test]
     fn test_is() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
-            r#"Action::"a""#.parse().unwrap(),
-            None,
+        let schema = parse_schema(
+            r#"entity E, User { baz : E }; action a appliesTo {principal: User, resource: E};"#,
         );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"a""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
+            None,
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E, User { baz : E }; action a appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
 
         assert_snapshot!(
@@ -1018,27 +1074,38 @@ mod tests {
             interpret_typed_str_to_str("principal.baz is Document"),
             @"(principal.baz) is Document"
         );
+        assert_snapshot!(
+            interpret_typed_str_to_str("User::\"alice\" is User"),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("User::\"alice\" is E"),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str("(if (9223372036854775807 * 2 == 0) then User::\"alice\" else principal) is E"),
+            @"error()"
+        );
     }
 
     #[test]
     fn test_like() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("E"),
+        let schema = parse_schema(
+            r#"entity E { s : String }; action a appliesTo {principal: E, resource: E};"#,
+        );
+        let req = PartialRequest::new(
             unknown_euid("E"),
             r#"Action::"a""#.parse().unwrap(),
+            unknown_euid("E"),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { s : String }; action a appliesTo {principal: E, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
 
         assert_snapshot!(
@@ -1050,38 +1117,53 @@ mod tests {
             @"false"
         );
         assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.s like "*""#),
+            @r#"(principal.s) like "*""#
+        );
+        assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.s like "b*""#),
             @r#"(principal.s) like "b*""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then "a" else "b") like "b*""#),
+            @"error()"
         );
     }
 
     #[test]
-    fn test_unary_app() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("E"),
-            concrete_euid(r#"E::"""#),
-            r#"Action::"a""#.parse().unwrap(),
-            None,
+    fn test_negation() {
+        let schema = parse_schema(
+            r#"entity E { l : Long , b: Bool }; action a appliesTo {principal: E, resource: E};"#,
         );
+        let req = PartialRequest::new(
+            unknown_euid("E"),
+            r#"Action::"a""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
+            None,
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { l : Long , b: Bool }; action a appliesTo {principal: E, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"-(42)"#),
             @"(-42)"
         );
         assert_snapshot!(
+            interpret_typed_str_to_str(r#"-(-9223372036854775808)"#),
+            @"error()"
+        );
+        assert_snapshot!(
             interpret_typed_str_to_str(r#"-(principal.l)"#),
             @"-(principal.l)"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"--(principal.l)"#),
+            @"-(-(principal.l))"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"!(false)"#),
@@ -1091,62 +1173,52 @@ mod tests {
             interpret_typed_str_to_str(r#"!(principal.b)"#),
             @"!(principal.b)"
         );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"!!(principal.b)"#),
+            @"!(!(principal.b))"
+        );
     }
 
     #[test]
-    fn test_get_attr() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("E"),
-            concrete_euid(r#"User::"""#),
+    fn test_get_attr_simple() {
+        let schema = parse_schema(
+            r#"entity E { s: String }; action get appliesTo {principal: E, resource: E};"#,
+        );
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": { "s": "bar" },
+                },
+                {
+                    "uid": { "type": "E", "id": "e" },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let req = PartialRequest::new(
+            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("E"),
             None,
-        );
-        let entities = PartialEntities::from_entities_unchecked(
-            [
-                (
-                    r#"User::"""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"User::"""#.parse().unwrap(),
-                        attrs: Some(BTreeMap::from_iter([(
-                            "s".parse().unwrap(),
-                            Value::from("bar"),
-                        )])),
-                        ancestors: None,
-                        tags: None,
-                    },
-                ),
-                (
-                    r#"E::"e""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"E::"e""#.parse().unwrap(),
-                        attrs: None,
-                        ancestors: None,
-                        tags: None,
-                    },
-                ),
-            ]
-            .into_iter(),
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { s: String }; entity User { s: String }; action get appliesTo {principal: E, resource: User};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"resource.s"#),
+            interpret_typed_str_to_str(r#"principal.s"#),
             @r#""bar""#
         );
         // When LHS is unknown, the entire expression is
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"principal.s"#),
-            @"principal.s"
+            interpret_typed_str_to_str(r#"resource.s"#),
+            @"resource.s"
         );
         // When LHS is not in the entities, the entire expression is unknown
         assert_snapshot!(
@@ -1159,53 +1231,112 @@ mod tests {
             interpret_typed_str_to_str(r#"E::"e".s"#),
             @r#"E::"e".s"#
         );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then E::"alice" else E::"bob").s"#),
+            @"error()"
+        );
     }
 
     #[test]
-    fn test_has_attr() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("E"),
-            concrete_euid(r#"User::"""#),
+    fn test_get_attr_chained() {
+        let schema = parse_schema(
+            r#"entity E { s: String, e: E }; action get appliesTo {principal: E, resource: E};"#,
+        );
+        // `E::"loop".e` points back at itself, so chained access through it
+        // always terminates at `E::"loop"`.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": {
+                        "s": "bar",
+                        "e": { "__entity": { "type": "E", "id": "x" } },
+                    },
+                },
+                {
+                    "uid": { "type": "E", "id": "loop" },
+                    "attrs": {
+                        "s": "loop_str",
+                        "e": { "__entity": { "type": "E", "id": "loop" } },
+                    },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let req = PartialRequest::new(
+            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("E"),
             None,
-        );
-        let entities = PartialEntities::from_entities_unchecked(
-            [
-                (
-                    r#"User::"""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"User::"""#.parse().unwrap(),
-                        attrs: Some(BTreeMap::from_iter([(
-                            "s".parse().unwrap(),
-                            Value::from("bar"),
-                        )])),
-                        ancestors: None,
-                        tags: None,
-                    },
-                ),
-                (
-                    r#"E::"e""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"E::"e""#.parse().unwrap(),
-                        attrs: None,
-                        ancestors: None,
-                        tags: None,
-                    },
-                ),
-            ]
-            .into_iter(),
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.e.s"#),
+            @r#"E::"x".s"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.e.e.e.s"#),
+            @r#"((E::"x".e).e).s"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.e.s"#),
+            @"(resource.e).s"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"loop".e"#),
+            @r#"E::"loop""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"loop".e.e.e.e"#),
+            @r#"E::"loop""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"loop".e.e.e.e.s"#),
+            @r#""loop_str""#
+        );
+    }
+
+    #[test]
+    fn test_has_attr() {
+        let schema = parse_schema(
             r#"entity E { s: String }; entity User { s: String }; action get appliesTo {principal: E, resource: User};"#,
-            &Extensions::all_available(),
+        );
+        // `User::""` has known attributes while `E::"e"` omits `attrs`, marking
+        // them unknown.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "User", "id": "" },
+                    "attrs": { "s": "bar" },
+                },
+                {
+                    "uid": { "type": "E", "id": "e" },
+                },
+            ]),
+            &schema,
         )
-        .unwrap()
-        .0;
+        .unwrap();
+        let req = PartialRequest::new(
+            unknown_euid("E"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"User::"""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource has s"#),
@@ -1244,12 +1375,14 @@ mod tests {
 
     #[test]
     fn test_set() {
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1277,12 +1410,14 @@ mod tests {
 
     #[test]
     fn test_record() {
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1304,13 +1439,192 @@ mod tests {
     }
 
     #[test]
-    fn test_call() {
-        let req = PartialRequest::new_unchecked(
-            unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
-            r#"Action::"get""#.parse().unwrap(),
-            None,
+    fn test_get_attr_record() {
+        let schema = parse_schema(
+            r#"entity E { rec: { s: String, inner: { n: Long } } }; entity User; action get appliesTo {principal: User, resource: E, context: {c: {n: Long}}};"#,
         );
+
+        // Entity `E::""` has a `rec` attribute that is a nested record.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": { "rec": { "s": "bar", "inner": { "n": 1 } } },
+                },
+                {
+                    "uid": { "type": "E", "id": "unk_attrs" },
+                }
+            ]),
+            &schema,
+        )
+        .unwrap();
+
+        // A context record with a nested record field.
+        let Ok(Context::Value(context)) =
+            Context::from_json_value(serde_json::json!({ "c": { "n": 2 } }))
+        else {
+            panic!("expected concrete context")
+        };
+
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
+            Some(context),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // Nested records read from an entity attribute.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.rec.s"#),
+            @r#""bar""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.rec.inner.n"#),
+            @"1"
+        );
+
+        // Nested records read from the context.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"context.c"#),
+            @"{n: 2}"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"context.c.n"#),
+            @"2"
+        );
+
+        // Attribute access on record literals.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{s: "lit"}.s"#),
+            @r#""lit""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{inner: {n: 3}}.inner.n"#),
+            @"3"
+        );
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{e: E::"unk"}.e.rec"#),
+            @r#"E::"unk".rec"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{e: E::"unk_attrs"}.e.rec"#),
+            @r#"E::"unk_attrs".rec"#
+        );
+
+        // Residuals inside record literals prevent reduction to preserve error semantics
+        // cases to preserve semantics, should often be possible.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{e: if principal == User::"alice" then 9223372036854775807*2 else 0, l: 0}.l"#),
+            @r#"{e: if (principal == User::"alice") then (error()) else 0, l: 0}.l"#
+        );
+        // But it should be possible in other cases
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{p: principal}.p"#),
+            @"{p: principal}.p"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"{p: principal, l: 0}.l"#),
+            @"{l: 0, p: principal}.l"
+        );
+    }
+
+    #[test]
+    fn test_get_attr_intermediate_entities_emulate_unknown_attrs() {
+        let schema = parse_schema(
+            r#"
+            entity E0 { metadata: { m0: M0, m1: M1 } };
+            entity M0 { data: Long };
+            entity M1 { data: Long };
+            entity User;
+            action get appliesTo { principal: User, resource: E0 };"#,
+        );
+
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E0", "id": "e" },
+                    "attrs": {
+                        "metadata": {
+                            "m0": { "__entity": { "type": "M0", "id": "m0" } },
+                            "m1": { "__entity": { "type": "M1", "id": "m1" } },
+                        }
+                    },
+                },
+                {
+                    "uid": { "type": "M0", "id": "m0" },
+                    "attrs": { "data": 42 },
+                },
+                // `M1::"m1"` intentionally omits `attrs`, marking them unknown.
+                {
+                    "uid": { "type": "M1", "id": "m1" },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E0::"e""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // The referenced entity uids are always known.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.metadata.m0"#),
+            @r#"M0::"m0""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.metadata.m1"#),
+            @r#"M1::"m1""#
+        );
+
+        // `m0`'s attributes are known, so `data` reduces to a concrete value.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.metadata.m0.data"#),
+            @"42"
+        );
+        // `m1`'s attributes are unknown, so `data` stays a residual: this is how
+        // the intermediate entity emulates an unknown attribute.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.metadata.m1.data"#),
+            @r#"M1::"m1".data"#
+        );
+        // Mixing a known and an unknown attribute leaves a partial residual.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.metadata.m0.data + resource.metadata.m1.data"#),
+            @r#"42 + (M1::"m1".data)"#
+        );
+    }
+
+    #[test]
+    fn test_call() {
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
+            None,
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1318,57 +1632,37 @@ mod tests {
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"decimal("0.0")"#),
-            @r#"decimal("0.0000")"#
+            interpret_typed_str_to_str(r#"ip("192.168.0.1").isInRange(ip("192.168.0.0/16"))"#),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if principal == User::"alice" then ip("127.0.0.1") else ip("192.168.0.1")).isInRange(ip("192.168.0.0/16"))"#),
+            @r#"(if (principal == User::"alice") then (ip("127.0.0.1/32")) else (ip("192.168.0.1/32"))).isInRange(ip("192.168.0.0/16"))"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then ip("127.0.0.1") else ip("192.168.0.1")).isInRange(ip("192.168.0.0/16"))"#),
+            @"error()"
         );
     }
 
     #[test]
-    fn test_binary_app() {
-        let req = PartialRequest::new_unchecked(
+    fn test_binary_app_eq() {
+        let schema = parse_schema(
+            r#"entity E; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
             None,
-        );
-        // not valid entities
-        let entities = PartialEntities::from_entities_unchecked(
-            [
-                (
-                    r#"User::"""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"User::"""#.parse().unwrap(),
-                        attrs: None,
-                        ancestors: Some(HashSet::from_iter([r#"E::"e""#.parse().unwrap()])),
-                        tags: Some(BTreeMap::from_iter([(
-                            "s".parse().unwrap(),
-                            Value::from("bar"),
-                        )])),
-                    },
-                ),
-                (
-                    r#"E::"e""#.parse().unwrap(),
-                    PartialEntity {
-                        uid: r#"E::"e""#.parse().unwrap(),
-                        attrs: None,
-                        ancestors: Some(HashSet::default()),
-                        tags: None,
-                    },
-                ),
-            ]
-            .into_iter(),
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
-            entities: &entities,
+            entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E; entity User in E tags String; action get appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource == E::"""#),
@@ -1386,6 +1680,39 @@ mod tests {
             interpret_typed_str_to_str(r#"principal == E::"""#),
             @r#"principal == E::"""#
         );
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal == (if (9223372036854775807 * 2 == 0) then User::"alice" else User::"bob")"#),
+            @"error()"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then User::"alice" else User::"bob") == principal"#),
+            @"error()"
+        );
+    }
+
+    #[test]
+    fn test_binary_app_arith() {
+        let schema = parse_schema(
+            r#"entity E; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
+        let req = {
+            let schema: &ValidatorSchema = &schema;
+            PartialRequest::new(
+                unknown_euid("User"),
+                r#"Action::"get""#.parse().unwrap(),
+                concrete_euid(r#"E::"""#),
+                None,
+                schema,
+            )
+            .unwrap()
+        };
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"9223372036854775807 + 9223372036854775807"#),
             @"error()"
@@ -1394,6 +1721,27 @@ mod tests {
             interpret_typed_str_to_str(r#"1 + 1"#),
             @"2"
         );
+    }
+
+    #[test]
+    fn test_binary_app_contains() {
+        let schema = parse_schema(
+            r#"entity E; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[E::""].contains(resource)"#),
             @"true"
@@ -1402,57 +1750,351 @@ mod tests {
             interpret_typed_str_to_str(r#"[User::""].contains(principal)"#),
             @r#"[User::""].contains(principal)"#
         );
+    }
+
+    #[test]
+    fn test_binary_app_in() {
+        let schema = parse_schema(
+            r#"entity E in E; entity User in E; action get appliesTo {principal: User, resource: E, context: {e: E}};"#,
+        );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"resource""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        // `E::"e"` has known (empty) ancestors; `E::"child"` has a declared
+        // parent `E::""`. The other referenced entities are absent, so their
+        // ancestors are unknown and `in` stays a residual.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "no_parents" },
+                    "parents": [],
+                },
+                {
+                    "uid": { "type": "E", "id": "resource_child" },
+                    "parents": [ { "type": "E", "id": "" } ],
+                },
+                {
+                    "uid": { "type": "E", "id": "parents_none" },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"E::"e" in resource"#),
+            interpret_typed_str_to_str(r#"E::"no_parents" in resource"#),
             @"false"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"E::"" in E::"e""#),
-            @r#"E::"" in E::"e""#
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"E::"f" in resource"#),
-            @r#"E::"f" in E::"""#
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"E::"a" in resource"#),
-            @r#"E::"a" in E::"""#
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"User::"".hasTag("s")"#),
+            interpret_typed_str_to_str(r#"E::"resource" in E::"resource""#),
             @"true"
         );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"resource_child" in resource"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"resource_child" in E::"not_parent""#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"resource_child" in [E::"not_parent", resource]"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"resource_child" in context.e"#),
+            @r#"E::"resource_child" in (context.e)"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"resource_child" in [context.e]"#),
+            @r#"E::"resource_child" in [context.e]"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"context.e in E::"resource""#),
+            @r#"(context.e) in E::"resource""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in resource"#),
+            @r#"E::"undefined" in E::"resource""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"parents_none" in resource"#),
+            @r#"E::"parents_none" in E::"resource""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [resource]"#),
+            @r#"E::"undefined" in [E::"resource"]"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"parents_none" in [resource]"#),
+            @r#"E::"parents_none" in [E::"resource"]"#
+        );
+    }
+
+    fn binary_app_tags_env() -> (ValidatorSchema, PartialEntities, PartialRequest) {
+        let schema = parse_schema(
+            r#"entity E; entity User tags String; action get appliesTo {principal: User, resource: E, context: {tag: String}};"#,
+        );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"resource""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "User", "id": "some_tags" },
+                    "tags": { "s": "bar" },
+                },
+                {
+                    "uid": { "type": "User", "id": "none_tags" },
+                },
+                {
+                    "uid": { "type": "E", "id": "none_tags" },
+                },
+                {
+                    "uid": { "type": "E", "id": "empty_tags" },
+                    "tags": {},
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        (schema, entities, req)
+    }
+
+    #[test]
+    fn test_binary_app_has_tag() {
+        let (schema, entities, req) = binary_app_tags_env();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // Known tags: `hasTag` resolves to a concrete bool.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"some_tags".hasTag("s")"#),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"some_tags".hasTag("bogus")"#),
+            @"false"
+        );
+        // Unknown entity uid, unknown tags, or absent entity: `hasTag` stays a residual.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.hasTag("s")"#),
             @r#"principal.hasTag("s")"#
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"resource.hasTag("s")"#),
-            @r#"E::"".hasTag("s")"#
+            interpret_typed_str_to_str(r#"User::"none_tags".hasTag("s")"#),
+            @r#"User::"none_tags".hasTag("s")"#
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"User::"foo".hasTag("s")"#),
-            @r#"User::"foo".hasTag("s")"#
+            interpret_typed_str_to_str(r#"User::"undefined".hasTag("s")"#),
+            @r#"User::"undefined".hasTag("s")"#
         );
+    }
+
+    #[test]
+    fn test_binary_app_get_tag() {
+        let (schema, entities, req) = binary_app_tags_env();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // Known tags: resolves to a concrete bool.
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"E::"e".hasTag("s")"#),
-            @r#"E::"e".hasTag("s")"#
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"User::"".hasTag("s") && User::"".getTag("s") == "bar" "#),
+            interpret_typed_str_to_str(r#"User::"some_tags".hasTag("s") && User::"some_tags".getTag("s") == "bar" "#),
             @"true"
+        );
+        // Known tags, missing key: `hasTag` is false and short-circuits.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"some_tags".hasTag("bogus") && User::"some_tags".getTag("bogus") == "bar" "#),
+            @"false"
+        );
+        // Unknown cases
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.hasTag("s") && principal.getTag("s") == "bar" "#),
+            @r#"(principal.hasTag("s")) && ((principal.getTag("s")) == "bar")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"none_tags".hasTag("s") && User::"none_tags".getTag("s") == "bar" "#),
+            @r#"(User::"none_tags".hasTag("s")) && ((User::"none_tags".getTag("s")) == "bar")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"undefined".hasTag("s") && User::"undefined".getTag("s") == "bar" "#),
+            @r#"(User::"undefined".hasTag("s")) && ((User::"undefined".getTag("s")) == "bar")"#
+        );
+
+        // `E` entities can't have tags, but `hasTag` is still well-typed. These could all reduce to
+        // `false`, but only the explicit empty tag case does atm.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"empty_tags".hasTag("s") && E::"empty_tags".getTag("s") == "bar" "#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"none_tags".hasTag("s") && E::"none_tags".getTag("s") == "bar" "#),
+            @r#"E::"none_tags".hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined_tags".hasTag("s") && E::"undefined_tags".getTag("s") == "bar" "#),
+            @r#"E::"undefined_tags".hasTag("s")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined".hasTag("s") && E::"undefined".getTag("s") == "bar" "#),
+            @r#"E::"undefined".hasTag("s")"#
+        );
+    }
+
+    #[test]
+    fn test_binary_app_tag_unknown_key() {
+        let (schema, entities, req) = binary_app_tags_env();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.hasTag(context.tag) && principal.getTag(context.tag) == "bar" "#),
+            @r#"(principal.hasTag(context.tag)) && ((principal.getTag(context.tag)) == "bar")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"some_tags".hasTag(context.tag) && User::"some_tags".getTag(context.tag) == "bar" "#),
+            @r#"(User::"some_tags".hasTag(context.tag)) && ((User::"some_tags".getTag(context.tag)) == "bar")"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"empty_tags".hasTag(context.tag) && E::"empty_tags".getTag(context.tag) == "bar" "#),
+            @r#"E::"empty_tags".hasTag(context.tag)"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"none_tags".hasTag(context.tag) && E::"none_tags".getTag(context.tag) == "bar" "#),
+            @r#"E::"none_tags".hasTag(context.tag)"#
+        );
+    }
+
+    #[test]
+    fn test_binary_app_get_tag_record() {
+        let schema = parse_schema(
+            r#"entity E; entity User tags { s: String, inner: { n: Long } }; action get appliesTo {principal: User, resource: E};"#,
+        );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        // `User::"rec"` has a known tag `k` holding a nested record.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "User", "id": "rec" },
+                    "tags": { "k": { "s": "bar", "inner": { "n": 1 } } },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"rec".hasTag("k") && User::"other".hasTag("k") && User::"rec".getTag("k") == User::"other".getTag("k")"#),
+            @r#"(User::"other".hasTag("k")) && ({inner: {n: 1}, s: "bar"} == (User::"other".getTag("k")))"#
+        );
+    }
+
+    #[test]
+    fn test_binary_app_get_tag_entity() {
+        let schema = parse_schema(
+            r#"entity E { data: Long }; entity User tags E; action get appliesTo {principal: User, resource: E};"#,
+        );
+        let req = PartialRequest::new(
+            unknown_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("E"),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "User", "id": "ent" },
+                    "tags": {
+                        "k": { "__entity": { "type": "E", "id": "target" } },
+                        "unk": { "__entity": { "type": "E", "id": "unk" } },
+                    },
+                },
+                {
+                    "uid": { "type": "E", "id": "target" },
+                    "attrs": { "data": 42 },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"ent".hasTag("k") && User::"ent".getTag("k").data == 42"#),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"ent".hasTag("k") && User::"ent".getTag("k") == resource"#),
+            @r#"E::"target" == resource"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"ent".hasTag("unk") && User::"ent".getTag("unk").data == 42"#),
+            @r#"(E::"unk".data) == 42"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal.hasTag("k") && principal.getTag("k").data == 42"#),
+            @r#"(principal.hasTag("k")) && (((principal.getTag("k")).data) == 42)"#
         );
     }
 
     // Test containsAll/containsAny operations
     #[test]
     fn test_set_ops() {
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1487,12 +2129,14 @@ mod tests {
         // while the Rust side representation without canonicalization can be either the
         // direct datetime or the offset from the Unix Epoch, depending on where the term
         // originated from.
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1509,12 +2153,14 @@ mod tests {
     #[test]
     fn test_decimal_residual_normalization() {
         // decimal("0.0") should be normalized to decimal("0.0000") (4-digit padded)
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1530,12 +2176,14 @@ mod tests {
     #[test]
     fn test_ip_residual_normalization() {
         // ip("::1") should be normalized to include the prefix: ip("::1/128")
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1551,12 +2199,14 @@ mod tests {
     #[test]
     fn test_duration_residual_normalization() {
         // duration("1d") should be normalized to duration("86400000ms")
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"Document::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"Document::"""#),
             None,
-        );
+            &schema(),
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
@@ -1571,47 +2221,41 @@ mod tests {
 
     #[test]
     fn test_datetime_attr_from_entity_is_normalized() {
-        let extensions = Extensions::all_available();
-        let datetime_fn = extensions.func(&"datetime".parse().unwrap()).unwrap();
-        let datetime_val = match datetime_fn.call(&[Value::from("2026-10-01")]).unwrap() {
-            crate::ast::PartialValue::Value(v) => v,
-            _ => panic!("expected concrete value"),
-        };
-
-        // Create an entity whose attribute "dt" holds this non-canonical datetime.
-        let entity_uid: EntityUID = r#"E::"""#.parse().unwrap();
-        let entities = PartialEntities::from_entities_unchecked(
-            [(
-                entity_uid.clone(),
-                PartialEntity {
-                    uid: entity_uid.clone(),
-                    attrs: Some(BTreeMap::from_iter([("dt".parse().unwrap(), datetime_val)])),
-                    ancestors: None,
-                    tags: None,
-                },
-            )]
-            .into_iter(),
+        let schema = parse_schema(
+            r#"entity E { dt: datetime }; entity User; action get appliesTo {principal: User, resource: E};"#,
         );
+
+        // Create an entity whose attribute "dt" holds a non-canonical datetime
+        // (constructed via `datetime(..)` rather than the canonical
+        // `datetime(..).offset(..)` form).
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": {
+                        "dt": { "__extn": { "fn": "datetime", "arg": "2026-10-01" } },
+                    },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
 
         // Principal is unknown so that the overall expression stays partial,
         // making the datetime value appear in the residual.
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { dt: datetime }; entity User; action get appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
 
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
@@ -1622,48 +2266,39 @@ mod tests {
 
     #[test]
     fn test_datetime_in_record_attr_from_entity_is_normalized() {
-        use smol_str::ToSmolStr;
-        let extensions = Extensions::all_available();
-        let datetime_fn = extensions.func(&"datetime".parse().unwrap()).unwrap();
-        let datetime_val = match datetime_fn.call(&[Value::from("2026-10-01")]).unwrap() {
-            crate::ast::PartialValue::Value(v) => v,
-            _ => panic!("expected concrete value"),
-        };
+        let schema = parse_schema(
+            r#"entity E { rec: { dt: datetime } }; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
 
         // Entity attribute "rec" is a record containing the non-canonical datetime.
-        let entity_uid: EntityUID = r#"E::"""#.parse().unwrap();
-        let rec_val = Value::record([("dt".to_smolstr(), datetime_val)], None);
-        let entities = PartialEntities::from_entities_unchecked(
-            [(
-                entity_uid.clone(),
-                PartialEntity {
-                    uid: entity_uid.clone(),
-                    attrs: Some(BTreeMap::from_iter([("rec".parse().unwrap(), rec_val)])),
-                    ancestors: None,
-                    tags: None,
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": {
+                        "rec": {
+                            "dt": { "__extn": { "fn": "datetime", "arg": "2026-10-01" } },
+                        },
+                    },
                 },
-            )]
-            .into_iter(),
-        );
+            ]),
+            &schema,
+        )
+        .unwrap();
 
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { rec: { dt: datetime } }; entity User; action get appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
 
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
@@ -1674,107 +2309,84 @@ mod tests {
 
     #[test]
     fn test_datetime_in_set_attr_from_entity_is_normalized() {
-        let extensions = Extensions::all_available();
-        let datetime_fn = extensions.func(&"datetime".parse().unwrap()).unwrap();
-        let datetime_val = match datetime_fn.call(&[Value::from("2026-10-01")]).unwrap() {
-            crate::ast::PartialValue::Value(v) => v,
-            _ => panic!("expected concrete value"),
-        };
+        let schema = parse_schema(
+            r#"entity E { s: Set<datetime> }; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
 
-        // Entity attribute "s" is a set containing a plain value followed by the
-        // non-canonical datetime, so the loop skips the first element before normalizing.
-        let entity_uid: EntityUID = r#"E::"""#.parse().unwrap();
-        let set_val = Value::set([Value::from(1), datetime_val], None);
-        let entities = PartialEntities::from_entities_unchecked(
-            [(
-                entity_uid.clone(),
-                PartialEntity {
-                    uid: entity_uid.clone(),
-                    attrs: Some(BTreeMap::from_iter([("s".parse().unwrap(), set_val)])),
-                    ancestors: None,
-                    tags: None,
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": {
+                        "s": [
+                            { "__extn": { "fn": "datetime", "arg": "1970-01-02" } },
+                            { "__extn": { "fn": "datetime", "arg": "2026-10-01" } },
+                        ],
+                    },
                 },
-            )]
-            .into_iter(),
-        );
+            ]),
+            &schema,
+        )
+        .unwrap();
 
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
 
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { s: Set<datetime> }; entity User; action get appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
-
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.s"#),
-            @r#"[1, (datetime("1970-01-01")).offset(duration("1790812800000ms"))]"#
+            @r#"[(datetime("1970-01-01")).offset(duration("86400000ms")), (datetime("1970-01-01")).offset(duration("1790812800000ms"))]"#
         );
     }
 
     #[test]
     fn test_datetime_in_multi_field_record_is_normalized() {
-        use smol_str::ToSmolStr;
-        let extensions = Extensions::all_available();
-        let datetime_fn = extensions.func(&"datetime".parse().unwrap()).unwrap();
-        let datetime_val = match datetime_fn.call(&[Value::from("2026-10-01")]).unwrap() {
-            crate::ast::PartialValue::Value(v) => v,
-            _ => panic!("expected concrete value"),
-        };
+        let schema = parse_schema(
+            r#"entity E { rec: { a: Long, dt: datetime, z: Long } }; entity User; action get appliesTo {principal: User, resource: E};"#,
+        );
 
         // Record with "a" before "dt" and "z" after, so the skip(idx+1) path is exercised.
-        let entity_uid: EntityUID = r#"E::"""#.parse().unwrap();
-        let rec_val = Value::record(
-            [
-                ("a".to_smolstr(), Value::from(1)),
-                ("dt".to_smolstr(), datetime_val),
-                ("z".to_smolstr(), Value::from(2)),
-            ],
-            None,
-        );
-        let entities = PartialEntities::from_entities_unchecked(
-            [(
-                entity_uid.clone(),
-                PartialEntity {
-                    uid: entity_uid.clone(),
-                    attrs: Some(BTreeMap::from_iter([("rec".parse().unwrap(), rec_val)])),
-                    ancestors: None,
-                    tags: None,
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "" },
+                    "attrs": {
+                        "rec": {
+                            "a": 1,
+                            "dt": { "__extn": { "fn": "datetime", "arg": "2026-10-01" } },
+                            "z": 2,
+                        },
+                    },
                 },
-            )]
-            .into_iter(),
-        );
+            ]),
+            &schema,
+        )
+        .unwrap();
 
-        let req = PartialRequest::new_unchecked(
+        let req = PartialRequest::new(
             unknown_euid("User"),
-            concrete_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
+            concrete_euid(r#"E::"""#),
             None,
-        );
+            &schema,
+        )
+        .unwrap();
         let eval = Evaluator {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
         };
-
-        let schema = ValidatorSchema::from_cedarschema_str(
-            r#"entity E { rec: { a: Long, dt: datetime, z: Long } }; entity User; action get appliesTo {principal: User, resource: E};"#,
-            &Extensions::all_available(),
-        )
-        .unwrap()
-        .0;
 
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -686,6 +686,17 @@ mod tests {
         )
     }
 
+    fn concrete_user_req() -> PartialRequest {
+        PartialRequest::new(
+            concrete_euid(r#"User::"foo""#),
+            r#"Action::"get""#.parse().unwrap(),
+            unknown_euid("Document"),
+            None,
+            &schema(),
+        )
+        .unwrap()
+    }
+
     #[track_caller]
     fn parse_typed_expr(
         expr_str: &str,
@@ -726,18 +737,6 @@ mod tests {
         }
     }
 
-    fn typed_req() -> PartialRequest {
-        // Request matches schema in parse_typed_expr
-        PartialRequest::new(
-            concrete_euid(r#"User::"foo""#),
-            r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("Document"),
-            None,
-            &schema(),
-        )
-        .unwrap()
-    }
-
     #[track_caller]
     fn interpret_typed_str_to_str(
         evaluator: &Evaluator<'_>,
@@ -769,12 +768,11 @@ mod tests {
     #[test]
     fn test_var() {
         let eval = Evaluator {
-            request: &typed_req(),
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = schema();
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         // principal -> principal because its eid is unknown
         assert_snapshot!(
             interpret_typed_str_to_str("principal"),
@@ -836,12 +834,11 @@ mod tests {
     #[test]
     fn test_and() {
         let eval = Evaluator {
-            request: &typed_req(),
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = schema();
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         // Note: The test expressions are in the same order as the match statements
 
         // "false && <any>" => "false"
@@ -909,12 +906,11 @@ mod tests {
     #[test]
     fn test_or() {
         let eval = Evaluator {
-            request: &typed_req(),
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let schema = schema();
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         // Note: The test expressions are in the same order as the match statements
 
         // "true || <any>" => "true"
@@ -981,35 +977,26 @@ mod tests {
 
     #[test]
     fn test_ite() {
-        let schema = schema();
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("Document"),
-            None,
-            &schema,
-        )
-        .unwrap();
         let eval = Evaluator {
-            request: &req,
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
-            interpret_typed_str_to_str("if true then principal else 2"),
-            @"principal"
+            interpret_typed_str_to_str("if true then resource else 2"),
+            @"resource"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str("if false then principal else 2"),
+            interpret_typed_str_to_str("if false then resource else 2"),
             @"2"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"if (principal == User::"alice") then Document::"A" else Document::"B""#),
-            @r#"if (principal == User::"alice") then Document::"A" else Document::"B""#
+            interpret_typed_str_to_str(r#"if (resource == User::"alice") then Document::"A" else Document::"B""#),
+            @r#"if (resource == User::"alice") then Document::"B" else Document::"B""#
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(&r#"if (9223372036854775807 * 2) == 0 then principal else User::"alice""#),
+            interpret_typed_str_to_str(&r#"if (9223372036854775807 * 2) == 0 then resource else Document::"A""#),
             @"error()"
         );
         assert_snapshot!(
@@ -1375,16 +1362,8 @@ mod tests {
 
     #[test]
     fn test_set() {
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
         let eval = Evaluator {
-            request: &req,
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
@@ -1392,15 +1371,15 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[resource]"#),
-            @r#"[Document::""]"#
+            @"[resource]"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[principal]"#),
-            @"[principal]"
+            @r#"[User::"foo"]"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[principal, User::"alice"]"#),
-            @r#"[principal, User::"alice"]"#
+            @r#"[User::"alice", User::"foo"]"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[0, -(-9223372036854775808)]"#),
@@ -1410,27 +1389,19 @@ mod tests {
 
     #[test]
     fn test_record() {
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
         let eval = Evaluator {
-            request: &req,
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"{s: resource}"#),
-            @r#"{s: Document::""}"#
+            @"{s: resource}"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"{s: principal}"#),
-            @"{s: principal}"
+            @r#"{s: User::"foo"}"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"{s: -(-9223372036854775808), "": resource}"#),
@@ -1563,7 +1534,6 @@ mod tests {
                     "uid": { "type": "M0", "id": "m0" },
                     "attrs": { "data": 42 },
                 },
-                // `M1::"m1"` intentionally omits `attrs`, marking them unknown.
                 {
                     "uid": { "type": "M1", "id": "m1" },
                 },
@@ -1617,16 +1587,8 @@ mod tests {
 
     #[test]
     fn test_call() {
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
         let eval = Evaluator {
-            request: &req,
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
@@ -1637,7 +1599,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(if principal == User::"alice" then ip("127.0.0.1") else ip("192.168.0.1")).isInRange(ip("192.168.0.0/16"))"#),
-            @r#"(if (principal == User::"alice") then (ip("127.0.0.1/32")) else (ip("192.168.0.1/32"))).isInRange(ip("192.168.0.0/16"))"#
+            @"true"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then ip("127.0.0.1") else ip("192.168.0.1")).isInRange(ip("192.168.0.0/16"))"#),
@@ -2087,16 +2049,8 @@ mod tests {
     // Test containsAll/containsAny operations
     #[test]
     fn test_set_ops() {
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
         let eval = Evaluator {
-            request: &req,
+            request: &concrete_user_req(),
             entities: &PartialEntities::new(),
             extensions: Extensions::all_available(),
         };
@@ -2106,21 +2060,27 @@ mod tests {
             @"true"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"[true, false].containsAll([false, principal == User::"alice"])"#),
-            @r#"[false, true].containsAll([false, principal == User::"alice"])"#
+            interpret_typed_str_to_str(r#"[true, false].containsAll([false, resource == Document::"mine"])"#),
+            @r#"[false, true].containsAll([false, resource == Document::"mine"])"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"[true, false].containsAny([false])"#),
             @"true"
         );
         assert_snapshot!(
-            interpret_typed_str_to_str(r#"[true].containsAny([principal == User::"alice"])"#),
-            @r#"[true].containsAny([principal == User::"alice"])"#
+            interpret_typed_str_to_str(r#"[true].containsAny([resource == Document::"alice"])"#),
+            @r#"[true].containsAny([resource == Document::"alice"])"#
         );
     }
 
     #[test]
-    fn test_datetime_residual_normalization() {
+    fn test_ext_normalization() {
+        let eval = Evaluator {
+            request: &concrete_user_req(),
+            entities: &PartialEntities::new(),
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         // When the TPE evaluator evaluates datetime("6640-02-11") with all
         // concrete args, the resulting residual should use the canonical
         // offset(datetime("1970-01-01"), duration("Nms")) form — not the
@@ -2129,90 +2089,18 @@ mod tests {
         // while the Rust side representation without canonicalization can be either the
         // direct datetime or the offset from the Unix Epoch, depending on where the term
         // originated from.
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
-        let eval = Evaluator {
-            request: &req,
-            entities: &PartialEntities::new(),
-            extensions: Extensions::all_available(),
-        };
-
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"datetime("6640-02-11")"#),
             @r#"(datetime("1970-01-01")).offset(duration("147374467200000ms"))"#
         );
-    }
-
-    #[test]
-    fn test_decimal_residual_normalization() {
-        // decimal("0.0") should be normalized to decimal("0.0000") (4-digit padded)
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
-        let eval = Evaluator {
-            request: &req,
-            entities: &PartialEntities::new(),
-            extensions: Extensions::all_available(),
-        };
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"decimal("0.0")"#),
             @r#"decimal("0.0000")"#
         );
-    }
-
-    #[test]
-    fn test_ip_residual_normalization() {
-        // ip("::1") should be normalized to include the prefix: ip("::1/128")
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
-        let eval = Evaluator {
-            request: &req,
-            entities: &PartialEntities::new(),
-            extensions: Extensions::all_available(),
-        };
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"ip("::1")"#),
             @r#"ip("::1/128")"#
         );
-    }
-
-    #[test]
-    fn test_duration_residual_normalization() {
-        // duration("1d") should be normalized to duration("86400000ms")
-        let req = PartialRequest::new(
-            unknown_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"Document::"""#),
-            None,
-            &schema(),
-        )
-        .unwrap();
-        let eval = Evaluator {
-            request: &req,
-            entities: &PartialEntities::new(),
-            extensions: Extensions::all_available(),
-        };
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
         assert_snapshot!(
             interpret_typed_str_to_str(r#"duration("1d")"#),
             @r#"duration("86400000ms")"#

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -648,7 +648,7 @@ mod tests {
 
     use crate::ast::{Expr, SlotEnv};
     use crate::tpe::err::ExprToResidualError;
-    use crate::tpe::test_utils::{concrete_euid, parse_typed_expr, unknown_euid};
+    use crate::tpe::test_utils::{parse_partial_euid, parse_typed_expr};
     use crate::validator::types::Type;
     use crate::validator::ValidatorSchema;
     use crate::{
@@ -683,9 +683,9 @@ mod tests {
 
     fn concrete_user_req() -> PartialRequest {
         PartialRequest::new(
-            concrete_euid(r#"User::"foo""#),
+            parse_partial_euid(r#"User::"foo""#),
             r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("Document"),
+            parse_partial_euid("Document"),
             None,
             &schema(),
         )
@@ -757,9 +757,9 @@ mod tests {
         );
         let eval = Evaluator {
             request: &PartialRequest::new(
-                unknown_euid(r#"E"#),
+                parse_partial_euid(r#"E"#),
                 r#"Action::"a""#.parse().unwrap(),
-                unknown_euid("E"),
+                parse_partial_euid("E"),
                 Some(Arc::new(BTreeMap::from([(
                     "l".parse().unwrap(),
                     Value::from(0),
@@ -978,9 +978,9 @@ mod tests {
             r#"entity E, User { baz : E }; action a appliesTo {principal: User, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"a""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -1036,9 +1036,9 @@ mod tests {
             r#"entity E { s : String }; action a appliesTo {principal: E, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             r#"Action::"a""#.parse().unwrap(),
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             None,
             &schema,
         )
@@ -1078,9 +1078,9 @@ mod tests {
             r#"entity E { l : Long , b: Bool }; action a appliesTo {principal: E, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             r#"Action::"a""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -1132,9 +1132,9 @@ mod tests {
             panic!("expected concrete context")
         };
         let req = PartialRequest::new(
-            concrete_euid(r#"E::"foo""#),
+            parse_partial_euid(r#"E::"foo""#),
             r#"Action::"a""#.parse().unwrap(),
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             Some(context),
             &schema,
         )
@@ -1186,9 +1186,9 @@ mod tests {
         )
         .unwrap();
         let req = PartialRequest::new(
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             None,
             &schema,
         )
@@ -1253,9 +1253,9 @@ mod tests {
         )
         .unwrap();
         let req = PartialRequest::new(
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             None,
             &schema,
         )
@@ -1313,9 +1313,9 @@ mod tests {
         )
         .unwrap();
         let req = PartialRequest::new(
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"User::"""#),
+            parse_partial_euid(r#"User::"""#),
             None,
             &schema,
         )
@@ -1444,9 +1444,9 @@ mod tests {
         };
 
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             Some(context),
             &schema,
         )
@@ -1549,9 +1549,9 @@ mod tests {
         .unwrap();
 
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E0::"e""#),
+            parse_partial_euid(r#"E0::"e""#),
             None,
             &schema,
         )
@@ -1619,9 +1619,9 @@ mod tests {
             r#"entity E; entity User; action get appliesTo {principal: User, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -1667,9 +1667,9 @@ mod tests {
         let req = {
             let schema: &ValidatorSchema = &schema;
             PartialRequest::new(
-                unknown_euid("User"),
+                parse_partial_euid("User"),
                 r#"Action::"get""#.parse().unwrap(),
-                concrete_euid(r#"E::"""#),
+                parse_partial_euid(r#"E::"""#),
                 None,
                 schema,
             )
@@ -1697,9 +1697,9 @@ mod tests {
             r#"entity E; entity User; action get appliesTo {principal: User, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -1726,9 +1726,9 @@ mod tests {
             r#"entity E in E; entity User in E; action get appliesTo {principal: User, resource: E, context: {e: E}};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"resource""#),
+            parse_partial_euid(r#"E::"resource""#),
             None,
             &schema,
         )
@@ -1814,9 +1814,9 @@ mod tests {
             r#"entity E; entity User tags String; action get appliesTo {principal: User, resource: E, context: {tag: String}};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"resource""#),
+            parse_partial_euid(r#"E::"resource""#),
             None,
             &schema,
         )
@@ -1966,9 +1966,9 @@ mod tests {
             r#"entity E; entity User tags { s: String, inner: { n: Long } }; action get appliesTo {principal: User, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -2003,9 +2003,9 @@ mod tests {
             r#"entity E { data: Long }; entity User tags E; action get appliesTo {principal: User, resource: E};"#,
         );
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("E"),
+            parse_partial_euid("E"),
             None,
             &schema,
         )
@@ -2138,9 +2138,9 @@ mod tests {
         // Principal is unknown so that the overall expression stays partial,
         // making the datetime value appear in the residual.
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -2181,9 +2181,9 @@ mod tests {
         .unwrap();
 
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -2224,9 +2224,9 @@ mod tests {
         .unwrap();
 
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )
@@ -2269,9 +2269,9 @@ mod tests {
         .unwrap();
 
         let req = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            concrete_euid(r#"E::"""#),
+            parse_partial_euid(r#"E::"""#),
             None,
             &schema,
         )

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -728,7 +728,7 @@ mod tests {
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
-        // principal -> User::"foo"
+        // principal -> User::""
         assert_snapshot!(
             interpret_typed_str_to_str("principal"),
             @r#"User::"foo""#
@@ -1122,6 +1122,52 @@ mod tests {
     }
 
     #[test]
+    fn test_is_empty() {
+        let schema = parse_schema(
+            r#"entity E { s: Set<Long> }; action a appliesTo {principal: E, resource: E, context: {s0: Set<Long>, s1: Set<Long>}};"#,
+        );
+        let Ok(Context::Value(context)) =
+            Context::from_json_value(serde_json::json!({ "s0": [], "s1": [0] }))
+        else {
+            panic!("expected concrete context")
+        };
+        let req = PartialRequest::new(
+            concrete_euid(r#"E::"foo""#),
+            r#"Action::"a""#.parse().unwrap(),
+            unknown_euid("E"),
+            Some(context),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"[1].isEmpty()"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"context.s0.isEmpty()"#),
+            @"true"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"context.s1.isEmpty()"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource.s.isEmpty()"#),
+            @"(resource.s).isEmpty()"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then [1] else [2]).isEmpty()"#),
+            @"error()"
+        );
+    }
+
+    #[test]
     fn test_get_attr_simple() {
         let schema = parse_schema(
             r#"entity E { s: String }; action get appliesTo {principal: E, resource: E};"#,
@@ -1312,6 +1358,11 @@ mod tests {
         assert_snapshot!(
             interpret_typed_str_to_str(r#"{s: 0} has t"#),
             @"false"
+        );
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then E::"alice" else E::"bob") has s"#),
+            @"error()"
         );
     }
 

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -643,28 +643,24 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
     use std::str::FromStr;
     use std::sync::Arc;
 
     use crate::ast::{Expr, SlotEnv};
-    use crate::parser::parse_expr;
     use crate::tpe::err::ExprToResidualError;
-    use crate::validator::typecheck::Typechecker;
+    use crate::tpe::test_utils::{concrete_euid, parse_typed_expr, unknown_euid};
     use crate::validator::types::Type;
-    use crate::validator::{ValidationMode, ValidatorSchema};
+    use crate::validator::ValidatorSchema;
     use crate::{
-        ast::{Context, EntityUID, ExprBuilder, Value, Var},
+        ast::{Context, ExprBuilder, Value, Var},
         expr_builder::ExprBuilder as _,
         extensions::Extensions,
     };
     use insta::assert_snapshot;
 
     use crate::{
-        ast,
-        tpe::entities::PartialEntities,
-        tpe::request::{PartialEntityUID, PartialRequest},
-        tpe::residual::Residual,
+        ast, tpe::entities::PartialEntities, tpe::request::PartialRequest, tpe::residual::Residual,
     };
 
     use super::Evaluator;
@@ -698,52 +694,12 @@ mod tests {
     }
 
     #[track_caller]
-    fn parse_typed_expr(
-        expr_str: &str,
-        request: &PartialRequest,
-        schema: &ValidatorSchema,
-    ) -> Expr<Option<Type>> {
-        let expr = parse_expr(expr_str).unwrap();
-        let policy_id = crate::ast::PolicyID::from_string("test");
-
-        let env = request
-            .find_request_env(&schema)
-            .unwrap()
-            .link_slot_env(&SlotEnv::new());
-
-        let mut type_errors = HashSet::new();
-        let typechecker = Typechecker::new(schema, ValidationMode::Strict);
-        let ans =
-            typechecker.typecheck_expr_with_request_env(&env, &expr, &policy_id, &mut type_errors);
-        if !type_errors.is_empty() {
-            println!("got {} type errors", type_errors.len());
-            for e in type_errors {
-                println!("{:?}", miette::Report::new(e));
-            }
-            panic!("unexpected type error in expression")
-        }
-        ans.into_typed_expr()
-            .expect("expected typechecking to produce a typed expression")
-    }
-
-    fn concrete_euid(euid: &str) -> PartialEntityUID {
-        EntityUID::from_str(euid).unwrap().into()
-    }
-
-    fn unknown_euid(ty: &str) -> PartialEntityUID {
-        PartialEntityUID {
-            ty: ty.parse().unwrap(),
-            eid: None,
-        }
-    }
-
-    #[track_caller]
     fn interpret_typed_str_to_str(
         evaluator: &Evaluator<'_>,
         expr_str: &str,
         schema: &ValidatorSchema,
     ) -> String {
-        let expr = parse_typed_expr(expr_str, evaluator.request, schema);
+        let expr = parse_typed_expr(expr_str, evaluator.request, schema, &SlotEnv::new());
         interpret_expr_to_str(evaluator, &expr)
     }
 

--- a/cedar-policy-core/src/tpe/request.rs
+++ b/cedar-policy-core/src/tpe/request.rs
@@ -498,6 +498,7 @@ mod request_builder_tests {
         tpe::{
             err::RequestBuilderError,
             request::{PartialEntityUID, PartialRequest, RequestBuilder},
+            test_utils::unknown_euid,
         },
         validator::ValidatorSchema,
     };
@@ -525,15 +526,9 @@ mod request_builder_tests {
     #[track_caller]
     fn request() -> PartialRequest {
         PartialRequest::new(
-            PartialEntityUID {
-                ty: "A".parse().unwrap(),
-                eid: None,
-            },
+            unknown_euid("A"),
             r#"Action::"a""#.parse().unwrap(),
-            PartialEntityUID {
-                ty: "B".parse().unwrap(),
-                eid: None,
-            },
+            unknown_euid("B"),
             None,
             &schema(),
         )

--- a/cedar-policy-core/src/tpe/request.rs
+++ b/cedar-policy-core/src/tpe/request.rs
@@ -497,7 +497,7 @@ mod request_builder_tests {
         extensions::Extensions,
         tpe::{
             err::RequestBuilderError,
-            request::{PartialEntityUID, PartialRequest, RequestBuilder},
+            request::{PartialRequest, RequestBuilder},
             test_utils::unknown_euid,
         },
         validator::ValidatorSchema,

--- a/cedar-policy-core/src/tpe/request.rs
+++ b/cedar-policy-core/src/tpe/request.rs
@@ -487,29 +487,6 @@ impl<'s> RequestBuilder<'s> {
     }
 }
 
-/// Test utilities for constructing [`PartialEntityUID`]s.
-#[cfg(test)]
-pub(crate) mod test_utils {
-    use super::PartialEntityUID;
-    use crate::ast::EntityUID;
-
-    /// Parse a [`PartialEntityUID`] from a string.
-    ///
-    /// Accepts either a bare entity type (e.g. `A`), yielding an unknown eid, or
-    /// a full entity uid (e.g. `A::"foo"`), yielding a concrete eid.
-    #[track_caller]
-    pub(crate) fn parse_partial_euid(s: &str) -> PartialEntityUID {
-        if let Ok(euid) = s.parse::<EntityUID>() {
-            PartialEntityUID::from(euid)
-        } else {
-            PartialEntityUID {
-                ty: s.parse().expect("should parse as an entity type"),
-                eid: None,
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod invalid_requests {
     use std::{collections::BTreeMap, sync::Arc};
@@ -518,7 +495,8 @@ mod invalid_requests {
         ast::Value,
         extensions::Extensions,
         test_utils::{expect_err, ExpectedErrorMessage, ExpectedErrorMessageBuilder},
-        tpe::request::{test_utils::parse_partial_euid, PartialRequest},
+        tpe::request::PartialRequest,
+        tpe::test_utils::parse_partial_euid,
         validator::ValidatorSchema,
     };
 
@@ -700,7 +678,7 @@ mod inconsistent_requests {
         ast::{Context, EntityUIDEntry, Request, Value},
         extensions::Extensions,
         test_utils::{expect_err, ExpectedErrorMessageBuilder},
-        tpe::request::{test_utils::parse_partial_euid, PartialRequest},
+        tpe::{request::PartialRequest, test_utils::parse_partial_euid},
         validator::ValidatorSchema,
     };
 
@@ -901,7 +879,8 @@ mod request_builder_tests {
         extensions::Extensions,
         tpe::{
             err::RequestBuilderError,
-            request::{test_utils::parse_partial_euid, PartialRequest, RequestBuilder},
+            request::{PartialRequest, RequestBuilder},
+            test_utils::parse_partial_euid,
         },
         validator::{RequestValidationError, ValidatorSchema},
     };
@@ -929,9 +908,9 @@ mod request_builder_tests {
     #[track_caller]
     fn request() -> PartialRequest {
         PartialRequest::new(
-            unknown_euid("A"),
+            parse_partial_euid("A"),
             r#"Action::"a""#.parse().unwrap(),
-            unknown_euid("B"),
+            parse_partial_euid("B"),
             None,
             &schema(),
         )

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -562,7 +562,7 @@ pub(super) mod test {
     use crate::extensions::Extensions;
     use crate::parser::parse_expr;
     use crate::tpe::request::PartialRequest;
-    use crate::tpe::test_utils::unknown_euid;
+    use crate::tpe::test_utils::parse_partial_euid;
     use crate::validator::types::BoolType;
     use crate::validator::ValidatorSchema;
     use cool_asserts::assert_matches;
@@ -581,9 +581,9 @@ pub(super) mod test {
         .0;
 
         let request = PartialRequest::new(
-            unknown_euid("User"),
+            parse_partial_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            unknown_euid("Document"),
+            parse_partial_euid("Document"),
             None,
             &schema,
         )

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -562,7 +562,7 @@ pub(super) mod test {
     use crate::extensions::Extensions;
     use crate::parser::parse_expr;
     use crate::tpe::request::{PartialEntityUID, PartialRequest};
-    use crate::validator::typecheck::{PolicyCheck, Typechecker};
+    use crate::validator::typecheck::Typechecker;
     use crate::validator::types::BoolType;
     use crate::validator::{ValidationMode, Validator, ValidatorSchema};
     use cool_asserts::assert_matches;
@@ -573,14 +573,14 @@ pub(super) mod test {
         let expr = parse_expr(expr_str).unwrap();
         let policy_id = crate::ast::PolicyID::from_string("test");
         let t = Template::new_shared(
-            policy_id,
+            policy_id.clone(),
             None,
             Arc::new(Annotations::default()),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Some(Arc::new(expr)),
+            Some(Arc::new(expr.clone())),
         );
 
         let schema = ValidatorSchema::from_cedarschema_str(r#"
@@ -616,29 +616,25 @@ pub(super) mod test {
 
         let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, &t).collect();
         if !errs.is_empty() {
+            println!("got {} type errors", errs.len());
+            for e in errs {
+                println!("{:?}", miette::Report::new(e));
+            }
             panic!("unexpected type error in expression");
         }
-        match typechecker.typecheck_by_single_request_env(&t, &env) {
-            PolicyCheck::Success(expr) => expr,
-            PolicyCheck::Fail(errs) => {
-                println!("got {} type errors", errs.len());
-                for e in errs {
-                    println!("{:?}", miette::Report::new(e));
-                }
-                panic!("unexpected type error in expression")
+
+        let mut type_errors = HashSet::new();
+        let ans =
+            typechecker.typecheck_expr_with_request_env(&env, &expr, &policy_id, &mut type_errors);
+        if !type_errors.is_empty() {
+            println!("got {} type errors", type_errors.len());
+            for e in type_errors {
+                println!("{:?}", miette::Report::new(e));
             }
-            PolicyCheck::Irrelevant(errs, expr) => {
-                if errs.is_empty() {
-                    expr
-                } else {
-                    println!("got {} type errors", errs.len());
-                    for e in errs {
-                        println!("{:?}", miette::Report::new(e));
-                    }
-                    panic!("unexpected type error in expression")
-                }
-            }
+            panic!("unexpected type error in expression")
         }
+        ans.into_typed_expr()
+            .expect("expected typechecking to produce a typed expression")
     }
 
     #[track_caller]
@@ -660,17 +656,12 @@ pub(super) mod test {
         assert_eq!(
             Expr::from(
                 Residual::try_from_typed_expr(
-                    &parse_typed_expr(
-                        "principal == ?principal && resource in ?resource",
-                        &env
-                    ),
+                    &parse_typed_expr("principal == ?principal && resource in ?resource", &env),
                     &env
                 )
                 .unwrap()
             ),
-            // extra `true &&` because `parse_type_expr` constructs a policy for typechecking
-            parse_expr(r#"true && (true && (true && (principal == User::"alice" && resource in Organization::"org")))"#)
-                .unwrap()
+            parse_expr(r#"principal == User::"alice" && resource in Organization::"org""#).unwrap()
         );
     }
 
@@ -875,10 +866,7 @@ pub(super) mod test {
     }
 
     fn assert_eq_expr(expr_str: &str) {
-        // The unconstrained
-        let e: Expr = format!("true && (true && (true && ({})))", expr_str)
-            .parse()
-            .unwrap();
+        let e: Expr = expr_str.parse().unwrap();
         let residual = parse_residual(expr_str);
         let e2 = Expr::from(residual);
         println!("e: {}", e);

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -558,31 +558,18 @@ impl From<Residual> for Expr {
 #[cfg(test)]
 pub(super) mod test {
     use super::*;
-    use crate::ast::{ActionConstraint, PrincipalConstraint, ResourceConstraint, SlotId, Template};
+    use crate::ast::SlotId;
     use crate::extensions::Extensions;
     use crate::parser::parse_expr;
-    use crate::tpe::request::{PartialEntityUID, PartialRequest};
-    use crate::validator::typecheck::Typechecker;
+    use crate::tpe::request::PartialRequest;
+    use crate::tpe::test_utils::unknown_euid;
     use crate::validator::types::BoolType;
-    use crate::validator::{ValidationMode, Validator, ValidatorSchema};
+    use crate::validator::ValidatorSchema;
     use cool_asserts::assert_matches;
     use similar_asserts::assert_eq;
 
     #[track_caller]
     pub(crate) fn parse_typed_expr(expr_str: &str, slot_env: &SlotEnv) -> Expr<Option<Type>> {
-        let expr = parse_expr(expr_str).unwrap();
-        let policy_id = crate::ast::PolicyID::from_string("test");
-        let t = Template::new_shared(
-            policy_id.clone(),
-            None,
-            Arc::new(Annotations::default()),
-            Effect::Permit,
-            PrincipalConstraint::any(),
-            ActionConstraint::any(),
-            ResourceConstraint::any(),
-            Some(Arc::new(expr.clone())),
-        );
-
         let schema = ValidatorSchema::from_cedarschema_str(r#"
             entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
             entity Organization;
@@ -593,48 +580,16 @@ pub(super) mod test {
         .unwrap()
         .0;
 
-        let typechecker = Typechecker::new(&schema, ValidationMode::Strict);
-
         let request = PartialRequest::new(
-            PartialEntityUID {
-                ty: "User".parse().unwrap(),
-                eid: None,
-            },
+            unknown_euid("User"),
             r#"Action::"get""#.parse().unwrap(),
-            PartialEntityUID {
-                ty: "Document".parse().unwrap(),
-                eid: None,
-            },
+            unknown_euid("Document"),
             None,
             &schema,
         )
         .unwrap();
-        let env = request
-            .find_request_env(&schema)
-            .unwrap()
-            .link_slot_env(slot_env);
 
-        let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, &t).collect();
-        if !errs.is_empty() {
-            println!("got {} type errors", errs.len());
-            for e in errs {
-                println!("{:?}", miette::Report::new(e));
-            }
-            panic!("unexpected type error in expression");
-        }
-
-        let mut type_errors = HashSet::new();
-        let ans =
-            typechecker.typecheck_expr_with_request_env(&env, &expr, &policy_id, &mut type_errors);
-        if !type_errors.is_empty() {
-            println!("got {} type errors", type_errors.len());
-            for e in type_errors {
-                println!("{:?}", miette::Report::new(e));
-            }
-            panic!("unexpected type error in expression")
-        }
-        ans.into_typed_expr()
-            .expect("expected typechecking to produce a typed expression")
+        crate::tpe::test_utils::parse_typed_expr(expr_str, &request, &schema, slot_env)
     }
 
     #[track_caller]

--- a/cedar-policy-core/src/tpe/test_utils.rs
+++ b/cedar-policy-core/src/tpe/test_utils.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Utilities for writing TPE test cases
+
+use std::{collections::HashSet, str::FromStr};
+
+use crate::{
+    ast::{EntityUID, Expr, PolicyID, SlotEnv},
+    parser::parse_expr,
+    tpe::request::{PartialEntityUID, PartialRequest},
+    validator::{typecheck::Typechecker, types::Type, ValidationMode, ValidatorSchema},
+};
+
+#[track_caller]
+pub(crate) fn concrete_euid(euid: &str) -> PartialEntityUID {
+    EntityUID::from_str(euid).unwrap().into()
+}
+
+#[track_caller]
+pub(crate) fn unknown_euid(ty: &str) -> PartialEntityUID {
+    PartialEntityUID {
+        ty: ty.parse().unwrap(),
+        eid: None,
+    }
+}
+
+/// Given a expression as a Cedar source string, parse and typecheck it, giving
+/// a type annotated expression.
+#[track_caller]
+pub(crate) fn parse_typed_expr(
+    expr_str: &str,
+    request: &PartialRequest,
+    schema: &ValidatorSchema,
+    slot_env: &SlotEnv,
+) -> Expr<Option<Type>> {
+    let env = request
+        .find_request_env(&schema)
+        .unwrap()
+        .link_slot_env(slot_env);
+
+    let expr = parse_expr(expr_str).unwrap();
+    let mut type_errors = HashSet::new();
+    let id = PolicyID::from_string("test");
+    let ans = Typechecker::new(schema, ValidationMode::Strict).typecheck_expr_with_request_env(
+        &env,
+        &expr,
+        &id,
+        &mut type_errors,
+    );
+    if !type_errors.is_empty() {
+        println!("got {} type errors", type_errors.len());
+        for e in type_errors {
+            println!("{:?}", miette::Report::new(e));
+        }
+        panic!("unexpected type error in expression")
+    }
+    ans.into_typed_expr()
+        .expect("expected typechecking to produce a typed expression")
+}

--- a/cedar-policy-core/src/tpe/test_utils.rs
+++ b/cedar-policy-core/src/tpe/test_utils.rs
@@ -16,7 +16,7 @@
 
 //! Utilities for writing TPE test cases
 
-use std::{collections::HashSet, str::FromStr};
+use std::collections::HashSet;
 
 use crate::{
     ast::{EntityUID, Expr, PolicyID, SlotEnv},
@@ -25,16 +25,19 @@ use crate::{
     validator::{typecheck::Typechecker, types::Type, ValidationMode, ValidatorSchema},
 };
 
+/// Parse a [`PartialEntityUID`] from a string.
+///
+/// Accepts either a bare entity type (e.g. `A`), yielding an unknown eid, or
+/// a full entity uid (e.g. `A::"foo"`), yielding a concrete eid.
 #[track_caller]
-pub(crate) fn concrete_euid(euid: &str) -> PartialEntityUID {
-    EntityUID::from_str(euid).unwrap().into()
-}
-
-#[track_caller]
-pub(crate) fn unknown_euid(ty: &str) -> PartialEntityUID {
-    PartialEntityUID {
-        ty: ty.parse().unwrap(),
-        eid: None,
+pub(crate) fn parse_partial_euid(s: &str) -> PartialEntityUID {
+    if let Ok(euid) = s.parse::<EntityUID>() {
+        PartialEntityUID::from(euid)
+    } else {
+        PartialEntityUID {
+            ty: s.parse().expect("should parse as an entity type"),
+            eid: None,
+        }
     }
 }
 

--- a/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
@@ -108,12 +108,29 @@ impl Typechecker<'_> {
             principal_slot: None,
             resource_slot: None,
         };
+        self.typecheck_expr_with_request_env(&request_env, e, policy_id, unique_type_errors)
+    }
+
+    /// Typecheck an expression outside the context of a policy, using the given
+    /// `request_env` to determine the types of `principal`, `action`,
+    /// `resource`, and `context`. Unlike policy typechecking, the expression is
+    /// not required to have type boolean; its type is inferred instead.
+    ///
+    /// `policy_id`: Policy ID to associate with this `Expr`, for the purposes
+    /// of reporting the policy ID in validation errors
+    pub(crate) fn typecheck_expr_with_request_env<'a>(
+        &self,
+        request_env: &RequestEnv<'_>,
+        e: &'a Expr,
+        policy_id: &'a PolicyID,
+        unique_type_errors: &mut HashSet<ValidationError>,
+    ) -> TypecheckAnswer<'a> {
         let typechecker = SingleEnvTypechecker {
             schema: self.schema,
             extensions: self.extensions,
             mode: self.mode,
             policy_id,
-            request_env: &request_env,
+            request_env,
         };
         let mut type_errors = Vec::new();
         let ans = typechecker.typecheck(&CapabilitySet::new(), e, &mut type_errors);

--- a/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
@@ -111,13 +111,7 @@ impl Typechecker<'_> {
         self.typecheck_expr_with_request_env(&request_env, e, policy_id, unique_type_errors)
     }
 
-    /// Typecheck an expression outside the context of a policy, using the given
-    /// `request_env` to determine the types of `principal`, `action`,
-    /// `resource`, and `context`. Unlike policy typechecking, the expression is
-    /// not required to have type boolean; its type is inferred instead.
-    ///
-    /// `policy_id`: Policy ID to associate with this `Expr`, for the purposes
-    /// of reporting the policy ID in validation errors
+    /// Typecheck an expression outside the context of a policy, in the given `request_env`.
     pub(crate) fn typecheck_expr_with_request_env<'a>(
         &self,
         request_env: &RequestEnv<'_>,


### PR DESCRIPTION

Instead of manually constructing expression and using `assert_matches` on residuals, we can parse expression and then assert on the string representation of the residual. This makes the tests substantially more compact, and much easier to update and review for future changes to the algorithm. 

Total LOC doesn't change much because I've also add new tests where I felt coverage with incomplete. 

Given the size of this diff I'm mostly asking you to trust that I've not been deleting tests and just review for maintainability and effectiveness of the new tests. Rather than reviewing the diff it's probably easier to just treat the whole test module as new code and review that. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
