### PR TITLE
update educe to 0.7.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "educe"
-version = "0.6.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+checksum = "92c3e1715a2bf74bc8f68cd7bae12ff144f02669c602106ad1fa16f2ba62e646"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -27,7 +27,7 @@ stacker = "0.1.24"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 miette = { version = "7.6.0", features = ["serde"] }
 nonempty = { version = "0.12.0", features = ["serialize"] }
-educe = "0.6.0"
+educe = "0.7.4"
 unicode-security = "0.1.0"
 regex = { version = "1.12", features = ["unicode"] }
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }

--- a/cedar-policy-core/src/validator/json_schema.rs
+++ b/cedar-policy-core/src/validator/json_schema.rs
@@ -438,7 +438,7 @@ pub struct NamespaceDefinition<N> {
 
     #[cfg(feature = "extended-schema")]
     #[serde(skip)]
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub loc: Option<Loc>,
 }
 
@@ -1341,7 +1341,7 @@ impl From<EntityUID> for ActionEntityUID<Name> {
 /// this [`Type`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Educe, Debug, Clone, Serialize)]
-#[educe(PartialEq(bound(N: PartialEq)), Eq, PartialOrd, Ord(bound(N: Ord)))]
+#[educe(PartialEq(bound(N: PartialEq)), Eq(bound(N: Eq)), PartialOrd(bound(N: PartialOrd)), Ord(bound(N: Ord)))]
 // This enum is `untagged` with these variants as a workaround to a serde
 // limitation. It is not possible to have the known variants on one enum, and
 // then, have catch-all variant for any unrecognized tag in the same enum that
@@ -2154,7 +2154,7 @@ impl RecordType<ConditionalName> {
 /// this [`TypeVariant`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Educe, Debug, Clone, Serialize, Deserialize)]
-#[educe(PartialEq(bound(N: PartialEq)), Eq, PartialOrd, Ord(bound(N: Ord)))]
+#[educe(PartialEq(bound(N: PartialEq)), Eq(bound(N: Eq)), PartialOrd(bound(N: PartialOrd)), Ord(bound(N: Ord)))]
 #[serde(tag = "type")]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
@@ -2448,7 +2448,7 @@ pub struct TypeOfAttribute<N> {
 
     /// Source location - if available
     #[cfg(feature = "extended-schema")]
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     #[serde(skip)]
     pub loc: Option<Loc>,
 }

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -201,11 +201,11 @@ pub struct LocatedCommonType {
     pub name: SmolStr,
 
     /// Common type name source location if available
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub name_loc: Option<Loc>,
 
     /// Common type definition source location if available
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub type_loc: Option<Loc>,
 }
 
@@ -233,11 +233,11 @@ pub struct LocatedNamespace {
     /// Name of namespace
     pub name: SmolStr,
     /// Namespace name source location if available
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub name_loc: Option<Loc>,
 
     /// Namespace definition source location if available
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub def_loc: Option<Loc>,
 }
 

--- a/cedar-policy-core/src/validator/types.rs
+++ b/cedar-policy-core/src/validator/types.rs
@@ -1223,7 +1223,7 @@ pub struct AttributeType {
     pub is_required: bool,
     ///  Source location - if available
     #[cfg(feature = "extended-schema")]
-    #[educe(Eq(ignore))]
+    #[educe(PartialEq(ignore))]
     pub loc: Option<Loc>,
 }
 


### PR DESCRIPTION
## Description of changes

See changelog here https://github.com/magiclen/educe/blob/master/CHANGELOG-0.6.0-to-0.7.0.md

The `Eq(ignore)` change is exactly as documented there. It also documents that something changed with bounds, but fixing it was trial and error.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
