### PR TITLE
Simplify `in` set with unknown ancestors

### DIFF
--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -476,6 +476,15 @@ impl PartialEntities {
         self.entities.get(euid)
     }
 
+    /// Get the ancestors for this `PartialEntity`
+    ///
+    /// Returns ancestors if this entity exists and its ancestors are known. TPE treats missing
+    /// entity and unknown ancestors identically. If you need to distinguish them, get the full
+    /// partial entity (if it exists) using [`PartialEntities::get`].
+    pub fn get_ancestors(&self, euid: &EntityUID) -> Option<&HashSet<EntityUID>> {
+        self.get(euid).and_then(|e| e.ancestors())
+    }
+
     /// Check if there is a `PartialEntity` with identifier
     pub fn contains_entity(&self, euid: &EntityUID) -> bool {
         self.entities.contains_key(euid)

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -281,10 +281,22 @@ impl Evaluator<'_> {
                                 if let Ok(uid2) = v2.get_as_entity() {
                                     if uid1 == uid2 {
                                         return mk_concrete(true.into());
+<<<<<<< HEAD
                                     } else if let Some(entity) = self.entities.get(uid1) {
                                         if let Some(ancestors) = entity.ancestors() {
                                             return mk_concrete(ancestors.contains(uid2).into());
                                         }
+||||||| parent of 4d4582f9 (Simplify `in` set with unknown ancestors)
+                                    } else if let Some(entity) = self.entities.get(uid1) {
+                                        if let Some(ancestors) = &entity.ancestors {
+                                            return mk_concrete(ancestors.contains(uid2).into());
+                                        }
+=======
+                                    } else if let Some(ancestors) =
+                                        self.entities.get_ancestors(uid1)
+                                    {
+                                        return mk_concrete(ancestors.contains(uid2).into());
+>>>>>>> 4d4582f9 (Simplify `in` set with unknown ancestors)
                                     }
                                     binapp_residual(arg1, arg2)
                                 } else if let Ok(s) = v2.get_as_set() {
@@ -293,6 +305,7 @@ impl Evaluator<'_> {
                                         .map(Value::get_as_entity)
                                         .collect::<std::result::Result<Vec<_>, _>>()
                                     {
+<<<<<<< HEAD
                                         for uid2 in uids {
                                             if uid1 == uid2 {
                                                 return mk_concrete(true.into());
@@ -307,8 +320,35 @@ impl Evaluator<'_> {
                                             } else {
                                                 return binapp_residual(arg1, arg2);
                                             }
+||||||| parent of 4d4582f9 (Simplify `in` set with unknown ancestors)
+                                        for uid2 in uids {
+                                            if uid1 == uid2 {
+                                                return mk_concrete(true.into());
+                                            } else if let Some(entity) = self.entities.get(uid1) {
+                                                if let Some(ancestors) = &entity.ancestors {
+                                                    if ancestors.contains(uid2) {
+                                                        return mk_concrete(true.into());
+                                                    }
+                                                } else {
+                                                    return binapp_residual(arg1, arg2);
+                                                }
+                                            } else {
+                                                return binapp_residual(arg1, arg2);
+                                            }
+=======
+                                        let ancestors = self.entities.get_ancestors(uid1);
+                                        if uids.contains(&uid1)
+                                            || ancestors.is_some_and(|ancestors| {
+                                                uids.iter().any(|uid2| ancestors.contains(uid2))
+                                            })
+                                        {
+                                            mk_concrete(true.into())
+                                        } else if ancestors.is_none() {
+                                            binapp_residual(arg1, arg2)
+                                        } else {
+                                            mk_concrete(false.into())
+>>>>>>> 4d4582f9 (Simplify `in` set with unknown ancestors)
                                         }
-                                        mk_concrete(false.into())
                                     } else {
                                         mk_error()
                                     }

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -1847,6 +1847,23 @@ mod tests {
             interpret_typed_str_to_str(r#"E::"parents_none" in [resource]"#),
             @r#"E::"parents_none" in [E::"resource"]"#
         );
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in E::"undefined""#),
+            @r#"true"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [E::"undefined"]"#),
+            @r#"true"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [E::"undefined", E::"other"]"#),
+            @r#"true"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [E::"other", E::"undefined"]"#),
+            @r#"true"#
+        );
     }
 
     fn binary_app_tags_env() -> (ValidatorSchema, PartialEntities, PartialRequest) {

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -343,7 +343,7 @@ impl Evaluator<'_> {
                                             })
                                         {
                                             mk_concrete(true.into())
-                                        } else if ancestors.is_none() {
+                                        } else if !uids.is_empty() && ancestors.is_none() {
                                             binapp_residual(arg1, arg2)
                                         } else {
                                             mk_concrete(false.into())
@@ -1872,6 +1872,55 @@ mod tests {
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"undefined" in [E::"undefined", (if 9223372036854775807 * 2 == 0 then E::"undefined" else E::"undefined")]"#),
             @"error()"
+        );
+    }
+
+    #[test]
+    fn test_binary_app_in_empty_set() {
+        let schema = parse_schema(
+            r#"entity E in E; entity User in E; action get appliesTo {principal: User, resource: E, context: {empty: Set<E>}};"#,
+        );
+        let Ok(Context::Value(context)) =
+            Context::from_json_value(serde_json::json!({ "empty": [] }))
+        else {
+            panic!("expected concrete context")
+        };
+        let req = PartialRequest::new(
+            parse_partial_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            parse_partial_euid("E"),
+            Some(context),
+            &schema,
+        )
+        .unwrap();
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "has_parents" },
+                    "parents": [ { "type": "E", "id": "" } ],
+                }
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"has_parents" in context.empty"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"unknown" in context.empty"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"resource in context.empty"#),
+            @"resource in []"
         );
     }
 

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -1864,6 +1864,15 @@ mod tests {
             interpret_typed_str_to_str(r#"E::"undefined" in [E::"other", E::"undefined"]"#),
             @r#"true"#
         );
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [E::"undefined", context.e]"#),
+            @r#"E::"undefined" in [E::"undefined", context.e]"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"undefined" in [E::"undefined", (if 9223372036854775807 * 2 == 0 then E::"undefined" else E::"undefined")]"#),
+            @"error()"
+        );
     }
 
     fn binary_app_tags_env() -> (ValidatorSchema, PartialEntities, PartialRequest) {

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -281,22 +281,10 @@ impl Evaluator<'_> {
                                 if let Ok(uid2) = v2.get_as_entity() {
                                     if uid1 == uid2 {
                                         return mk_concrete(true.into());
-<<<<<<< HEAD
-                                    } else if let Some(entity) = self.entities.get(uid1) {
-                                        if let Some(ancestors) = entity.ancestors() {
-                                            return mk_concrete(ancestors.contains(uid2).into());
-                                        }
-||||||| parent of 4d4582f9 (Simplify `in` set with unknown ancestors)
-                                    } else if let Some(entity) = self.entities.get(uid1) {
-                                        if let Some(ancestors) = &entity.ancestors {
-                                            return mk_concrete(ancestors.contains(uid2).into());
-                                        }
-=======
                                     } else if let Some(ancestors) =
                                         self.entities.get_ancestors(uid1)
                                     {
                                         return mk_concrete(ancestors.contains(uid2).into());
->>>>>>> 4d4582f9 (Simplify `in` set with unknown ancestors)
                                     }
                                     binapp_residual(arg1, arg2)
                                 } else if let Ok(s) = v2.get_as_set() {
@@ -305,37 +293,6 @@ impl Evaluator<'_> {
                                         .map(Value::get_as_entity)
                                         .collect::<std::result::Result<Vec<_>, _>>()
                                     {
-<<<<<<< HEAD
-                                        for uid2 in uids {
-                                            if uid1 == uid2 {
-                                                return mk_concrete(true.into());
-                                            } else if let Some(entity) = self.entities.get(uid1) {
-                                                if let Some(ancestors) = entity.ancestors() {
-                                                    if ancestors.contains(uid2) {
-                                                        return mk_concrete(true.into());
-                                                    }
-                                                } else {
-                                                    return binapp_residual(arg1, arg2);
-                                                }
-                                            } else {
-                                                return binapp_residual(arg1, arg2);
-                                            }
-||||||| parent of 4d4582f9 (Simplify `in` set with unknown ancestors)
-                                        for uid2 in uids {
-                                            if uid1 == uid2 {
-                                                return mk_concrete(true.into());
-                                            } else if let Some(entity) = self.entities.get(uid1) {
-                                                if let Some(ancestors) = &entity.ancestors {
-                                                    if ancestors.contains(uid2) {
-                                                        return mk_concrete(true.into());
-                                                    }
-                                                } else {
-                                                    return binapp_residual(arg1, arg2);
-                                                }
-                                            } else {
-                                                return binapp_residual(arg1, arg2);
-                                            }
-=======
                                         let ancestors = self.entities.get_ancestors(uid1);
                                         if uids.contains(&uid1)
                                             || ancestors.is_some_and(|ancestors| {
@@ -347,7 +304,6 @@ impl Evaluator<'_> {
                                             binapp_residual(arg1, arg2)
                                         } else {
                                             mk_concrete(false.into())
->>>>>>> 4d4582f9 (Simplify `in` set with unknown ancestors)
                                         }
                                     } else {
                                         mk_error()

--- a/cedar-policy-core/src/tpe/test_utils.rs
+++ b/cedar-policy-core/src/tpe/test_utils.rs
@@ -55,7 +55,15 @@ pub(crate) fn parse_typed_expr(
         .unwrap()
         .link_slot_env(slot_env);
 
-    let expr = parse_expr(expr_str).unwrap();
+    let expr = match parse_expr(expr_str) {
+        Ok(expr) => expr,
+        Err(es) => {
+            for e in es {
+                println!("{:?}", miette::Report::new(e));
+            }
+            panic!("parse error on input expression");
+        }
+    };
     let mut type_errors = HashSet::new();
     let id = PolicyID::from_string("test");
     let ans = Typechecker::new(schema, ValidationMode::Strict).typecheck_expr_with_request_env(


### PR DESCRIPTION
## Description of changes

Minor improvement to TPE for `in` set, allowing simplification of `User::"alice" in [Group::"admins",User::"alice"]` when ancestors of alice are unknown. 

Not expecting this to be useful anywhere, but the early return path just looked wrong in the code.

Lean at https://github.com/cedar-policy/cedar-spec/pull/980

I'll add a test case covering the changed behavior once #2448 is merged 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
