### PR TITLE
Add `Hash(ignore)` and `PartialOrd(ignore)` to match `PartialEq(ignore)`

### DIFF
--- a/cedar-policy-core/src/validator/json_schema.rs
+++ b/cedar-policy-core/src/validator/json_schema.rs
@@ -2449,6 +2449,7 @@ pub struct TypeOfAttribute<N> {
     /// Source location - if available
     #[cfg(feature = "extended-schema")]
     #[educe(PartialEq(ignore))]
+    #[educe(PartialOrd(ignore))]
     #[serde(skip)]
     pub loc: Option<Loc>,
 }

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -202,10 +202,12 @@ pub struct LocatedCommonType {
 
     /// Common type name source location if available
     #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     pub name_loc: Option<Loc>,
 
     /// Common type definition source location if available
     #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     pub type_loc: Option<Loc>,
 }
 
@@ -234,10 +236,12 @@ pub struct LocatedNamespace {
     pub name: SmolStr,
     /// Namespace name source location if available
     #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     pub name_loc: Option<Loc>,
 
     /// Namespace definition source location if available
     #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     pub def_loc: Option<Loc>,
 }
 


### PR DESCRIPTION
This was only missing in structs guarded by `feature = "extended-schema"` so the hash invariant violation has not impact on non-experimental code.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
