### PR TITLE
Error on templates in single-policy symcc targets

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -18,7 +18,7 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ### Fixed
 
-- `symcc` single-policy and two-policy commands now error if the `--policies` files contains templates. Previously templates were silently ignored.
+- `symcc` single-policy and two-policy commands now error if the `--policies` file contains templates. Previously templates were silently ignored.
    Policy-set commands continue to accept and ignore templates with a warning.
 
 ## 4.11.2

--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -18,7 +18,7 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ### Fixed
 
-- `symcc` single-policy an two-policy commands now error if the input policy files contains templates. Previously templates were silently ignored.
+- `symcc` single-policy and two-policy commands now error if the `--policies` files contains templates. Previously templates were silently ignored.
    Policy-set commands continue to accept and ignore templates with a warning.
 
 ## 4.11.2

--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -16,6 +16,11 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 - The `authorize` command with the `--template-linked` argument will now error if the link file does not exist.
 - For the experimental `tpe` and `partial-eval` features, an unknown authorization decision now causes the CLI to exit with exit code 4 instead of 0, making it distinguishable from a successful authorization allow decision (exit code 0).
 
+### Fixed
+
+- `symcc` single-policy an two-policy commands now error if the input policy files contains templates. Previously templates were silently ignored.
+   Policy-set commands continue to accept and ignore templates with a warning.
+
 ## 4.11.2
 
 ## 4.11.1

--- a/cedar-policy-cli/src/command/symcc.rs
+++ b/cedar-policy-cli/src/command/symcc.rs
@@ -231,17 +231,33 @@ fn warn_if_contains_templates(pset: &PolicySet, name: &str) {
     }
 }
 
+/// Extract exactly on policy from `pset`.
+///
+/// Returns an error if `pset` returns 0 or more than one policies. Returns an
+/// error if `pset` contains _any_ templates. This is an error for the single
+/// policy analysis targets because we expect the input to be a single policy,
+/// not a policy set. Any templates indicates that we were given a policy set.
+fn exactly_one_policy(pset: &PolicySet, name: &str) -> Result<Policy> {
+    let num_templates = pset.templates().count();
+    if num_templates > 0 {
+        Err(miette!(
+            "Expected exactly one static policy in {name}, found {num_templates} templates"
+        ))
+    } else {
+        pset.policies()
+            .exactly_one()
+            .map_err(|e| miette!("Expected exactly one policy in {name}, found {}", e.count()))
+            .cloned()
+    }
+}
+
 fn load_single_policy(
     policies: &SymccPoliciesArgs,
     schema_args: &SchemaArgs,
 ) -> Result<(Policy, Schema)> {
     let pset = policies.get_policy_set()?;
     let schema = schema_args.get_schema()?;
-    let policy = pset
-        .policies()
-        .exactly_one()
-        .map_err(|e| miette!("Expected exactly one policy, found {}", e.count()))?
-        .clone();
+    let policy = exactly_one_policy(&pset, "--policy")?;
     Ok((policy, schema))
 }
 
@@ -252,26 +268,8 @@ fn load_two_policies(
     let pset1 = args.get_policy_set_1()?;
     let pset2 = args.get_policy_set_2()?;
     let schema = schema_args.get_schema()?;
-    let p1 = pset1
-        .policies()
-        .exactly_one()
-        .map_err(|e| {
-            miette!(
-                "Expected exactly one policy in --policy1, found {}",
-                e.count()
-            )
-        })?
-        .clone();
-    let p2 = pset2
-        .policies()
-        .exactly_one()
-        .map_err(|e| {
-            miette!(
-                "Expected exactly one policy in --policy2, found {}",
-                e.count()
-            )
-        })?
-        .clone();
+    let p1 = exactly_one_policy(&pset1, "--policy1")?;
+    let p2 = exactly_one_policy(&pset2, "--policy2")?;
     Ok((p1, p2, schema))
 }
 

--- a/cedar-policy-cli/src/command/symcc.rs
+++ b/cedar-policy-cli/src/command/symcc.rs
@@ -231,9 +231,9 @@ fn warn_if_contains_templates(pset: &PolicySet, name: &str) {
     }
 }
 
-/// Extract exactly on policy from `pset`.
+/// Extract exactly one policy from `pset`.
 ///
-/// Returns an error if `pset` returns 0 or more than one policies. Returns an
+/// Returns an error if `pset` contains 0 or more than one policy. Returns an
 /// error if `pset` contains _any_ templates. This is an error for the single
 /// policy analysis targets because we expect the input to be a single policy,
 /// not a policy set. Any templates indicates that we were given a policy set.
@@ -241,7 +241,7 @@ fn exactly_one_policy(pset: &PolicySet, name: &str) -> Result<Policy> {
     let num_templates = pset.templates().count();
     if num_templates > 0 {
         Err(miette!(
-            "Expected exactly one static policy in {name}, found {num_templates} templates"
+            "Expected exactly one static policy in {name}, found {num_templates} policy template(s)"
         ))
     } else {
         pset.policies()
@@ -257,7 +257,7 @@ fn load_single_policy(
 ) -> Result<(Policy, Schema)> {
     let pset = policies.get_policy_set()?;
     let schema = schema_args.get_schema()?;
-    let policy = exactly_one_policy(&pset, "--policy")?;
+    let policy = exactly_one_policy(&pset, "--policies")?;
     Ok((policy, schema))
 }
 

--- a/cedar-policy-cli/tests/symcc.rs
+++ b/cedar-policy-cli/tests/symcc.rs
@@ -524,7 +524,7 @@ fn test_never_errors_rejects_empty_policy() {
         .assert()
         .failure()
         .stderr(predicates::str::contains(
-            "Expected exactly one policy in --policy, found 0",
+            "Expected exactly one policy in --policies, found 0",
         ));
 }
 
@@ -1063,7 +1063,7 @@ fn test_error_if_contains_templates_single_policy() {
     assert!(!output.status.success(), "expected non-zero exit code");
     insta::assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
     × Analysis failed
-    ╰─▶ Expected exactly one static policy in --policy, found 1 templates
+    ╰─▶ Expected exactly one static policy in --policies, found 1 policy template(s)
     ");
 }
 

--- a/cedar-policy-cli/tests/symcc.rs
+++ b/cedar-policy-cli/tests/symcc.rs
@@ -1063,7 +1063,8 @@ fn test_error_if_contains_templates_single_policy() {
     assert!(!output.status.success(), "expected non-zero exit code");
     insta::assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
     × Analysis failed
-    ╰─▶ Expected exactly one static policy in --policies, found 1 policy template(s)
+    ╰─▶ Expected exactly one static policy in --policies, found 1 policy
+        template(s)
     ");
 }
 

--- a/cedar-policy-cli/tests/symcc.rs
+++ b/cedar-policy-cli/tests/symcc.rs
@@ -524,7 +524,7 @@ fn test_never_errors_rejects_empty_policy() {
         .assert()
         .failure()
         .stderr(predicates::str::contains(
-            "Expected exactly one policy, found 0",
+            "Expected exactly one policy in --policy, found 0",
         ));
 }
 
@@ -1030,6 +1030,41 @@ fn test_no_template_warning_without_templates() {
         .assert()
         .success()
         .stderr(predicates::str::contains("will be ignored by analysis").not());
+}
+
+#[test]
+fn test_error_if_contains_templates_single_policy() {
+    let schema = write_temp(SAMPLE_SCHEMA);
+    let policy = write_temp(
+        r#"
+        permit(principal, action, resource);
+        forbid(principal == ?principal, action, resource);
+        "#,
+    );
+
+    let output = cargo::cargo_bin_cmd!("cedar")
+        .arg("symcc")
+        .arg("--principal-type")
+        .arg("Identity")
+        .arg("--action")
+        .arg(r#"Action::"view""#)
+        .arg("--resource-type")
+        .arg("Thing")
+        .arg("--schema")
+        .arg(schema.path())
+        .arg("--schema-format")
+        .arg("cedar")
+        .arg("always-matches")
+        .arg("--policies")
+        .arg(policy.path())
+        .output()
+        .expect("failed to run cedar");
+
+    assert!(!output.status.success(), "expected non-zero exit code");
+    insta::assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
+    × Analysis failed
+    ╰─▶ Expected exactly one static policy in --policy, found 1 templates
+    ");
 }
 
 #[test]


### PR DESCRIPTION
## Description of changes

This is a different design decision than we made for the policy-set command where a template is only a warning. For single policy commands we expect a policy and not a policy set, but a file containing a template can only be a policy set. We could back this off to a warning of people are concerned about the inconsistency but, I think it makes sense. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
