### PR TITLE
Introduce more helpers to simplfiy TPE evaluator

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -817,7 +817,7 @@ impl<'e> Evaluator<'e> {
         // check if `uid1` is a descendant of
         let rhs = match &arg2.value {
             ValueKind::Lit(Literal::EntityUID(uid)) => vec![uid.as_ref()],
-            ValueKind::Set(_) => arg2.as_entity_set()?,
+            ValueKind::Set(_) => arg2.get_as_entity_set()?,
             _ => {
                 return Err(EvaluationError::type_error(
                     nonempty![Type::Set, Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
@@ -1150,7 +1150,7 @@ impl Value {
 
     /// Convert the `Value` to a set of entities, throwing a type error if it's
     /// not a set, or a type error if any of its elements is not an entity.
-    pub(crate) fn as_entity_set(&self) -> Result<Vec<&EntityUID>> {
+    pub(crate) fn get_as_entity_set(&self) -> Result<Vec<&EntityUID>> {
         self.get_as_set()?
             .iter()
             .map(Value::get_as_entity)

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -20,7 +20,7 @@ use crate::ast::*;
 use crate::entities::{Dereference, Entities};
 use crate::extensions::Extensions;
 use crate::parser::Loc;
-#[cfg(feature = "partial-eval")]
+#[cfg(any(feature = "partial-eval", feature = "tpe"))]
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -589,8 +589,8 @@ impl<'e> Evaluator<'e> {
                             Dereference::Residual(r) => Ok(PartialValue::Residual(
                                 Expr::binary_app(BinaryOp::In, r, arg2.into()),
                             )),
-                            Dereference::NoSuchEntity => self.eval_in(uid1, None, arg2),
-                            Dereference::Data(entity1) => self.eval_in(uid1, Some(entity1), arg2),
+                            Dereference::NoSuchEntity => self.eval_in(uid1, None, &arg2),
+                            Dereference::Data(entity1) => self.eval_in(uid1, Some(entity1), &arg2),
                         }
                     }
                     // contains, which works on Sets
@@ -811,31 +811,22 @@ impl<'e> Evaluator<'e> {
         &self,
         uid1: &EntityUID,
         entity1: Option<&Entity>,
-        arg2: Value,
+        arg2: &Value,
     ) -> Result<PartialValue> {
         // `rhs` is a list of all the UIDs for which we need to
         // check if `uid1` is a descendant of
-        let rhs = match arg2.value {
-            ValueKind::Lit(Literal::EntityUID(uid)) => vec![Arc::unwrap_or_clone(uid)],
-            // we assume that iterating the `authoritative` BTreeSet is
-            // approximately the same cost as iterating the `fast` HashSet
-            ValueKind::Set(Set { authoritative, .. }) => authoritative
-                .iter()
-                .map(|val| Ok(val.get_as_entity()?.clone()))
-                .collect::<Result<Vec<EntityUID>>>()?,
+        let rhs = match &arg2.value {
+            ValueKind::Lit(Literal::EntityUID(uid)) => vec![uid.as_ref()],
+            ValueKind::Set(_) => arg2.as_entity_set()?,
             _ => {
                 return Err(EvaluationError::type_error(
                     nonempty![Type::Set, Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
-                    &arg2,
+                    arg2,
                 ))
             }
         };
         for uid2 in rhs {
-            if uid1 == &uid2
-                || entity1
-                    .map(|e1| e1.is_descendant_of(&uid2))
-                    .unwrap_or(false)
-            {
+            if uid1 == uid2 || entity1.map(|e1| e1.is_descendant_of(uid2)).unwrap_or(false) {
                 return Ok(true.into());
             }
         }
@@ -1137,7 +1128,7 @@ impl Value {
     }
 
     /// Convert the `Value` to a Record, or throw a type error if it's not a Record.
-    #[cfg(feature = "partial-eval")]
+    #[cfg(any(feature = "partial-eval", feature = "tpe"))]
     pub(crate) fn get_as_record(&self) -> Result<&Arc<BTreeMap<SmolStr, Value>>> {
         match &self.value {
             ValueKind::Record(rec) => Ok(rec),
@@ -1155,6 +1146,15 @@ impl Value {
                 self,
             )),
         }
+    }
+
+    /// Convert the `Value` to a set of entities, throwing a type error if it's
+    /// not a set, or a type error if any of its elements is not an entity.
+    pub(crate) fn as_entity_set(&self) -> Result<Vec<&EntityUID>> {
+        self.get_as_set()?
+            .iter()
+            .map(Value::get_as_entity)
+            .collect()
     }
 }
 

--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -485,6 +485,24 @@ impl PartialEntities {
         self.get(euid).and_then(|e| e.ancestors())
     }
 
+    /// Get the attributes for this `PartialEntity`
+    ///
+    /// Returns attributes if this entity exists and its attributes are known. TPE treats missing
+    /// entity and unknown attributes identically. If you need to distinguish them, get the full
+    /// partial entity (if it exists) using [`PartialEntities::get`].
+    pub fn get_attrs(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {
+        self.get(euid).and_then(|e| e.attrs())
+    }
+
+    /// Get the tags for this `PartialEntity`
+    ///
+    /// Returns tags if this entity exists and its tags are known. TPE treats missing entity and
+    /// unknown tags identically. If you need to distinguish them, get the full partial entity (if
+    /// it exists) using [`PartialEntities::get`].
+    pub fn get_tags(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {
+        self.get(euid).and_then(|e| e.tags())
+    }
+
     /// Check if there is a `PartialEntity` with identifier
     pub fn contains_entity(&self, euid: &EntityUID) -> bool {
         self.entities.contains_key(euid)

--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -478,7 +478,7 @@ impl PartialEntities {
 
     /// Get the ancestors for this `PartialEntity`
     ///
-    /// Returns ancestors if this entity exists and its ancestors are known. TPE treats missing
+    /// Returns ancestors if this entity exists and its ancestors are known. TPE treats a missing
     /// entity and unknown ancestors identically. If you need to distinguish them, get the full
     /// partial entity (if it exists) using [`PartialEntities::get`].
     pub fn get_ancestors(&self, euid: &EntityUID) -> Option<&HashSet<EntityUID>> {
@@ -487,7 +487,7 @@ impl PartialEntities {
 
     /// Get the attributes for this `PartialEntity`
     ///
-    /// Returns attributes if this entity exists and its attributes are known. TPE treats missing
+    /// Returns attributes if this entity exists and its attributes are known. TPE treats a missing
     /// entity and unknown attributes identically. If you need to distinguish them, get the full
     /// partial entity (if it exists) using [`PartialEntities::get`].
     pub fn get_attrs(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {
@@ -496,7 +496,7 @@ impl PartialEntities {
 
     /// Get the tags for this `PartialEntity`
     ///
-    /// Returns tags if this entity exists and its tags are known. TPE treats missing entity and
+    /// Returns tags if this entity exists and its tags are known. TPE treats a missing entity and
     /// unknown tags identically. If you need to distinguish them, get the full partial entity (if
     /// it exists) using [`PartialEntities::get`].
     pub fn get_tags(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -277,89 +277,67 @@ impl Evaluator<'_> {
                             }
                         }
                         BinaryOp::In => {
-                            if let Ok(uid1) = v1.get_as_entity() {
-                                if let Ok(uid2) = v2.get_as_entity() {
-                                    if uid1 == uid2 {
-                                        return mk_concrete(true.into());
-                                    } else if let Some(ancestors) =
-                                        self.entities.get_ancestors(uid1)
-                                    {
-                                        return mk_concrete(ancestors.contains(uid2).into());
-                                    }
+                            let Ok(uid1) = v1.get_as_entity() else {
+                                return mk_error();
+                            };
+                            if let Ok(uid2) = v2.get_as_entity() {
+                                if uid1 == uid2 {
+                                    return mk_concrete(true.into());
+                                } else if let Some(ancestors) = self.entities.get_ancestors(uid1) {
+                                    return mk_concrete(ancestors.contains(uid2).into());
+                                }
+                                binapp_residual(arg1, arg2)
+                            } else if let Ok(uids) = v2.as_entity_set() {
+                                let ancestors = self.entities.get_ancestors(uid1);
+                                if uids.contains(&uid1)
+                                    || ancestors.is_some_and(|ancestors| {
+                                        uids.iter().any(|uid2| ancestors.contains(uid2))
+                                    })
+                                {
+                                    // The set contains `uid1`, or `uid1` has known ancestors and the set contains one of these
+                                    mk_concrete(true.into())
+                                } else if !uids.is_empty() && ancestors.is_none() {
+                                    // `uid1` was not in the set and has unknown ancestors, so we can't reach a concrete value
+                                    // unless the set happens to be empty.
                                     binapp_residual(arg1, arg2)
-                                } else if let Ok(s) = v2.get_as_set() {
-                                    if let Ok(uids) = s
-                                        .iter()
-                                        .map(Value::get_as_entity)
-                                        .collect::<std::result::Result<Vec<_>, _>>()
-                                    {
-                                        let ancestors = self.entities.get_ancestors(uid1);
-                                        if uids.contains(&uid1)
-                                            || ancestors.is_some_and(|ancestors| {
-                                                uids.iter().any(|uid2| ancestors.contains(uid2))
-                                            })
-                                        {
-                                            mk_concrete(true.into())
-                                        } else if !uids.is_empty() && ancestors.is_none() {
-                                            binapp_residual(arg1, arg2)
-                                        } else {
-                                            mk_concrete(false.into())
-                                        }
-                                    } else {
-                                        mk_error()
-                                    }
                                 } else {
-                                    mk_error()
+                                    // `uid1` and it's ancestors are not in set
+                                    mk_concrete(false.into())
                                 }
                             } else {
                                 mk_error()
                             }
                         }
                         BinaryOp::GetTag => {
-                            if let Ok(uid) = v1.get_as_entity() {
-                                if let Ok(tag) = v2.get_as_string() {
-                                    if let Some(entity) = self.entities.get(uid) {
-                                        if let Some(tags) = entity.tags() {
-                                            if let Some(v) = tags.get(tag) {
-                                                mk_concrete(v.clone())
-                                            } else {
-                                                mk_error()
-                                            }
-                                        } else {
-                                            binapp_residual(arg1, arg2)
-                                        }
-                                    } else {
-                                        binapp_residual(arg1, arg2)
-                                    }
-                                } else {
-                                    mk_error()
-                                }
-                            } else {
-                                mk_error()
+                            let Ok(uid) = v1.get_as_entity() else {
+                                return mk_error();
+                            };
+                            let Ok(tag) = v2.get_as_string() else {
+                                return mk_error();
+                            };
+                            match self.entities.get_tags(uid) {
+                                Some(tags) => match tags.get(tag) {
+                                    Some(v) => mk_concrete(v.clone()),
+                                    None => mk_error(),
+                                },
+                                None => binapp_residual(arg1, arg2),
                             }
                         }
                         BinaryOp::HasTag => {
-                            if let Ok(uid) = v1.get_as_entity() {
-                                if let Ok(tag) = v2.get_as_string() {
-                                    if let Some(entity) = self.entities.get(uid) {
-                                        if let Some(tags) = entity.tags() {
-                                            mk_concrete(tags.contains_key(tag).into())
-                                        } else {
-                                            binapp_residual(arg1, arg2)
-                                        }
-                                    } else {
-                                        binapp_residual(arg1, arg2)
-                                    }
-                                } else {
-                                    mk_error()
-                                }
-                            } else {
-                                mk_error()
+                            let Ok(uid) = v1.get_as_entity() else {
+                                return mk_error();
+                            };
+                            let Ok(tag) = v2.get_as_string() else {
+                                return mk_error();
+                            };
+                            match self.entities.get_tags(uid) {
+                                Some(tags) => mk_concrete(tags.contains_key(tag).into()),
+                                None => binapp_residual(arg1, arg2),
                             }
                         }
-                        BinaryOp::Contains => match &v1.value {
-                            ValueKind::Set(s) => mk_concrete(s.contains(v2).into()),
-                            _ => mk_error(),
+                        BinaryOp::Contains => match v1.get_as_set() {
+                            Ok(s) => mk_concrete(s.contains(v2).into()),
+                            Err(_) => mk_error(),
                         },
                         BinaryOp::ContainsAll => match (v1.get_as_set(), v2.get_as_set()) {
                             (Ok(arg1_set), Ok(arg2_set)) => {
@@ -409,43 +387,28 @@ impl Evaluator<'_> {
             ResidualKind::GetAttr { expr, attr } => {
                 let expr = self.interpret(expr);
                 match &expr {
-                    Residual::Concrete {
-                        value:
-                            Value {
-                                value: ValueKind::Record(r),
-                                ..
-                            },
-                        ..
-                    } => {
-                        if let Some(val) = r.as_ref().get(attr) {
-                            mk_concrete(val.clone())
+                    Residual::Concrete { value, .. } => {
+                        if let Ok(r) = value.get_as_record() {
+                            if let Some(val) = r.as_ref().get(attr) {
+                                mk_concrete(val.clone())
+                            } else {
+                                mk_error()
+                            }
+                        } else if let Ok(uid) = value.get_as_entity() {
+                            match self.entities.get_attrs(uid) {
+                                Some(attrs) => match attrs.get(attr) {
+                                    Some(val) => mk_concrete(val.clone()),
+                                    None => mk_error(),
+                                },
+                                None => mk_residual(ResidualKind::GetAttr {
+                                    expr: Arc::new(expr),
+                                    attr: attr.clone(),
+                                }),
+                            }
                         } else {
                             mk_error()
                         }
                     }
-                    Residual::Concrete {
-                        value:
-                            Value {
-                                value: ValueKind::Lit(ast::Literal::EntityUID(uid)),
-                                ..
-                            },
-                        ..
-                    } => {
-                        if let Some(entity) = self.entities.get(uid.as_ref()) {
-                            if let Some(attrs) = entity.attrs() {
-                                if let Some(val) = attrs.get(attr) {
-                                    return mk_concrete(val.clone());
-                                } else {
-                                    return mk_error();
-                                }
-                            }
-                        }
-                        mk_residual(ResidualKind::GetAttr {
-                            expr: Arc::new(expr),
-                            attr: attr.clone(),
-                        })
-                    }
-                    Residual::Concrete { .. } => mk_error(),
                     Residual::Partial { .. } => mk_residual(ResidualKind::GetAttr {
                         expr: Arc::new(expr),
                         attr: attr.clone(),
@@ -456,33 +419,21 @@ impl Evaluator<'_> {
             ResidualKind::HasAttr { expr, attr } => {
                 let expr = self.interpret(expr);
                 match &expr {
-                    Residual::Concrete {
-                        value:
-                            Value {
-                                value: ValueKind::Record(r),
-                                ..
-                            },
-                        ..
-                    } => mk_concrete(r.as_ref().contains_key(attr).into()),
-                    Residual::Concrete {
-                        value:
-                            Value {
-                                value: ValueKind::Lit(ast::Literal::EntityUID(uid)),
-                                ..
-                            },
-                        ..
-                    } => {
-                        if let Some(entity) = self.entities.get(uid.as_ref()) {
-                            if let Some(attrs) = entity.attrs() {
-                                return mk_concrete(attrs.contains_key(attr).into());
+                    Residual::Concrete { value, .. } => {
+                        if let Ok(r) = value.get_as_record() {
+                            mk_concrete(r.as_ref().contains_key(attr).into())
+                        } else if let Ok(uid) = value.get_as_entity() {
+                            match self.entities.get_attrs(uid) {
+                                Some(attrs) => mk_concrete(attrs.contains_key(attr).into()),
+                                None => mk_residual(ResidualKind::HasAttr {
+                                    expr: Arc::new(expr),
+                                    attr: attr.clone(),
+                                }),
                             }
+                        } else {
+                            mk_error()
                         }
-                        mk_residual(ResidualKind::HasAttr {
-                            expr: Arc::new(expr),
-                            attr: attr.clone(),
-                        })
                     }
-                    Residual::Concrete { .. } => mk_error(),
                     Residual::Partial { .. } => mk_residual(ResidualKind::HasAttr {
                         expr: Arc::new(expr),
                         attr: attr.clone(),

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -287,7 +287,7 @@ impl Evaluator<'_> {
                                     return mk_concrete(ancestors.contains(uid2).into());
                                 }
                                 binapp_residual(arg1, arg2)
-                            } else if let Ok(uids) = v2.as_entity_set() {
+                            } else if let Ok(uids) = v2.get_as_entity_set() {
                                 let ancestors = self.entities.get_ancestors(uid1);
                                 if uids.contains(&uid1)
                                     || ancestors.is_some_and(|ancestors| {


### PR DESCRIPTION
## Description of changes

Adds

* `PartialEntities::get_attrs` and `PartialEntities::get_tags`, mirroring the existing `get_ancestors`
* Adds `Value::as_entity_set` for the somewhat complex matching logic used to get the set-of-entities out of `in` operands. I also use this helper in the concrete evaluator, so review that code carefully.

This PR also restructures some of the TPE evaluator code to have a less nested structure. There were previously some nested ifs like

```
if let Ok(e1) = v1.as_entity() {
  ...
} else {
  return mk_error();
}
```

When the "then" branch was long with nested conditionals inside, it becomes hard to keep track of what level indentation go with what guard, so IMO this flatter structure is easier to understand.

Review with ignore whitespace changes enabled.

( think this is the last TPE refactoring change in the pipeline for now)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
