### PR TITLE
Add comment documenting lack of validaiton in `ActionRequest` constructor

### DIFF
--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -264,7 +264,7 @@ pub struct ActionQueryRequest {
 }
 
 impl ActionQueryRequest {
-    /// Construct an [`ActionQueryRequest`]
+    /// Construct an [`ActionQueryRequest`].
     ///
     /// Unlike [`PartialRequest::new`] this constructor cannot validate the
     /// request because request validation requires knowing the specific action

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -266,11 +266,11 @@ pub struct ActionQueryRequest {
 impl ActionQueryRequest {
     /// Construct an [`ActionQueryRequest`].
     ///
-    /// Unlike [`PartialRequest::new`] this constructor cannot validate the
+    /// Unlike [`PartialRequest::new`], this constructor cannot validate the
     /// request because request validation requires knowing the specific action
     /// being authorized. Further, [`PolicySet::query_action`] cannot report
     /// request validation errors because it is expected that the
-    /// `principal`,`resource`, and `context` will be invalid for many of the
+    /// `principal`, `resource`, and `context` will be invalid for many of the
     /// actions in the schema.
     pub fn new(
         principal: PartialEntityUid,

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -264,7 +264,14 @@ pub struct ActionQueryRequest {
 }
 
 impl ActionQueryRequest {
-    /// Construct a valid [`ActionQueryRequest`] according to a [`Schema`]
+    /// Construct an [`ActionQueryRequest`]
+    ///
+    /// Unlike [`PartialRequest::new`] this constructor cannot validate the
+    /// request because request validation requires knowing the specific action
+    /// being authorized. Further, [`PolicySet::query_action`] cannot report
+    /// request validation errors because it is expected that the
+    /// `principal`,`resource`, and `context` will be invalid for many of the
+    /// actions in the schema.
     pub fn new(
         principal: PartialEntityUid,
         resource: PartialEntityUid,


### PR DESCRIPTION
## Description of changes

Documents confusing point in this API. We could consider changing the API before stabilizing, but exactly what it should do isn't obvious given that we do need an action to validate a request. 



## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
