### PR TITLE
Refactor protobuf policyset validation part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "insta",
  "itertools 0.15.0",
  "linked-hash-map",
+ "linked_hash_set",
  "miette",
  "nonempty",
  "oorandom",

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -494,7 +494,7 @@ fn describe_arity_error(
 ///   - the bound values for slots in the template
 ///
 /// Policies are not serializable (due to the pointer), and can be serialized
-/// by converting to/from LiteralPolicy
+/// by converting to/from [`LiteralPolicy`]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Policy {
     /// Reference to the template
@@ -845,7 +845,7 @@ pub enum ReificationError {
     /// The outer map key does not match the policy's own ID
     #[error("policy set map key `{key}` does not match the policy's own id `{policy_id}`")]
     PolicyIdMismatch {
-        /// The outer map key used in `LiteralPolicySet.links`
+        /// The outer map key
         key: PolicyID,
         /// The policy's own ID (from `LiteralPolicy::id()`)
         policy_id: PolicyID,

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -231,6 +231,27 @@ impl PolicySet {
         }
     }
 
+    /// Create a `PolicySet` from pre-built components.
+    ///
+    /// The caller is responsible for ensuring the invariants hold:
+    /// - Every link references a template that exists in `templates`
+    /// - `template_to_links_map` is consistent with `templates` and `links`
+    /// - Non-static link IDs do not collide with template IDs
+    ///
+    /// This is not intended for external use; use the incremental builder methods
+    /// (`add`, `add_template`, `link`) instead.
+    pub fn from_raw_components(
+        templates: LinkedHashMap<PolicyID, Arc<Template>>,
+        links: LinkedHashMap<PolicyID, Policy>,
+        template_to_links_map: LinkedHashMap<PolicyID, LinkedHashSet<PolicyID>>,
+    ) -> Self {
+        Self {
+            templates,
+            links,
+            template_to_links_map,
+        }
+    }
+
     /// Create a `PolicySet` containing a single policy.
     pub fn singleton(p: Policy) -> Self {
         let t = p.template_arc();

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -15,8 +15,8 @@
  */
 
 use super::{
-    EntityUID, LinkingError, LiteralPolicy, Policy, PolicyID, ReificationError, SlotId,
-    StaticPolicy, Template, TemplateValidationError,
+    EntityUID, LinkingError, Policy, PolicyID, SlotId, StaticPolicy, Template,
+    TemplateValidationError,
 };
 use itertools::Itertools;
 use linked_hash_map::{Entry, LinkedHashMap};
@@ -47,116 +47,6 @@ pub struct PolicySet {
     /// There is a key `t` iff `templates` contains the key `t`. The value of `t` will be a (possibly empty)
     /// set of every `p` in `links` s.t. `p.template().id() == t`.
     template_to_links_map: LinkedHashMap<PolicyID, LinkedHashSet<PolicyID>>,
-}
-
-/// A Policy Set that contains less rich information than `PolicySet`.
-///
-/// In particular, this form is easier to convert to/from the Protobuf
-/// representation of a `PolicySet`, because policies are represented as
-/// `LiteralPolicy` instead of `Policy`.
-#[derive(Debug)]
-pub struct LiteralPolicySet {
-    /// Like the `templates` field of `PolicySet`
-    templates: LinkedHashMap<PolicyID, Template>,
-    /// Like the `links` field of `PolicySet`, but maps to `LiteralPolicy` only.
-    /// The same invariants apply: e.g., a `StaticPolicy` must have exactly one `Policy` in `links`.
-    links: LinkedHashMap<PolicyID, LiteralPolicy>,
-}
-
-impl LiteralPolicySet {
-    /// Create a new `LiteralPolicySet`. Caller is responsible for ensuring the
-    /// invariants on `LiteralPolicySet`.
-    pub fn new(
-        templates: impl IntoIterator<Item = (PolicyID, Template)>,
-        links: impl IntoIterator<Item = (PolicyID, LiteralPolicy)>,
-    ) -> Self {
-        Self {
-            templates: templates.into_iter().collect(),
-            links: links.into_iter().collect(),
-        }
-    }
-
-    /// Iterate over the `Template`s in the `LiteralPolicySet`. This will
-    /// include both templates and static policies (represented as templates
-    /// with zero slots)
-    pub fn templates(&self) -> impl Iterator<Item = &Template> {
-        self.templates.values()
-    }
-
-    /// Iterate over the `LiteralPolicy`s in the `LiteralPolicySet`. This will
-    /// include both static and template-linked policies.
-    pub fn policies(&self) -> impl Iterator<Item = &LiteralPolicy> {
-        self.links.values()
-    }
-}
-
-/// Converts a LiteralPolicySet into a PolicySet, ensuring the invariants are met
-/// Every `Policy` must point to a `Template` that exists in the set.
-impl TryFrom<LiteralPolicySet> for PolicySet {
-    type Error = ReificationError;
-    fn try_from(pset: LiteralPolicySet) -> Result<Self, Self::Error> {
-        // Allocate the templates into Arc's
-        let templates = pset
-            .templates
-            .into_iter()
-            .map(|(id, template)| (id, Arc::new(template)))
-            .collect::<LinkedHashMap<PolicyID, Arc<Template>>>();
-        let links = pset
-            .links
-            .into_iter()
-            .map(|(id, literal)| {
-                if *literal.id() != id {
-                    return Err(ReificationError::PolicyIdMismatch {
-                        key: id,
-                        policy_id: literal.id().clone(),
-                    });
-                }
-                literal.reify(&templates).map(|linked| (id, linked))
-            })
-            .collect::<Result<LinkedHashMap<PolicyID, Policy>, ReificationError>>()?;
-
-        let mut template_to_links_map = LinkedHashMap::new();
-        for template in &templates {
-            template_to_links_map.insert(template.0.clone(), LinkedHashSet::new());
-        }
-        for (link_id, link) in &links {
-            let template = link.template().id();
-            // Check that template-linked policy IDs do not collide with template IDs.
-            // This is enforced when using `ast::policy_set::PolicySet::link` to construct a
-            // policy set incrementally and should also be enforced here.
-            if !link.is_static() && templates.contains_key(link_id) {
-                return Err(ReificationError::Linking(LinkingError::PolicyIdConflict {
-                    id: link_id.clone(),
-                }));
-            }
-            match template_to_links_map.entry(template.clone()) {
-                Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
-                Entry::Vacant(_) => return Err(ReificationError::NoSuchTemplate(template.clone())),
-            };
-        }
-
-        Ok(Self {
-            templates,
-            links,
-            template_to_links_map,
-        })
-    }
-}
-
-impl From<PolicySet> for LiteralPolicySet {
-    fn from(pset: PolicySet) -> Self {
-        let templates = pset
-            .templates
-            .into_iter()
-            .map(|(id, template)| (id, template.as_ref().clone()))
-            .collect();
-        let links = pset
-            .links
-            .into_iter()
-            .map(|(id, p)| (id, p.into()))
-            .collect();
-        Self { templates, links }
-    }
 }
 
 /// Potential errors when working with `PolicySet`s.
@@ -721,7 +611,7 @@ impl PolicySet {
     /// - every non-static link references a template with at least one slot.
     ///
     /// This does NOT check the following, which are instead ensured by construction
-    /// via the public API methods or the conversion [`TryFrom<LiteralPolicySet>`]:
+    /// via the public API methods or [`from_raw_components`](Self::from_raw_components):
     /// - slot binding correctness: the `values` match the template's slots,
     /// - no duplicate policy IDs across templates and links,
     /// - every link's template exists in `templates`,
@@ -1399,14 +1289,11 @@ mod policy_set_validate_test {
     }
 
     fn make_policy_set(templates: impl IntoIterator<Item = Template>) -> PolicySet {
-        let literal = LiteralPolicySet::new(
-            templates
-                .into_iter()
-                .map(|t| (t.id().clone(), t))
-                .collect::<Vec<_>>(),
-            std::iter::empty(),
-        );
-        PolicySet::try_from(literal).expect("failed to construct policy set")
+        let mut pset = PolicySet::new();
+        for t in templates {
+            pset.add_template(t).expect("failed to add template");
+        }
+        pset
     }
 
     #[test]
@@ -1446,106 +1333,19 @@ mod policy_set_validate_test {
     #[test]
     fn link_with_no_slots_rejected() {
         let t = valid_template("no_slots");
-        let literal = LiteralPolicySet::new(
-            [(t.id().clone(), t)],
-            [(
-                PolicyID::from_string("link1"),
-                LiteralPolicy::template_linked_policy(
-                    PolicyID::from_string("no_slots"),
-                    PolicyID::from_string("link1"),
-                    HashMap::new(),
-                ),
-            )],
-        );
-        let pset = PolicySet::try_from(literal).expect("failed to construct policy set");
+        let mut pset = PolicySet::new();
+        pset.add_template(t).unwrap();
+        pset.link(
+            PolicyID::from_string("no_slots"),
+            PolicyID::from_string("link1"),
+            HashMap::new(),
+        )
+        .unwrap();
         assert_matches!(
             pset.try_validate(),
             Err(PolicySetValidationError::LinkToSlotlessTemplate { link_id, template_id })
                 if link_id == PolicyID::from_string("link1")
                 && template_id == PolicyID::from_string("no_slots")
-        );
-    }
-
-    #[test]
-    fn link_id_conflicts_with_template_id_rejected() {
-        let id = PolicyID::from_string("t");
-        let t = Template::new(
-            id.clone(),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::is_eq_slot(),
-            ActionConstraint::Eq(action_euid()),
-            ResourceConstraint::any(),
-            None,
-        );
-        let mut values = HashMap::new();
-        values.insert(
-            SlotId::principal(),
-            EntityUID::with_eid_and_type("User", "alice").unwrap(),
-        );
-        let literal = LiteralPolicySet::new(
-            [(id.clone(), t.clone())],
-            [(
-                id.clone(),
-                LiteralPolicy::template_linked_policy(id.clone(), id, values),
-            )],
-        );
-        assert_matches!(
-            PolicySet::try_from(literal),
-            Err(ReificationError::Linking(LinkingError::PolicyIdConflict { id }))
-                if id == PolicyID::from_string("t")
-        );
-    }
-
-    #[test]
-    fn outer_key_mismatch_static_policy_rejected() {
-        let t = valid_template("policy1");
-        let literal = LiteralPolicySet::new(
-            [(t.id().clone(), t)],
-            [(
-                PolicyID::from_string("wrong_key"),
-                LiteralPolicy::static_policy(PolicyID::from_string("policy1")),
-            )],
-        );
-        assert_matches!(
-            PolicySet::try_from(literal),
-            Err(ReificationError::PolicyIdMismatch { key, policy_id })
-                if key == PolicyID::from_string("wrong_key")
-                && policy_id == PolicyID::from_string("policy1")
-        );
-    }
-
-    #[test]
-    fn outer_key_mismatch_linked_policy_rejected() {
-        let id = PolicyID::from_string("t");
-        let t = Template::new(
-            id.clone(),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::is_eq_slot(),
-            ActionConstraint::Eq(action_euid()),
-            ResourceConstraint::any(),
-            None,
-        );
-        let mut values = HashMap::new();
-        values.insert(
-            SlotId::principal(),
-            EntityUID::with_eid_and_type("User", "alice").unwrap(),
-        );
-        let literal = LiteralPolicySet::new(
-            [(id.clone(), t)],
-            [(
-                PolicyID::from_string("wrong_key"),
-                LiteralPolicy::template_linked_policy(id, PolicyID::from_string("link1"), values),
-            )],
-        );
-        assert_matches!(
-            PolicySet::try_from(literal),
-            Err(ReificationError::PolicyIdMismatch { key, policy_id })
-                if key == PolicyID::from_string("wrong_key")
-                && policy_id == PolicyID::from_string("link1")
         );
     }
 }

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -25,6 +25,7 @@ serde_with = "3.21.0"
 nonempty = { version = "0.12", optional = true }
 prost = { version = "0.14", optional = true }
 linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
+linked_hash_set = "0.1.6"
 
 # wasm dependencies
 # Intentionally not updated to 0.5.5, see issue #1744

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -142,8 +142,6 @@ impl traits::Protobuf for api::PolicySet {
         traits::encode_to_vec::<models::PolicySet>(self)
     }
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
-        // TODO: find a way to skip additional validation on PolicySet, currently validation happens
-        // once for decode_unchecked and twice for decode
         traits::try_decode::<models::PolicySet, _, Self>(buf)
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -19,7 +19,12 @@
 use super::ast::ProtobufConversionError;
 use super::models;
 use cedar_policy_core::{ast, FromNormalizedStr};
-use std::collections::{HashMap, HashSet};
+use linked_hash_map::{Entry, LinkedHashMap};
+use linked_hash_set::LinkedHashSet;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 impl TryFrom<models::Policy> for ast::LiteralPolicy {
     type Error = ProtobufConversionError;
@@ -431,8 +436,11 @@ impl From<&ast::Effect> for models::Effect {
     }
 }
 
-impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
+impl TryFrom<models::PolicySet> for ast::PolicySet {
     type Error = ProtobufConversionError;
+    // TODO: simplify this implementation — the second half (reification) contains redundant checks
+    // that are already guaranteed by the first half (proto validation). This was intentionally
+    // written as a mechanical composition of the two former conversion steps to ease review.
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
         let mut template_ids: HashSet<ast::PolicyID> = HashSet::new();
         let mut link_ids: HashSet<ast::PolicyID> = HashSet::new();
@@ -494,15 +502,60 @@ impl TryFrom<models::PolicySet> for ast::LiteralPolicySet {
             })
             .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
 
-        Ok(Self::new(templates_and_static_policies, links))
-    }
-}
+        // Allocate the templates into Arc's
+        let templates = templates_and_static_policies
+            .into_iter()
+            .map(|(id, template)| (id, Arc::new(template)))
+            .collect::<LinkedHashMap<ast::PolicyID, Arc<ast::Template>>>();
+        let links = links
+            .into_iter()
+            .map(|(id, literal)| {
+                if *literal.id() != id {
+                    return Err(ast::ReificationError::PolicyIdMismatch {
+                        key: id,
+                        policy_id: literal.id().clone(),
+                    });
+                }
+                literal.reify(&templates).map(|linked| (id, linked))
+            })
+            .collect::<Result<LinkedHashMap<ast::PolicyID, ast::Policy>, ast::ReificationError>>()
+            .map_err(|e| {
+                ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}"))
+            })?;
 
-impl From<&ast::LiteralPolicySet> for models::PolicySet {
-    fn from(v: &ast::LiteralPolicySet) -> Self {
-        let templates = v.templates().map(models::TemplateBody::from).collect();
-        let links = v.policies().map(models::Policy::from).collect();
-        Self { templates, links }
+        let mut template_to_links_map = LinkedHashMap::new();
+        for template in &templates {
+            template_to_links_map.insert(template.0.clone(), LinkedHashSet::new());
+        }
+        for (link_id, link) in &links {
+            let template = link.template().id();
+            // Check that template-linked policy IDs do not collide with template IDs.
+            // This is enforced when using `ast::policy_set::PolicySet::link` to construct a
+            // policy set incrementally and should also be enforced here.
+            if !link.is_static() && templates.contains_key(link_id) {
+                return Err(ProtobufConversionError::InvalidValue(format!(
+                    "invalid policy set: {}",
+                    ast::ReificationError::Linking(ast::LinkingError::PolicyIdConflict {
+                        id: link_id.clone(),
+                    })
+                )));
+            }
+            match template_to_links_map.entry(template.clone()) {
+                Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
+                Entry::Vacant(_) => {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "invalid policy set: {}",
+                        ast::ReificationError::NoSuchTemplate(template.clone())
+                    )));
+                }
+            };
+        }
+
+        Ok(ast::PolicySet::from_raw_components(
+            templates,
+            links,
+            template_to_links_map,
+        ))
     }
 }
 
@@ -511,15 +564,6 @@ impl From<&ast::PolicySet> for models::PolicySet {
         let templates = v.all_templates().map(models::TemplateBody::from).collect();
         let links = v.policies().map(models::Policy::from).collect();
         Self { templates, links }
-    }
-}
-
-impl TryFrom<models::PolicySet> for ast::PolicySet {
-    type Error = ProtobufConversionError;
-    fn try_from(pset: models::PolicySet) -> Result<Self, Self::Error> {
-        let literal = ast::LiteralPolicySet::try_from(pset)?;
-        ast::PolicySet::try_from(literal)
-            .map_err(|e| ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}")))
     }
 }
 
@@ -869,7 +913,7 @@ mod test {
         .unwrap();
         let mut mps = models::PolicySet::from(&ps);
         let mut mps_roundtrip =
-            models::PolicySet::from(&ast::LiteralPolicySet::try_from(mps.clone()).unwrap());
+            models::PolicySet::from(&ast::PolicySet::try_from(mps.clone()).unwrap());
 
         // we accept permutations as equivalent, so before comparison, we sort
         // both `.templates` and `.links`
@@ -940,7 +984,7 @@ mod test {
         .unwrap();
         let mut mps = models::PolicySet::from(&ps);
         let mut mps_roundtrip =
-            models::PolicySet::from(&ast::LiteralPolicySet::try_from(mps.clone()).unwrap());
+            models::PolicySet::from(&ast::PolicySet::try_from(mps.clone()).unwrap());
 
         // we accept permutations as equivalent, so before comparison, we sort
         // both `.templates` and `.links`
@@ -1111,7 +1155,7 @@ mod test {
             }],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
         );
     }
@@ -1124,7 +1168,7 @@ mod test {
             links: vec![],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate template_id")
         );
     }
@@ -1139,7 +1183,7 @@ mod test {
             ],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }
@@ -1151,7 +1195,7 @@ mod test {
             links: vec![template_link("shared_id", "shared_id")],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template_id")
         );
     }
@@ -1165,7 +1209,7 @@ mod test {
         };
         // This should succeed — static policies legitimately share an ID
         // between their template entry and link entry
-        assert_matches!(ast::LiteralPolicySet::try_from(pset), Ok(_));
+        assert_matches!(ast::PolicySet::try_from(pset), Ok(_));
     }
 
     #[test]
@@ -1175,7 +1219,7 @@ mod test {
             links: vec![static_policy_link("nonexistent")],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("references non-existent template")
         );
     }
@@ -1190,7 +1234,7 @@ mod test {
             ],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }
@@ -1204,7 +1248,7 @@ mod test {
             links: vec![static_policy_link("X"), template_link("T", "X")],
         };
         assert_matches!(
-            ast::LiteralPolicySet::try_from(bad),
+            ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
     }


### PR DESCRIPTION
This is part 1 of 2 of an attempt at removing `LiteralPolicySet` and `LiteralPolicy` to de-duplicate validation that happens in two stages. 
The validation code that converts `LiteralPolicySet` to `ast::PolicySet` is copy-pasted in the translation from `models::PolicySet` to `ast::PolicySet` and will be refactored later. But this should make it easier to review side by side.
The next PR will refactor validation. It may be possible to have some of that validation in `PolicySet::from_raw_components` so that the validation happens closer to the type it validates.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
