### PR TITLE
checking the PolicySet and Schema try_validate

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -691,16 +691,21 @@ impl PolicySet {
     }
 
     /// Validate that the [`PolicySet`] is well-formed, on top of the invariants guaranteed by the
-    /// public methods. This is useful when the [`PolicySet`] has been constructed directly
-    /// from Rust code, without going through the Cedar or JSON syntax parsers.
+    /// public methods. This is useful when the [`PolicySet`] has been constructed without going
+    /// through the Cedar or JSON syntax parsers. In other words, this checks invariants of
+    /// syntactically valid policy sets, but nothing more.
     ///
-    /// Checks the following invariants:
-    /// - each individual [`Template`] is valid,
+    /// More specifically, this checks the following invariants:
+    /// - each individual [`Template`] is valid (see [`Template::try_validate`]),
     /// - every non-static link references a template with at least one slot.
     ///
-    /// This assumes the [`PolicySet`] has been constructed with the public API methods
-    /// (e.g. [`PolicySet::add`]), which ensure the invariants documented for [`self.templates`],
-    /// [`self.links`] and [`self.template_to_links_map`] hold.
+    /// This does NOT check the following, which are instead ensured by construction
+    /// via the public API methods or the conversion [`TryFrom<LiteralPolicySet>`]:
+    /// - slot binding correctness: the `values` match the template's slots,
+    /// - no duplicate policy IDs across templates and links,
+    /// - every link's template exists in `templates`,
+    /// - consistency of `template_to_links_map` with `templates` and `links`,
+    /// - that linked policy IDs don't collide with template IDs.
     pub fn try_validate(self) -> Result<Self, PolicySetValidationError> {
         for (link_id, policy) in &self.links {
             if !policy.is_static() {

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -306,7 +306,10 @@ impl TryFrom<json_schema::Fragment<RawName>> for ValidatorSchema {
 }
 
 impl ValidatorSchema {
-    /// Construct a new `ValidatorSchema` from a set of `ValidatorEntityType`s and `ValidatorActionId`s
+    /// Construct a new `ValidatorSchema` from a set of `ValidatorEntityType`s and `ValidatorActionId`s.
+    ///
+    /// The caller must ensure that there are no duplicate entity type names or action names
+    /// in the input. Duplicates are silently collapsed (last entry wins).
     pub fn new(
         entity_types: impl IntoIterator<Item = ValidatorEntityType>,
         action_ids: impl IntoIterator<Item = ValidatorActionId>,
@@ -1225,6 +1228,25 @@ impl ValidatorSchema {
     /// This is useful when the schema has been constructed directly from Rust code,
     /// without going through the JSON or Cedar schema syntax, and thus may not have
     /// been checked for well-formedness by the JSON or Cedar schema parsers.
+    ///
+    /// More specifically, this checks the following:
+    /// - all entity types referenced are declared,
+    /// - all extension types in the schema are known extensions,
+    /// - `entity_types` does not declare actions and `action_ids` declares only actions,
+    /// - enum entities do not appear as descendants,
+    /// - RFC 70 shadowing rules are satisfied.
+    /// Additionally, this recomputes the transitive closure computation for entity types
+    /// and actions.
+    ///
+    /// This does NOT check the following, which must be ensured before construction:
+    /// - duplicate entity type or action declarations (duplicates are silently collapsed
+    ///   by [`ValidatorSchema::new`] since it collects into a `HashMap`; the protobuf
+    ///   conversion path detects duplicates before calling `new`),
+    /// - that context types are records
+    /// - common type resolution
+    ///
+    // Note: the invariants that are not checked and mentioned above are guaranteed
+    // by construction through the parsing paths, and the construction from protobuf.
     //
     // Note: The checks here partially overlap with `check_for_undeclared` and
     // the TC computation in `from_schema_fragments`. We cannot reuse those
@@ -1238,10 +1260,10 @@ impl ValidatorSchema {
         self.check_references_wf()?;
         self.check_extension_types_wf()?;
         self.check_decls_wf()?;
-        // Recompute transitive closure for entity types and actions,
-        // which also detects cycles in the action hierarchy.
+        // Recompute transitive closure for entity types and actions
         compute_tc(&mut self.entity_types, false)
             .map_err(|e| EntityTypeTransitiveClosureError::from(Box::new(e)))?;
+        // Also checks that the action hierarchy does not contain cycles.
         compute_tc(&mut self.action_ids, true)?;
         // Check hierarchy well-formedness AFTER transitive closure so that
         // transitive descendants are included in the enum-in-hierarchy check.

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -19,14 +19,14 @@
 use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::ast::{self, Eid};
-use cedar_policy_core::validator::types;
+use cedar_policy_core::validator::{self, types};
 use nonempty::NonEmpty;
 use smol_str::SmolStr;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-impl From<&cedar_policy_core::validator::ValidatorSchema> for models::Schema {
-    fn from(v: &cedar_policy_core::validator::ValidatorSchema) -> Self {
+impl From<&validator::ValidatorSchema> for models::Schema {
+    fn from(v: &validator::ValidatorSchema) -> Self {
         Self {
             entity_decls: v.entity_types().map(models::EntityDecl::from).collect(),
             action_decls: v.action_ids().map(models::ActionDecl::from).collect(),
@@ -34,51 +34,64 @@ impl From<&cedar_policy_core::validator::ValidatorSchema> for models::Schema {
     }
 }
 
-impl TryFrom<models::Schema> for cedar_policy_core::validator::ValidatorSchema {
+impl TryFrom<models::Schema> for validator::ValidatorSchema {
     type Error = ProtobufConversionError;
     fn try_from(v: models::Schema) -> Result<Self, Self::Error> {
-        Ok(Self::new(
-            v.entity_decls
-                .into_iter()
-                .map(cedar_policy_core::validator::ValidatorEntityType::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-            v.action_decls
-                .into_iter()
-                .map(cedar_policy_core::validator::ValidatorActionId::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-        ))
+        let mut entity_type_names: HashSet<ast::EntityType> = HashSet::new();
+        let entity_types = v
+            .entity_decls
+            .into_iter()
+            .map(|decl| {
+                let ety = validator::ValidatorEntityType::try_from(decl)?;
+                if !entity_type_names.insert(ety.name().clone()) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "duplicate entity type `{}` in `entity_decls`",
+                        ety.name()
+                    )));
+                }
+                Ok(ety)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut action_names: HashSet<ast::EntityUID> = HashSet::new();
+        let action_ids = v
+            .action_decls
+            .into_iter()
+            .map(|decl| {
+                let action = validator::ValidatorActionId::try_from(decl)?;
+                if !action_names.insert(action.name().clone()) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "duplicate action `{}` in `action_decls`",
+                        action.name()
+                    )));
+                }
+                Ok(action)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self::new(entity_types, action_ids))
     }
 }
 
-impl From<&cedar_policy_core::validator::ValidationMode> for models::ValidationMode {
-    fn from(v: &cedar_policy_core::validator::ValidationMode) -> Self {
+impl From<&validator::ValidationMode> for models::ValidationMode {
+    fn from(v: &validator::ValidationMode) -> Self {
         match v {
-            cedar_policy_core::validator::ValidationMode::Strict => models::ValidationMode::Strict,
-            cedar_policy_core::validator::ValidationMode::Permissive => {
-                models::ValidationMode::Permissive
-            }
+            validator::ValidationMode::Strict => models::ValidationMode::Strict,
+            validator::ValidationMode::Permissive => models::ValidationMode::Permissive,
             #[cfg(feature = "partial-validate")]
-            cedar_policy_core::validator::ValidationMode::Partial => {
-                models::ValidationMode::Partial
-            }
+            validator::ValidationMode::Partial => models::ValidationMode::Partial,
         }
     }
 }
 
-impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::ValidationMode {
+impl TryFrom<models::ValidationMode> for validator::ValidationMode {
     type Error = ProtobufConversionError;
     fn try_from(v: models::ValidationMode) -> Result<Self, Self::Error> {
         match v {
-            models::ValidationMode::Strict => {
-                Ok(cedar_policy_core::validator::ValidationMode::Strict)
-            }
-            models::ValidationMode::Permissive => {
-                Ok(cedar_policy_core::validator::ValidationMode::Permissive)
-            }
+            models::ValidationMode::Strict => Ok(validator::ValidationMode::Strict),
+            models::ValidationMode::Permissive => Ok(validator::ValidationMode::Permissive),
             #[cfg(feature = "partial-validate")]
-            models::ValidationMode::Partial => {
-                Ok(cedar_policy_core::validator::ValidationMode::Partial)
-            }
+            models::ValidationMode::Partial => Ok(validator::ValidationMode::Partial),
             #[cfg(not(feature = "partial-validate"))]
             models::ValidationMode::Partial => Err(ProtobufConversionError::missing(
                 "partial-validate feature (required for partial validation mode)",
@@ -88,9 +101,9 @@ impl TryFrom<models::ValidationMode> for cedar_policy_core::validator::Validatio
 }
 
 #[expect(clippy::fallible_impl_from, reason = "experimental feature")]
-impl From<&cedar_policy_core::validator::ValidatorActionId> for models::ActionDecl {
+impl From<&validator::ValidatorActionId> for models::ActionDecl {
     #[expect(clippy::panic, reason = "experimental feature")]
-    fn from(v: &cedar_policy_core::validator::ValidatorActionId) -> Self {
+    fn from(v: &validator::ValidatorActionId) -> Self {
         let ctx_attrs = match v.context() {
             types::Type::Record {
                 attrs,
@@ -108,7 +121,7 @@ impl From<&cedar_policy_core::validator::ValidatorActionId> for models::ActionDe
     }
 }
 
-impl TryFrom<models::ActionDecl> for cedar_policy_core::validator::ValidatorActionId {
+impl TryFrom<models::ActionDecl> for validator::ValidatorActionId {
     type Error = ProtobufConversionError;
     fn try_from(v: models::ActionDecl) -> Result<Self, Self::Error> {
         Ok(Self::new(
@@ -137,21 +150,21 @@ impl TryFrom<models::ActionDecl> for cedar_policy_core::validator::ValidatorActi
     }
 }
 
-impl From<&cedar_policy_core::validator::ValidatorEntityType> for models::EntityDecl {
-    fn from(v: &cedar_policy_core::validator::ValidatorEntityType) -> Self {
+impl From<&validator::ValidatorEntityType> for models::EntityDecl {
+    fn from(v: &validator::ValidatorEntityType) -> Self {
         let name = Some(models::Name::from(v.name()));
         let descendants = v.descendants.iter().map(models::Name::from).collect();
         let attributes = attributes_to_model(v.attributes());
         let tags = v.tag_type().map(models::Type::from);
         match &v.kind {
-            cedar_policy_core::validator::ValidatorEntityTypeKind::Standard(_) => Self {
+            validator::ValidatorEntityTypeKind::Standard(_) => Self {
                 name,
                 descendants,
                 attributes,
                 tags,
                 enum_choices: vec![],
             },
-            cedar_policy_core::validator::ValidatorEntityTypeKind::Enum(enum_choices) => Self {
+            validator::ValidatorEntityTypeKind::Enum(enum_choices) => Self {
                 name,
                 descendants,
                 attributes,
@@ -165,7 +178,7 @@ impl From<&cedar_policy_core::validator::ValidatorEntityType> for models::Entity
     }
 }
 
-impl TryFrom<models::EntityDecl> for cedar_policy_core::validator::ValidatorEntityType {
+impl TryFrom<models::EntityDecl> for validator::ValidatorEntityType {
     type Error = ProtobufConversionError;
     fn try_from(v: models::EntityDecl) -> Result<Self, Self::Error> {
         let name = ast::EntityType::try_from(
@@ -332,11 +345,11 @@ mod test {
 
     use super::models;
     use super::ProtobufConversionError;
-    use cedar_policy_core::validator::types::{
-        AttributeType, BoolType, EntityKind, EntityLUB, OpenTag, Type,
+    use cedar_policy_core::validator::{
+        self,
+        types::{AttributeType, BoolType, EntityKind, EntityLUB, OpenTag, Type},
+        SchemaError, ValidatorSchema,
     };
-    use cedar_policy_core::validator::SchemaError;
-    use cedar_policy_core::validator::ValidatorSchema;
     use cool_asserts::assert_matches;
     use similar_asserts::assert_eq;
 
@@ -495,7 +508,7 @@ mod test {
 
     #[test]
     fn validation_mode_roundtrip() {
-        use cedar_policy_core::validator::ValidationMode;
+        use validator::ValidationMode;
         assert_eq!(
             ValidationMode::Strict,
             ValidationMode::try_from(models::ValidationMode::from(&ValidationMode::Strict))
@@ -518,7 +531,7 @@ mod test {
             context: Default::default(),
         };
         assert_matches!(
-            cedar_policy_core::validator::ValidatorActionId::try_from(bad),
+            validator::ValidatorActionId::try_from(bad),
             Err(ProtobufConversionError::MissingField(f)) if f == "name"
         );
     }
@@ -533,7 +546,7 @@ mod test {
             enum_choices: vec![],
         };
         assert_matches!(
-            cedar_policy_core::validator::ValidatorEntityType::try_from(bad),
+            validator::ValidatorEntityType::try_from(bad),
             Err(ProtobufConversionError::MissingField(f)) if f == "name"
         );
     }
@@ -554,7 +567,7 @@ mod test {
             is_required: true,
         };
         assert_matches!(
-            cedar_policy_core::validator::types::AttributeType::try_from(bad),
+            validator::types::AttributeType::try_from(bad),
             Err(ProtobufConversionError::MissingField(f)) if f == "attr_type"
         );
     }
@@ -581,7 +594,7 @@ mod test {
             enum_choices: vec!["x".to_string()],
         };
         assert_matches!(
-            cedar_policy_core::validator::ValidatorEntityType::try_from(bad),
+            validator::ValidatorEntityType::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("should not have attributes")
         );
     }
@@ -601,7 +614,7 @@ mod test {
             enum_choices: vec!["x".to_string()],
         };
         assert_matches!(
-            cedar_policy_core::validator::ValidatorEntityType::try_from(bad),
+            validator::ValidatorEntityType::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("should not have tags")
         );
     }
@@ -830,6 +843,45 @@ mod test {
         assert_matches!(
             validator_try_from_ok_return_validate(bad),
             Err(SchemaError::InvalidActionType(_))
+        );
+    }
+
+    #[test]
+    fn schema_try_from_duplicate_entity_type() {
+        let bad = models::Schema {
+            entity_decls: vec![simple_entity_decl("A"), simple_entity_decl("A")],
+            action_decls: vec![],
+        };
+        assert_matches!(
+            ValidatorSchema::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate entity type")
+        );
+    }
+
+    #[test]
+    fn schema_try_from_duplicate_action() {
+        let bad = models::Schema {
+            entity_decls: vec![simple_entity_decl("A")],
+            action_decls: vec![
+                models::ActionDecl {
+                    name: Some(action_uid("act")),
+                    principal_types: vec![name("A")],
+                    resource_types: vec![name("A")],
+                    descendants: vec![],
+                    context: Default::default(),
+                },
+                models::ActionDecl {
+                    name: Some(action_uid("act")),
+                    principal_types: vec![name("A")],
+                    resource_types: vec![],
+                    descendants: vec![],
+                    context: Default::default(),
+                },
+            ],
+        };
+        assert_matches!(
+            ValidatorSchema::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate action")
         );
     }
 }


### PR DESCRIPTION
Adds comments and deduplication in schema action/entity declaration during conversion. With this, all the 'try_validate' methods have been reviewed a second time. 

One missing piece was the deduplication needed on the protobuf path before ValidatorSchema is created; this is similar to the checks done when converting LiteralPolicySet to PolicySet. The `ValidatorSchema::new` will silently ignore duplicates in the iterators.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
