### PR TITLE
symcc: add SymSchema for amortized SymEntities across request envs

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Cedar Language Version: TBD
 
+### Added
+
+- `SymSchema` type that precomputes symbolic entities once per schema and produces
+  `SymEnv` instances via `sym_env()`, avoiding expensive per-environment rebuilds.
+
 ### Fixed
 
 - Fix errors decoding models from Z3. The model decoder now accepts hexadecimal bitvectors

--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -10,7 +10,7 @@ Cedar Language Version: TBD
 
 ### Added
 
-- `SymSchema` type that precomputes symbolic entities once per schema and produces
+- `CompiledSchema` type that precomputes symbolic entities once per schema and produces
   `SymEnv` instances via `sym_env()`, avoiding expensive per-environment rebuilds.
 
 ### Fixed

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -47,7 +47,7 @@ pub use symcc::term_type;
 pub use symcc::type_abbrevs;
 pub use symcc::verifier::Asserts;
 pub use symcc::Interpretation;
-pub use symcc::{Env, SmtLibScript, SymEnv, SymSchema};
+pub use symcc::{CompiledSchema, Env, SmtLibScript, SymEnv};
 
 impl SymEnv {
     /// Constructs a new [`SymEnv`] from the given [`Schema`] and [`RequestEnv`].

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -47,7 +47,7 @@ pub use symcc::term_type;
 pub use symcc::type_abbrevs;
 pub use symcc::verifier::Asserts;
 pub use symcc::Interpretation;
-pub use symcc::{Env, SmtLibScript, SymEnv};
+pub use symcc::{Env, SmtLibScript, SymEnv, SymSchema};
 
 impl SymEnv {
     /// Constructs a new [`SymEnv`] from the given [`Schema`] and [`RequestEnv`].

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -65,7 +65,7 @@ pub use concretizer::ConcretizeError;
 pub use concretizer::Env;
 pub use decoder::DecodeError;
 pub use encoder::EncodeError;
-pub use env::{Environment, SymEnv};
+pub use env::{Environment, SymEnv, SymSchema};
 pub use interpretation::Interpretation;
 pub use result::CompileError;
 pub use smtlib_script::SmtLibScript;

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -65,7 +65,7 @@ pub use concretizer::ConcretizeError;
 pub use concretizer::Env;
 pub use decoder::DecodeError;
 pub use encoder::EncodeError;
-pub use env::{Environment, SymEnv, SymSchema};
+pub use env::{CompiledSchema, Environment, SymEnv};
 pub use interpretation::Interpretation;
 pub use result::CompileError;
 pub use smtlib_script::SmtLibScript;

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -760,12 +760,13 @@ mod unit_tests {
     use super::Encoder;
     use crate::symcc::term_type::TermType;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn declare_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder
@@ -778,7 +779,7 @@ mod unit_tests {
     async fn declare_entity_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let ety = cedar_policy::EntityTypeName::from_str("User").unwrap();
@@ -791,7 +792,7 @@ mod unit_tests {
     async fn declare_empty_record_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.declare_record_type(vec![]).await.unwrap();
@@ -801,7 +802,7 @@ mod unit_tests {
     async fn declare_record_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder
@@ -814,7 +815,7 @@ mod unit_tests {
     async fn encode_bool_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.encode_type(&TermType::Bool).await.unwrap();
@@ -824,7 +825,7 @@ mod unit_tests {
     async fn encode_string_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.encode_type(&TermType::String).await.unwrap();
@@ -834,7 +835,7 @@ mod unit_tests {
     async fn encode_uuf() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let my_uuf = crate::symcc::op::Uuf {
@@ -850,7 +851,7 @@ mod unit_tests {
         use cedar_policy::EntityUid;
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(BTreeMap::new()),
+            entities: SymEntities(Arc::new(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let entity_type_name = EntityTypeName::from_str("User").unwrap();

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -766,7 +766,7 @@ mod unit_tests {
     async fn declare_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder
@@ -779,7 +779,7 @@ mod unit_tests {
     async fn declare_entity_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let ety = cedar_policy::EntityTypeName::from_str("User").unwrap();
@@ -792,7 +792,7 @@ mod unit_tests {
     async fn declare_empty_record_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.declare_record_type(vec![]).await.unwrap();
@@ -802,7 +802,7 @@ mod unit_tests {
     async fn declare_record_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder
@@ -815,7 +815,7 @@ mod unit_tests {
     async fn encode_bool_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.encode_type(&TermType::Bool).await.unwrap();
@@ -825,7 +825,7 @@ mod unit_tests {
     async fn encode_string_type() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         encoder.encode_type(&TermType::String).await.unwrap();
@@ -835,7 +835,7 @@ mod unit_tests {
     async fn encode_uuf() {
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let my_uuf = crate::symcc::op::Uuf {
@@ -851,7 +851,7 @@ mod unit_tests {
         use cedar_policy::EntityUid;
         let symenv = SymEnv {
             request: SymRequest::empty_sym_req(),
-            entities: SymEntities(Arc::new(BTreeMap::new())),
+            entities: Arc::new(SymEntities(BTreeMap::new())),
         };
         let mut encoder = Encoder::new(&symenv, Vec::<u8>::new()).unwrap();
         let entity_type_name = EntityTypeName::from_str("User").unwrap();

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -29,6 +29,7 @@ use super::tags::SymTags;
 use super::term::{Term, TermPrim, TermVar};
 use super::term_type::TermType;
 use super::type_abbrevs::*;
+use cedar_policy::{RequestEnv, Schema};
 use cedar_policy_core::validator::ValidatorSchema;
 use cedar_policy_core::validator::{
     types::{Attributes, OpenTag, Type},
@@ -114,13 +115,13 @@ impl SymEntityData {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
-pub struct SymEntities(pub BTreeMap<EntityType, SymEntityData>);
+pub struct SymEntities(pub Arc<BTreeMap<EntityType, SymEntityData>>);
 
 impl Deref for SymEntities {
     type Target = BTreeMap<EntityType, SymEntityData>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0.as_ref()
     }
 }
 
@@ -366,9 +367,9 @@ impl SymEntities {
                 SymEntityData::of_action_type(act_ty, act_tys.clone(), schema),
             ))
         });
-        Ok(SymEntities(
+        Ok(SymEntities(Arc::new(
             e_data.into_iter().chain(a_data).collect::<Result<_, _>>()?,
-        ))
+        )))
     }
 }
 
@@ -418,6 +419,51 @@ impl SymEnv {
 // `cedar-policy-validator` doesn't have an equivalent of several types like
 // `RequestType` that are only used in `Cedar/SymCC/Env.lean`, so we define
 // them here.
+
+/// A [`Schema`] paired with its precomputed [`SymEntities`].
+///
+/// Building [`SymEntities`] from a schema is expensive and depends only on the
+/// schema, not on any particular request environment. [`SymSchema`] computes it
+/// once so it can be reused across many request environments via
+/// [`SymSchema::sym_env`], which is significantly cheaper than rebuilding the
+/// symbolic entities per environment (as [`SymEnv::new`] does).
+#[derive(Debug, Clone)]
+pub struct SymSchema {
+    schema: Schema,
+    entities: SymEntities,
+}
+
+impl SymSchema {
+    /// Builds the symbolic entities for `schema` once, up front.
+    pub fn new(schema: &Schema) -> crate::err::Result<Self> {
+        Ok(Self {
+            schema: schema.clone(),
+            entities: SymEntities::of_schema(schema.as_ref())?,
+        })
+    }
+
+    /// The [`Schema`] this symbolic schema was built from.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    /// Returns a [`SymEnv`] for `req_env`, reusing the precomputed [`SymEntities`].
+    ///
+    /// Only the (cheap) symbolic request is built per call; the (expensive)
+    /// symbolic entities are shared via a reference-counted clone. The resulting
+    /// [`SymEnv`] is identical to one built by [`SymEnv::new`] for the same
+    /// schema and request environment.
+    // INVARIANT: must produce the same SymEnv as SymEnv::of_env / SymEnv::new.
+    // Guarded by test sym_schema_sym_env_matches_sym_env_new.
+    pub fn sym_env(&self, req_env: &RequestEnv) -> crate::err::Result<SymEnv> {
+        let env = Environment::from_request_env(req_env, self.schema.as_ref())
+            .ok_or_else(|| crate::err::Error::ActionNotInSchema(req_env.action().to_string()))?;
+        Ok(SymEnv {
+            request: SymRequest::of_request_type(&env.req_ty)?,
+            entities: self.entities.clone(),
+        })
+    }
+}
 
 // TODO: test this
 

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -423,17 +423,17 @@ impl SymEnv {
 /// A [`Schema`] paired with its precomputed [`SymEntities`].
 ///
 /// Building [`SymEntities`] from a schema is expensive and depends only on the
-/// schema, not on any particular request environment. [`SymSchema`] computes it
+/// schema, not on any particular request environment. [`CompiledSchema`] computes it
 /// once so it can be reused across many request environments via
-/// [`SymSchema::sym_env`], which is significantly cheaper than rebuilding the
+/// [`CompiledSchema::sym_env`], which is significantly cheaper than rebuilding the
 /// symbolic entities per environment (as [`SymEnv::new`] does).
 #[derive(Debug, Clone)]
-pub struct SymSchema {
+pub struct CompiledSchema {
     schema: Schema,
     entities: Arc<SymEntities>,
 }
 
-impl SymSchema {
+impl CompiledSchema {
     /// Builds the symbolic entities for `schema` once, up front.
     pub fn new(schema: &Schema) -> crate::err::Result<Self> {
         Ok(Self {
@@ -454,7 +454,7 @@ impl SymSchema {
     /// [`SymEnv`] is identical to one built by [`SymEnv::new`] for the same
     /// schema and request environment.
     // INVARIANT: must produce the same SymEnv as SymEnv::of_env / SymEnv::new.
-    // Guarded by test sym_schema_sym_env_matches_sym_env_new.
+    // Guarded by test compiled_schema_sym_env_matches_sym_env_new.
     pub fn sym_env(&self, req_env: &RequestEnv) -> crate::err::Result<SymEnv> {
         let env = Environment::from_request_env(req_env, self.schema.as_ref())
             .ok_or_else(|| crate::err::Error::ActionNotInSchema(req_env.action().to_string()))?;

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -115,13 +115,13 @@ impl SymEntityData {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
-pub struct SymEntities(pub Arc<BTreeMap<EntityType, SymEntityData>>);
+pub struct SymEntities(pub BTreeMap<EntityType, SymEntityData>);
 
 impl Deref for SymEntities {
     type Target = BTreeMap<EntityType, SymEntityData>;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
+        &self.0
     }
 }
 
@@ -174,7 +174,7 @@ pub struct SymEnv {
     /// Symbolic request
     pub request: SymRequest,
     /// Symbolic entities
-    pub entities: SymEntities,
+    pub entities: Arc<SymEntities>,
 }
 
 impl SymEnv {
@@ -367,9 +367,9 @@ impl SymEntities {
                 SymEntityData::of_action_type(act_ty, act_tys.clone(), schema),
             ))
         });
-        Ok(SymEntities(Arc::new(
+        Ok(SymEntities(
             e_data.into_iter().chain(a_data).collect::<Result<_, _>>()?,
-        )))
+        ))
     }
 }
 
@@ -404,7 +404,7 @@ impl SymEnv {
     pub fn of_env(ty_env: &Environment<'_>) -> Result<Self, CompileError> {
         Ok(SymEnv {
             request: SymRequest::of_request_type(&ty_env.req_ty)?,
-            entities: SymEntities::of_schema(ty_env.schema)?,
+            entities: Arc::new(SymEntities::of_schema(ty_env.schema)?),
         })
     }
 }
@@ -430,7 +430,7 @@ impl SymEnv {
 #[derive(Debug, Clone)]
 pub struct SymSchema {
     schema: Schema,
-    entities: SymEntities,
+    entities: Arc<SymEntities>,
 }
 
 impl SymSchema {
@@ -438,7 +438,7 @@ impl SymSchema {
     pub fn new(schema: &Schema) -> crate::err::Result<Self> {
         Ok(Self {
             schema: schema.clone(),
-            entities: SymEntities::of_schema(schema.as_ref())?,
+            entities: Arc::new(SymEntities::of_schema(schema.as_ref())?),
         })
     }
 

--- a/cedar-policy-symcc/src/symcc/interpretation.rs
+++ b/cedar-policy-symcc/src/symcc/interpretation.rs
@@ -304,12 +304,12 @@ impl SymEntityData {
 impl SymEntities {
     /// Interpret a [`SymEntities`] with the given interpretation.
     pub fn interpret(&self, interp: &Interpretation<'_>) -> SymEntities {
-        SymEntities(Arc::new(
+        SymEntities(
             self.0
                 .iter()
                 .map(|(ent, data)| (ent.clone(), data.interpret(interp)))
                 .collect(),
-        ))
+        )
     }
 }
 
@@ -317,7 +317,7 @@ impl SymEnv {
     /// Interpret a [`SymEnv`] with the given interpretation.
     pub fn interpret(&self, interp: &Interpretation<'_>) -> SymEnv {
         SymEnv {
-            entities: self.entities.interpret(interp),
+            entities: Arc::new(self.entities.interpret(interp)),
             request: self.request.interpret(interp),
         }
     }

--- a/cedar-policy-symcc/src/symcc/interpretation.rs
+++ b/cedar-policy-symcc/src/symcc/interpretation.rs
@@ -304,12 +304,12 @@ impl SymEntityData {
 impl SymEntities {
     /// Interpret a [`SymEntities`] with the given interpretation.
     pub fn interpret(&self, interp: &Interpretation<'_>) -> SymEntities {
-        SymEntities(
+        SymEntities(Arc::new(
             self.0
                 .iter()
                 .map(|(ent, data)| (ent.clone(), data.interpret(interp)))
                 .collect(),
-        )
+        ))
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/symbolizer.rs
+++ b/cedar-policy-symcc/src/symcc/symbolizer.rs
@@ -403,12 +403,12 @@ impl SymEntities {
             ))
         });
 
-        Ok(SymEntities(
+        Ok(SymEntities(Arc::new(
             entities
                 .into_iter()
                 .chain(actions)
                 .collect::<Result<_, _>>()?,
-        ))
+        )))
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/symbolizer.rs
+++ b/cedar-policy-symcc/src/symcc/symbolizer.rs
@@ -403,12 +403,12 @@ impl SymEntities {
             ))
         });
 
-        Ok(SymEntities(Arc::new(
+        Ok(SymEntities(
             entities
                 .into_iter()
                 .chain(actions)
                 .collect::<Result<_, _>>()?,
-        )))
+        ))
     }
 }
 
@@ -426,7 +426,7 @@ impl SymEnv {
             .ok_or(SymbolizeError::IllFormedTypeEnv)?;
         Ok(SymEnv {
             request: SymRequest::from_request(&type_env, &env.request)?,
-            entities: SymEntities::from_entities(&type_env, &env.entities)?,
+            entities: Arc::new(SymEntities::from_entities(&type_env, &env.entities)?),
         })
     }
 }

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -17,10 +17,11 @@ use std::str::FromStr;
  */
 use cedar_policy::{EntityUid, Policy, PolicyId, PolicySet, Schema, SlotId, Template, Validator};
 use cedar_policy_symcc::{
-    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet,
+    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet, SymEnv, SymSchema,
 };
 use cool_asserts::assert_matches;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 mod utils;
 use utils::Environments;
@@ -2529,5 +2530,110 @@ async fn template_linked_policy_unsupported() {
         Some(cedar_policy_symcc::err::Error::CompileError(
             CompileError::UnsupportedFeature(..)
         ))
+    );
+}
+
+/// `SymSchema::sym_env` reuses shared symbolic entities across request envs
+/// instead of rebuilding them per env (as `SymEnv::new` does), and its doc
+/// claims the result is *identical* to `SymEnv::new`. Every other test builds
+/// envs via `SymEnv::new`, so this is the sole guard that the cheaper reuse
+/// path has not diverged. `sample_schema`'s entity hierarchy (`Thing in
+/// Account`) exercises the shared ancestor tables.
+#[test]
+fn sym_schema_sym_env_matches_sym_env_new() {
+    let schema = sample_schema();
+    let req_env = utils::req_env_from_strs("Identity", "Action::\"view\"", "Thing");
+    let reused = SymSchema::new(&schema).unwrap().sym_env(&req_env).unwrap();
+    let fresh = SymEnv::new(&schema, &req_env).unwrap();
+    assert_eq!(reused, fresh);
+}
+
+/// Multiple `sym_env` calls on the same `SymSchema` share the same `Arc`'d
+/// entities and each produce a result equal to a fresh `SymEnv::new`.
+#[test]
+fn sym_schema_reuse_across_envs() {
+    let schema = sample_schema();
+    let sym_schema = SymSchema::new(&schema).unwrap();
+    let req_env = utils::req_env_from_strs("Identity", "Action::\"view\"", "Thing");
+    let env_a = sym_schema.sym_env(&req_env).unwrap();
+    let env_b = sym_schema.sym_env(&req_env).unwrap();
+    // Both reuse the same underlying entities (Arc pointer equality).
+    assert!(Arc::ptr_eq(&env_a.entities.0, &env_b.entities.0));
+    // And both match a fresh build.
+    assert_eq!(env_a, SymEnv::new(&schema, &req_env).unwrap());
+}
+
+/// End-to-end example: use `SymSchema` to amortize `SymEntities` across
+/// request environments when calling `check_implies_opt`.
+#[tokio::test]
+async fn sym_schema_check_implies_opt_example() {
+    let schema = sample_schema();
+    let mut pset_a = PolicySet::new();
+    pset_a
+        .add(
+            Policy::parse(
+                Some(PolicyId::from_str("a").unwrap()),
+                r#"permit(principal, action == Action::"view", resource);"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    let mut pset_b = PolicySet::new();
+    pset_b
+        .add(
+            Policy::parse(
+                Some(PolicyId::from_str("b").unwrap()),
+                r#"permit(principal, action == Action::"view", resource);"#,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    let request_envs = vec![utils::req_env_from_strs(
+        "Identity",
+        "Action::\"view\"",
+        "Thing",
+    )];
+
+    let sym_schema = SymSchema::new(&schema).unwrap();
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+
+    for req_env in &request_envs {
+        let sym_env = sym_schema.sym_env(req_env).unwrap();
+        let compiled_a = CompiledPolicySet::compile_with_custom_symenv(
+            &pset_a,
+            req_env,
+            &schema,
+            sym_env.clone(),
+        )
+        .unwrap();
+        let compiled_b = CompiledPolicySet::compile_with_custom_symenv(
+            &pset_b,
+            req_env,
+            &schema,
+            sym_env.clone(),
+        )
+        .unwrap();
+        let implies = compiler
+            .check_implies_opt(&compiled_a, &compiled_b)
+            .await
+            .unwrap();
+        assert!(implies);
+    }
+}
+
+/// `SymSchema::sym_env` must surface `ActionNotInSchema` when the request env
+/// names an action absent from the schema, rather than panicking or building a
+/// bogus env.
+#[test]
+fn sym_schema_sym_env_rejects_unknown_action() {
+    let schema = sample_schema();
+    let req_env = utils::req_env_from_strs("Identity", "Action::\"nonexistent\"", "Thing");
+    let err = SymSchema::new(&schema)
+        .unwrap()
+        .sym_env(&req_env)
+        .unwrap_err();
+    assert!(
+        matches!(err, cedar_policy_symcc::err::Error::ActionNotInSchema(_)),
+        "expected ActionNotInSchema, got {err:?}"
     );
 }

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -2558,7 +2558,7 @@ fn sym_schema_reuse_across_envs() {
     let env_a = sym_schema.sym_env(&req_env).unwrap();
     let env_b = sym_schema.sym_env(&req_env).unwrap();
     // Both reuse the same underlying entities (Arc pointer equality).
-    assert!(Arc::ptr_eq(&env_a.entities.0, &env_b.entities.0));
+    assert!(Arc::ptr_eq(&env_a.entities, &env_b.entities));
     // And both match a fresh build.
     assert_eq!(env_a, SymEnv::new(&schema, &req_env).unwrap());
 }

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -17,7 +17,8 @@ use std::str::FromStr;
  */
 use cedar_policy::{EntityUid, Policy, PolicyId, PolicySet, Schema, SlotId, Template, Validator};
 use cedar_policy_symcc::{
-    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet, SymEnv, SymSchema,
+    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet, CompiledSchema,
+    SymEnv,
 };
 use cool_asserts::assert_matches;
 use std::collections::HashMap;
@@ -2533,40 +2534,43 @@ async fn template_linked_policy_unsupported() {
     );
 }
 
-/// `SymSchema::sym_env` reuses shared symbolic entities across request envs
+/// `CompiledSchema::sym_env` reuses shared symbolic entities across request envs
 /// instead of rebuilding them per env (as `SymEnv::new` does), and its doc
 /// claims the result is *identical* to `SymEnv::new`. Every other test builds
 /// envs via `SymEnv::new`, so this is the sole guard that the cheaper reuse
 /// path has not diverged. `sample_schema`'s entity hierarchy (`Thing in
 /// Account`) exercises the shared ancestor tables.
 #[test]
-fn sym_schema_sym_env_matches_sym_env_new() {
+fn compiled_schema_sym_env_matches_sym_env_new() {
     let schema = sample_schema();
     let req_env = utils::req_env_from_strs("Identity", "Action::\"view\"", "Thing");
-    let reused = SymSchema::new(&schema).unwrap().sym_env(&req_env).unwrap();
+    let reused = CompiledSchema::new(&schema)
+        .unwrap()
+        .sym_env(&req_env)
+        .unwrap();
     let fresh = SymEnv::new(&schema, &req_env).unwrap();
     assert_eq!(reused, fresh);
 }
 
-/// Multiple `sym_env` calls on the same `SymSchema` share the same `Arc`'d
+/// Multiple `sym_env` calls on the same `CompiledSchema` share the same `Arc`'d
 /// entities and each produce a result equal to a fresh `SymEnv::new`.
 #[test]
-fn sym_schema_reuse_across_envs() {
+fn compiled_schema_reuse_across_envs() {
     let schema = sample_schema();
-    let sym_schema = SymSchema::new(&schema).unwrap();
+    let compiled_schema = CompiledSchema::new(&schema).unwrap();
     let req_env = utils::req_env_from_strs("Identity", "Action::\"view\"", "Thing");
-    let env_a = sym_schema.sym_env(&req_env).unwrap();
-    let env_b = sym_schema.sym_env(&req_env).unwrap();
+    let env_a = compiled_schema.sym_env(&req_env).unwrap();
+    let env_b = compiled_schema.sym_env(&req_env).unwrap();
     // Both reuse the same underlying entities (Arc pointer equality).
     assert!(Arc::ptr_eq(&env_a.entities, &env_b.entities));
     // And both match a fresh build.
     assert_eq!(env_a, SymEnv::new(&schema, &req_env).unwrap());
 }
 
-/// End-to-end example: use `SymSchema` to amortize `SymEntities` across
+/// End-to-end example: use `CompiledSchema` to amortize `SymEntities` across
 /// request environments when calling `check_implies_opt`.
 #[tokio::test]
-async fn sym_schema_check_implies_opt_example() {
+async fn compiled_schema_check_implies_opt_example() {
     let schema = sample_schema();
     let mut pset_a = PolicySet::new();
     pset_a
@@ -2594,11 +2598,11 @@ async fn sym_schema_check_implies_opt_example() {
         "Thing",
     )];
 
-    let sym_schema = SymSchema::new(&schema).unwrap();
+    let compiled_schema = CompiledSchema::new(&schema).unwrap();
     let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
 
     for req_env in &request_envs {
-        let sym_env = sym_schema.sym_env(req_env).unwrap();
+        let sym_env = compiled_schema.sym_env(req_env).unwrap();
         let compiled_a = CompiledPolicySet::compile_with_custom_symenv(
             &pset_a,
             req_env,
@@ -2621,14 +2625,14 @@ async fn sym_schema_check_implies_opt_example() {
     }
 }
 
-/// `SymSchema::sym_env` must surface `ActionNotInSchema` when the request env
+/// `CompiledSchema::sym_env` must surface `ActionNotInSchema` when the request env
 /// names an action absent from the schema, rather than panicking or building a
 /// bogus env.
 #[test]
-fn sym_schema_sym_env_rejects_unknown_action() {
+fn compiled_schema_sym_env_rejects_unknown_action() {
     let schema = sample_schema();
     let req_env = utils::req_env_from_strs("Identity", "Action::\"nonexistent\"", "Thing");
-    let err = SymSchema::new(&schema)
+    let err = CompiledSchema::new(&schema)
         .unwrap()
         .sym_env(&req_env)
         .unwrap_err();


### PR DESCRIPTION
## Description of changes
Add SymSchema to cedar-policy-symcc for amortizing the expensive SymEntities::of_schema computation across multiple request environments.

Callers checking many request environments against the same schema (e.g. policy subsumption with large action lists) previously rebuilt symbolic entities per environment (~3.7s each in my perhaps pathological case). SymSchema precomputes them once (~1.86s for me) and produces SymEnv instances via sym_env() that share the entities via Arc (0.9ms each).

Example usage:
```rust
let sym_schema = SymSchema::new(&schema)?;
let mut compiler = CedarSymCompiler::new(solver)?;

for req_env in &request_envs {
    let sym_env = sym_schema.sym_env(req_env)?;
    let compiled_a = CompiledPolicySet::compile_with_custom_symenv(
        &pset_a, req_env, &schema, sym_env.clone(),
    )?;
    let compiled_b = CompiledPolicySet::compile_with_custom_symenv(
        &pset_b, req_env, &schema, sym_env.clone(),
    )?;
    let implies = compiler.check_implies_opt(&compiled_a, &compiled_b).await?;
    assert!(implies);
}
```

I benchmarked this against the non-deprecated symcc with good results. Since this wraps the symcc functionality I don't believe it requires a lean change.

Since this is a new public type I figured this is a new minor version at least.

## Issue #, if available
None, perhaps a continuation cousin of #2439. I can make a new issue if desired.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
