### PR TITLE
remove `LiteralPolicy` for proto and merge validation steps

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -22,7 +22,6 @@ use crate::parser::{
 use annotation::{Annotation, Annotations};
 use educe::Educe;
 use itertools::Itertools;
-use linked_hash_map::LinkedHashMap;
 use miette::Diagnostic;
 use nonempty::{nonempty, NonEmpty};
 use serde::{Deserialize, Serialize};
@@ -345,6 +344,14 @@ impl Template {
             .map(|_| Policy::new(template, Some(new_id), values))
     }
 
+    /// Create a static policy from a template that has no slots.
+    /// This will fail if the template has any open slots.
+    pub fn try_as_policy(template: Arc<Template>) -> Result<Policy, LinkingError> {
+        // INVARIANT (policy total map) Relies on check_binding to uphold the invariant
+        Template::check_binding(&template, &HashMap::new())
+            .map(|_| Policy::new(template, None, HashMap::new()))
+    }
+
     /// Take a static policy and create a template and a template-linked policy for it.
     /// They will share the same ID
     pub fn link_static_policy(p: StaticPolicy) -> (Arc<Template>, Policy) {
@@ -493,8 +500,8 @@ fn describe_arity_error(
 ///   - a link ID (unless it's a static policy)
 ///   - the bound values for slots in the template
 ///
-/// Policies are not serializable (due to the pointer), and can be serialized
-/// by converting to/from [`LiteralPolicy`]
+/// Policies are not directly serializable (due to the Arc pointer to the
+/// template).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Policy {
     /// Reference to the template
@@ -713,6 +720,12 @@ impl Policy {
     }
 }
 
+fn display_slot_env(env: &SlotEnv) -> String {
+    env.iter()
+        .map(|(slot, value)| format!("{slot} -> {value}"))
+        .join(",")
+}
+
 impl std::fmt::Display for Policy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_static() {
@@ -730,198 +743,6 @@ impl std::fmt::Display for Policy {
 
 /// Map from Slot Ids to Entity UIDs which fill the slots
 pub type SlotEnv = HashMap<SlotId, EntityUID>;
-
-/// Represents either a static policy or a template linked policy.
-///
-/// Contains less rich information than `Policy`. In particular, this form is
-/// easier to convert to/from the Protobuf representation of a `Policy`, because
-/// it simply refers to the `Template` by its Id and does not contain a
-/// reference to the `Template` itself.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LiteralPolicy {
-    /// ID of the template this policy is an instance of
-    template_id: PolicyID,
-    /// ID of this link.
-    /// This is `None` for static policies, and the static policy ID is defined
-    /// as the `template_id`
-    link_id: Option<PolicyID>,
-    /// Values of the slots
-    values: SlotEnv,
-}
-
-impl LiteralPolicy {
-    /// Create a `LiteralPolicy` representing a static policy with the given ID.
-    ///
-    /// The policy set should also contain a (zero-slot) `Template` with the given ID.
-    pub fn static_policy(template_id: PolicyID) -> Self {
-        Self {
-            template_id,
-            link_id: None,
-            values: SlotEnv::new(),
-        }
-    }
-
-    /// Create a `LiteralPolicy` representing a template-linked policy.
-    ///
-    /// The policy set should also contain the associated `Template`.
-    pub fn template_linked_policy(
-        template_id: PolicyID,
-        link_id: PolicyID,
-        values: SlotEnv,
-    ) -> Self {
-        Self {
-            template_id,
-            link_id: Some(link_id),
-            values,
-        }
-    }
-
-    /// Get the `EntityUID` associated with the given `SlotId`, if it exists
-    pub fn value(&self, slot: &SlotId) -> Option<&EntityUID> {
-        self.values.get(slot)
-    }
-}
-
-// Can we verify the hash property?
-
-impl std::hash::Hash for LiteralPolicy {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.template_id.hash(state);
-        // this shouldn't be a performance issue as these vectors should be small
-        let mut buf = self.values.iter().collect::<Vec<_>>();
-        buf.sort();
-        for (id, euid) in buf {
-            id.hash(state);
-            euid.hash(state);
-        }
-    }
-}
-
-// These would be great as property tests
-#[cfg(test)]
-mod hashing_tests {
-    use std::{
-        collections::hash_map::DefaultHasher,
-        hash::{Hash, Hasher},
-    };
-
-    use super::*;
-
-    fn compute_hash(ir: &LiteralPolicy) -> u64 {
-        let mut s = DefaultHasher::new();
-        ir.hash(&mut s);
-        s.finish()
-    }
-
-    fn build_template_linked_policy() -> LiteralPolicy {
-        let mut map = HashMap::new();
-        map.insert(SlotId::principal(), EntityUID::with_eid("eid"));
-        LiteralPolicy {
-            template_id: PolicyID::from_string("template"),
-            link_id: Some(PolicyID::from_string("id")),
-            values: map,
-        }
-    }
-
-    #[test]
-    fn hash_property_instances() {
-        let a = build_template_linked_policy();
-        let b = build_template_linked_policy();
-        assert_eq!(a, b);
-        assert_eq!(compute_hash(&a), compute_hash(&b));
-    }
-}
-
-/// Errors that can happen during policy reification
-#[derive(Debug, Diagnostic, Error)]
-pub enum ReificationError {
-    /// The [`PolicyID`] linked to did not exist
-    #[error("the id linked to does not exist")]
-    NoSuchTemplate(PolicyID),
-    /// Error linking the policy
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    Linking(#[from] LinkingError),
-    /// The outer map key does not match the policy's own ID
-    #[error("policy set map key `{key}` does not match the policy's own id `{policy_id}`")]
-    PolicyIdMismatch {
-        /// The outer map key
-        key: PolicyID,
-        /// The policy's own ID (from `LiteralPolicy::id()`)
-        policy_id: PolicyID,
-    },
-}
-
-impl LiteralPolicy {
-    /// Attempt to reify this template linked policy.
-    /// Ensures the linked template actually exists, replaces the id with a reference to the underlying template.
-    /// Fails if the template does not exist.
-    /// Consumes the policy.
-    pub fn reify(
-        self,
-        templates: &LinkedHashMap<PolicyID, Arc<Template>>,
-    ) -> Result<Policy, ReificationError> {
-        let template = templates
-            .get(&self.template_id)
-            .ok_or_else(|| ReificationError::NoSuchTemplate(self.template_id().clone()))?;
-        // INVARIANT (values total map)
-        Template::check_binding(template, &self.values).map_err(ReificationError::Linking)?;
-        Ok(Policy::new(template.clone(), self.link_id, self.values))
-    }
-
-    /// Lookup the euid bound by a SlotId
-    pub fn get(&self, id: &SlotId) -> Option<&EntityUID> {
-        self.values.get(id)
-    }
-
-    /// Get the [`PolicyID`] of this static or template-linked policy.
-    pub fn id(&self) -> &PolicyID {
-        self.link_id.as_ref().unwrap_or(&self.template_id)
-    }
-
-    /// Get the [`PolicyID`] of the template associated with this policy.
-    ///
-    /// For static policies, this is just the static policy ID.
-    pub fn template_id(&self) -> &PolicyID {
-        &self.template_id
-    }
-
-    /// Is this a static policy
-    pub fn is_static(&self) -> bool {
-        self.link_id.is_none()
-    }
-}
-
-fn display_slot_env(env: &SlotEnv) -> String {
-    env.iter()
-        .map(|(slot, value)| format!("{slot} -> {value}"))
-        .join(",")
-}
-
-impl std::fmt::Display for LiteralPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_static() {
-            write!(f, "Static policy w/ ID {}", self.template_id())
-        } else {
-            write!(
-                f,
-                "Template linked policy of {}, slots: [{}]",
-                self.template_id(),
-                display_slot_env(&self.values),
-            )
-        }
-    }
-}
-
-impl From<Policy> for LiteralPolicy {
-    fn from(p: Policy) -> Self {
-        Self {
-            template_id: p.template.id().clone(),
-            link_id: p.link,
-            values: p.values,
-        }
-    }
-}
 
 /// Static Policies are policy that do not come from templates.
 /// They have the same structure as a template definition, but cannot contain slots

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -631,6 +631,42 @@ mod test {
         }
     }
 
+    /// Create a template-linked `ast::Policy` with a `?principal` slot bound to
+    /// `entity_type`::`eid`, along with the templates map needed for reification.
+    fn make_linked_policy(
+        template_id: &str,
+        link_id: &str,
+        entity_type: &str,
+        eid: &str,
+    ) -> (
+        ast::Policy,
+        LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
+    ) {
+        let tb = ast::TemplateBody::new(
+            ast::PolicyID::from_string(template_id),
+            None,
+            ast::Annotations::from_iter([]),
+            ast::Effect::Permit,
+            ast::PrincipalConstraint::is_eq_slot(),
+            ast::ActionConstraint::Any,
+            ast::ResourceConstraint::any(),
+            None,
+        );
+        let template = Arc::new(ast::Template::from(tb));
+        let templates =
+            LinkedHashMap::from_iter([(ast::PolicyID::from_string(template_id), template.clone())]);
+        let policy = ast::Template::link(
+            template,
+            ast::PolicyID::from_string(link_id),
+            HashMap::from_iter([(
+                ast::SlotId::principal(),
+                ast::EntityUID::with_eid_and_type(entity_type, eid).unwrap(),
+            )]),
+        )
+        .unwrap();
+        (policy, templates)
+    }
+
     #[test]
     #[expect(clippy::too_many_lines, reason = "unit test code")]
     fn policy_roundtrip() {
@@ -781,36 +817,10 @@ mod test {
         );
 
         // Test reify roundtrip: ast::Policy -> models::Policy -> reify
-        // We need a template with a principal slot for the linked policy.
-        let slotted_tb = ast::TemplateBody::new(
-            ast::PolicyID::from_string("template"),
-            None,
-            ast::Annotations::from_iter([]),
-            ast::Effect::Permit,
-            ast::PrincipalConstraint::is_eq_slot(),
-            ac1.clone(),
-            rc.clone(),
-            None,
-        );
-        let slotted_template = Arc::new(ast::Template::from(slotted_tb));
-        let templates = LinkedHashMap::from_iter([(
-            ast::PolicyID::from_string("template"),
-            slotted_template.clone(),
-        )]);
-        let linked_policy = ast::Template::link(
-            slotted_template,
-            ast::PolicyID::from_string("id"),
-            HashMap::from_iter([(
-                ast::SlotId::principal(),
-                ast::EntityUID::with_eid_and_type("A", "eid").unwrap(),
-            )]),
-        )
-        .unwrap();
+        let (linked_policy, templates) = make_linked_policy("template", "id", "A", "eid");
         let model = models::Policy::from(&linked_policy);
         let roundtripped = reify(model, &templates).unwrap();
-        assert_eq!(linked_policy.id(), roundtripped.id());
-        assert_eq!(linked_policy.template().id(), roundtripped.template().id());
-        assert_eq!(linked_policy.env(), roundtripped.env());
+        assert_eq!(linked_policy, roundtripped);
 
         let tb = ast::TemplateBody::new(
             ast::PolicyID::from_string("\0\n \' \"+-$^!"),
@@ -828,38 +838,11 @@ mod test {
         );
 
         // Test reify roundtrip with special characters in IDs
-        let slotted_tb2 = ast::TemplateBody::new(
-            ast::PolicyID::from_string("template\0\n \' \"+-$^!"),
-            None,
-            ast::Annotations::from_iter([]),
-            ast::Effect::Permit,
-            ast::PrincipalConstraint::is_eq_slot(),
-            ast::ActionConstraint::Any,
-            ast::ResourceConstraint::any(),
-            None,
-        );
-        let slotted_template2 = Arc::new(ast::Template::from(slotted_tb2));
-        let templates2 = LinkedHashMap::from_iter([(
-            ast::PolicyID::from_string("template\0\n \' \"+-$^!"),
-            slotted_template2.clone(),
-        )]);
-        let linked_policy2 = ast::Template::link(
-            slotted_template2,
-            ast::PolicyID::from_string("link\0\n \' \"+-$^!"),
-            HashMap::from_iter([(
-                ast::SlotId::principal(),
-                ast::EntityUID::with_eid_and_type("A", "eid").unwrap(),
-            )]),
-        )
-        .unwrap();
+        let (linked_policy2, templates2) =
+            make_linked_policy("template\0\n \' \"+-$^!", "link\0\n \' \"+-$^!", "A", "eid");
         let model2 = models::Policy::from(&linked_policy2);
         let roundtripped2 = reify(model2, &templates2).unwrap();
-        assert_eq!(linked_policy2.id(), roundtripped2.id());
-        assert_eq!(
-            linked_policy2.template().id(),
-            roundtripped2.template().id()
-        );
-        assert_eq!(linked_policy2.env(), roundtripped2.env());
+        assert_eq!(linked_policy2, roundtripped2);
     }
 
     #[test]

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -28,7 +28,7 @@ use std::{
 
 /// Convert a [`models::Policy`] to an [`ast::Policy`] given a set of `templates`.
 /// Returns an error when any of the invariants of [`ast::Policy`] would be violated,
-/// or the template references in the model doesn't exist in the set of templates.
+/// or the template referenced by the model doesn't exist in the set of templates.
 fn reify(
     v: models::Policy,
     templates: &LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
@@ -1337,5 +1337,119 @@ mod test {
             ast::PolicySet::try_from(bad),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
         );
+    }
+
+    #[test]
+    fn literal_policy_set_rejects_static_policy_colliding_with_template_link_id() {
+        // Template-link with link_id "X" where "X" is also a template_id.
+        // The link_id-vs-template_id check catches this regardless of ordering
+        // with static policies, because a static policy's ID is always a template_id.
+        let bad = models::PolicySet {
+            templates: vec![slotted_template_body("T"), trivial_template_body("X")],
+            links: vec![template_link("T", "X"), static_policy_link("X")],
+        };
+        assert_matches!(
+            ast::PolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template_id")
+        );
+    }
+
+    // Tests with realistic policy sets containing multiple valid entries alongside
+    // the problematic one, to ensure validation works in the presence of noise.
+
+    #[test]
+    fn noisy_policy_set_rejects_duplicate_template_ids() {
+        let bad = models::PolicySet {
+            templates: vec![
+                trivial_template_body("ok1"),
+                slotted_template_body("ok2"),
+                trivial_template_body("duplicate"),
+                trivial_template_body("duplicate"),
+            ],
+            links: vec![static_policy_link("ok1"), template_link("ok2", "link1")],
+        };
+        assert_matches!(
+            ast::PolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("duplicate template_id")
+        );
+    }
+
+    #[test]
+    fn noisy_policy_set_rejects_duplicate_link_ids() {
+        let bad = models::PolicySet {
+            templates: vec![
+                trivial_template_body("t1"),
+                trivial_template_body("t2"),
+                slotted_template_body("t3"),
+            ],
+            links: vec![
+                static_policy_link("t1"),
+                template_link("t3", "link_ok"),
+                static_policy_link("t2"),
+                static_policy_link("t2"), // duplicate
+            ],
+        };
+        assert_matches!(
+            ast::PolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a policy id")
+        );
+    }
+
+    #[test]
+    fn noisy_policy_set_rejects_template_link_id_colliding_with_template_id() {
+        let bad = models::PolicySet {
+            templates: vec![
+                trivial_template_body("t1"),
+                slotted_template_body("t2"),
+                trivial_template_body("collide"),
+            ],
+            links: vec![
+                static_policy_link("t1"),
+                template_link("t2", "link_ok"),
+                template_link("t2", "collide"), // link_id == template_id "collide"
+            ],
+        };
+        assert_matches!(
+            ast::PolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("conflicts with a template_id")
+        );
+    }
+
+    #[test]
+    fn noisy_policy_set_rejects_nonexistent_template() {
+        let bad = models::PolicySet {
+            templates: vec![trivial_template_body("t1"), slotted_template_body("t2")],
+            links: vec![
+                static_policy_link("t1"),
+                template_link("t2", "link_ok"),
+                static_policy_link("ghost"), // references nonexistent template
+            ],
+        };
+        assert_matches!(
+            ast::PolicySet::try_from(bad),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("no such template")
+        );
+    }
+
+    #[test]
+    fn noisy_policy_set_valid_with_multiple_templates_and_links() {
+        let pset = models::PolicySet {
+            templates: vec![
+                trivial_template_body("static1"),
+                trivial_template_body("static2"),
+                slotted_template_body("tmpl1"),
+                slotted_template_body("tmpl2"),
+            ],
+            links: vec![
+                static_policy_link("static1"),
+                static_policy_link("static2"),
+                template_link("tmpl1", "link1"),
+                template_link("tmpl1", "link2"),
+                template_link("tmpl2", "link3"),
+            ],
+        };
+        let ps = ast::PolicySet::try_from(pset).unwrap();
+        assert_eq!(ps.all_templates().count(), 4);
+        assert_eq!(ps.policies().count(), 5);
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -631,6 +631,24 @@ mod test {
         }
     }
 
+    /// Build a templates map with a single template that has a `?principal` slot.
+    fn slotted_templates_map(id: &str) -> LinkedHashMap<ast::PolicyID, Arc<ast::Template>> {
+        let tb = ast::TemplateBody::new(
+            ast::PolicyID::from_string(id),
+            None,
+            ast::Annotations::from_iter([]),
+            ast::Effect::Permit,
+            ast::PrincipalConstraint::is_eq_slot(),
+            ast::ActionConstraint::Any,
+            ast::ResourceConstraint::any(),
+            None,
+        );
+        LinkedHashMap::from_iter([(
+            ast::PolicyID::from_string(id),
+            Arc::new(ast::Template::from(tb)),
+        )])
+    }
+
     /// Create a template-linked `ast::Policy` with a `?principal` slot bound to
     /// `entity_type`::`eid`, along with the templates map needed for reification.
     fn make_linked_policy(
@@ -642,21 +660,12 @@ mod test {
         ast::Policy,
         LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
     ) {
-        let tb = ast::TemplateBody::new(
-            ast::PolicyID::from_string(template_id),
-            None,
-            ast::Annotations::from_iter([]),
-            ast::Effect::Permit,
-            ast::PrincipalConstraint::is_eq_slot(),
-            ast::ActionConstraint::Any,
-            ast::ResourceConstraint::any(),
-            None,
-        );
-        let template = Arc::new(ast::Template::from(tb));
-        let templates =
-            LinkedHashMap::from_iter([(ast::PolicyID::from_string(template_id), template.clone())]);
+        let templates = slotted_templates_map(template_id);
+        let template = templates
+            .get(&ast::PolicyID::from_string(template_id))
+            .unwrap();
         let policy = ast::Template::link(
-            template,
+            template.clone(),
             ast::PolicyID::from_string(link_id),
             HashMap::from_iter([(
                 ast::SlotId::principal(),
@@ -1134,6 +1143,88 @@ mod test {
         assert_matches!(
             reify(bad, &templates),
             Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
+        );
+    }
+
+    #[test]
+    fn reify_rejects_link_with_wrong_slots() {
+        // Template has ?principal slot, but we provide ?resource instead
+        let templates = slotted_templates_map("t");
+        let bad = models::Policy {
+            template_id: "t".to_string(),
+            link_id: Some("link".to_string()),
+            is_template_link: true,
+            principal_euid: None,
+            resource_euid: Some(models::EntityUid {
+                ty: Some(models::Name {
+                    id: "User".to_string(),
+                    path: vec![],
+                }),
+                eid: "alice".to_string(),
+            }),
+        };
+        assert_matches!(
+            reify(bad, &templates),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("failed to convert to policy")
+        );
+    }
+
+    #[test]
+    fn reify_rejects_static_policy_from_slotted_template() {
+        // Template has ?principal slot, but we try to use it as a static policy
+        let templates = slotted_templates_map("t");
+        let bad = models::Policy {
+            template_id: "t".to_string(),
+            link_id: None,
+            is_template_link: false,
+            principal_euid: None,
+            resource_euid: None,
+        };
+        assert_matches!(
+            reify(bad, &templates),
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("failed to convert a static policy")
+        );
+    }
+
+    #[test]
+    fn template_body_try_from_missing_action_constraint() {
+        let bad = models::TemplateBody {
+            action_constraint: None,
+            ..trivial_template_body("t")
+        };
+        assert_matches!(
+            ast::TemplateBody::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "action_constraint"
+        );
+    }
+
+    #[test]
+    fn template_body_try_from_missing_resource_constraint() {
+        let bad = models::TemplateBody {
+            resource_constraint: None,
+            ..trivial_template_body("t")
+        };
+        assert_matches!(
+            ast::TemplateBody::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "resource_constraint"
+        );
+    }
+
+    #[test]
+    fn action_constraint_try_from_in_with_invalid_euid() {
+        let bad = models::ActionConstraint {
+            data: Some(models::action_constraint::Data::In(
+                models::action_constraint::InMessage {
+                    euids: vec![models::EntityUid {
+                        ty: None,
+                        eid: "read".to_string(),
+                    }],
+                },
+            )),
+        };
+        assert_matches!(
+            ast::ActionConstraint::try_from(bad),
+            Err(ProtobufConversionError::MissingField(f)) if f == "ty"
         );
     }
 

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -26,9 +26,19 @@ use std::{
     sync::Arc,
 };
 
-impl TryFrom<models::Policy> for ast::LiteralPolicy {
-    type Error = ProtobufConversionError;
-    fn try_from(v: models::Policy) -> Result<Self, Self::Error> {
+/// Convert a [`models::Policy`] to an [`ast::Policy`] given a set of `templates`.
+/// Returns an error when any of the invariants of [`ast::Policy`] would be violated,
+/// or the template references in the model doesn't exist in the set of templates.
+fn reify(
+    v: models::Policy,
+    templates: &LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
+) -> Result<ast::Policy, ProtobufConversionError> {
+    let template_id = ast::PolicyID::from_string(v.template_id);
+    let template = templates.get(&template_id).ok_or_else(|| {
+        ProtobufConversionError::InvalidValue(format!("no such template: {template_id}"))
+    })?;
+
+    if v.is_template_link {
         let mut values: ast::SlotEnv = HashMap::new();
         if let Some(principal_euid) = v.principal_euid {
             values.insert(
@@ -43,41 +53,18 @@ impl TryFrom<models::Policy> for ast::LiteralPolicy {
             );
         }
 
-        let template_id = ast::PolicyID::from_string(v.template_id);
-
-        if v.is_template_link {
-            Ok(Self::template_linked_policy(
-                template_id,
-                ast::PolicyID::from_string(
-                    v.link_id
-                        .as_ref()
-                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?,
-                ),
-                values,
-            ))
-        } else {
-            Ok(Self::static_policy(template_id))
-        }
-    }
-}
-
-impl From<&ast::LiteralPolicy> for models::Policy {
-    fn from(v: &ast::LiteralPolicy) -> Self {
-        Self {
-            template_id: v.template_id().as_ref().to_string(),
-            link_id: if v.is_static() {
-                None
-            } else {
-                Some(v.id().as_ref().to_string())
-            },
-            is_template_link: !v.is_static(),
-            principal_euid: v
-                .value(&ast::SlotId::principal())
-                .map(models::EntityUid::from),
-            resource_euid: v
-                .value(&ast::SlotId::resource())
-                .map(models::EntityUid::from),
-        }
+        let link_id = ast::PolicyID::from_string(
+            v.link_id
+                .as_ref()
+                .ok_or_else(|| ProtobufConversionError::missing("link_id"))?,
+        );
+        ast::Template::link(template.clone(), link_id, values).map_err(|e| {
+            ProtobufConversionError::InvalidValue(format!("failed to convert to policy: {e}"))
+        })
+    } else {
+        ast::Template::try_as_policy(template.clone()).map_err(|e| {
+            ProtobufConversionError::InvalidValue(format!("failed to convert a static policy: {e}"))
+        })
     }
 }
 
@@ -438,117 +425,73 @@ impl From<&ast::Effect> for models::Effect {
 
 impl TryFrom<models::PolicySet> for ast::PolicySet {
     type Error = ProtobufConversionError;
-    // TODO: simplify this implementation — the second half (reification) contains redundant checks
-    // that are already guaranteed by the first half (proto validation). This was intentionally
-    // written as a mechanical composition of the two former conversion steps to ease review.
     fn try_from(v: models::PolicySet) -> Result<Self, Self::Error> {
-        let mut template_ids: HashSet<ast::PolicyID> = HashSet::new();
         let mut link_ids: HashSet<ast::PolicyID> = HashSet::new();
 
-        let templates_and_static_policies = v
-            .templates
-            .into_iter()
-            .map(|tb| {
-                let id = ast::PolicyID::from_string(&tb.id);
-                if !template_ids.insert(id.clone()) {
+        // models::Template into the Arc<ast::Template>, detecting duplicates via entry API.
+        let mut templates: LinkedHashMap<ast::PolicyID, Arc<ast::Template>> = LinkedHashMap::new();
+        for tb in v.templates {
+            let id = ast::PolicyID::from_string(&tb.id);
+            let template = Arc::new(ast::Template::from(ast::TemplateBody::try_from(tb)?));
+            match templates.entry(id.clone()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(template);
+                }
+                Entry::Occupied(_) => {
                     return Err(ProtobufConversionError::InvalidValue(format!(
                         "duplicate template_id `{id}` in `templates`"
                     )));
                 }
-                Ok((id, ast::Template::from(ast::TemplateBody::try_from(tb)?)))
-            })
-            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
+            }
+        }
 
-        let links = v
-            .links
-            .into_iter()
-            .map(|p| {
-                // per docs in core.proto, for static policies, `link_id` is omitted/ignored,
-                // and the ID of the policy is the `template_id`.
-                let template_id = ast::PolicyID::from_string(&p.template_id);
-                if !template_ids.contains(&template_id) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "template_id `{template_id}` of link references non-existent template of `templates`"
-                    )));
-                }
-                if p.is_template_link {
-                    let link_id = p
-                        .link_id
-                        .as_ref()
-                        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?;
-                    let link_id = ast::PolicyID::from_string(link_id);
-                    if !link_ids.insert(link_id.clone()) {
-                        return Err(ProtobufConversionError::InvalidValue(format!(
-                            "link_id `{link_id}` conflicts with a policy id (link_id or template_id) in `links`"
-                        )));
-                    }
-                    // Template ids and link ids must not conflict!
-                    if template_ids.contains(&link_id) {
-                        return Err(ProtobufConversionError::InvalidValue(format!(
-                            "link_id `{link_id}` conflicts with a template_id in `templates`"
-                        )));
-                    }
-                    // the linked policy id is the link id
-                    Ok((link_id, ast::LiteralPolicy::try_from(p)?))
-                } else {
-                    // the policy id is the template id (see protobuf docs)
-                    if !link_ids.insert(template_id.clone()) {
-                        return Err(ProtobufConversionError::InvalidValue(format!(
-                            "template_id `{template_id}` of a static link conflicts with a policy id (link_id or template_id) in `links`"
-                        )));
-                    }
-                    Ok((template_id, ast::LiteralPolicy::try_from(p)?))
-                }
-            })
-            .collect::<Result<Vec<_>, ProtobufConversionError>>()?;
-
-        // Allocate the templates into Arc's
-        let templates = templates_and_static_policies
-            .into_iter()
-            .map(|(id, template)| (id, Arc::new(template)))
-            .collect::<LinkedHashMap<ast::PolicyID, Arc<ast::Template>>>();
-        let links = links
-            .into_iter()
-            .map(|(id, literal)| {
-                if *literal.id() != id {
-                    return Err(ast::ReificationError::PolicyIdMismatch {
-                        key: id,
-                        policy_id: literal.id().clone(),
-                    });
-                }
-                literal.reify(&templates).map(|linked| (id, linked))
-            })
-            .collect::<Result<LinkedHashMap<ast::PolicyID, ast::Policy>, ast::ReificationError>>()
-            .map_err(|e| {
-                ProtobufConversionError::InvalidValue(format!("invalid policy set: {e}"))
-            })?;
-
-        let mut template_to_links_map = LinkedHashMap::new();
+        // Build the links map and the template-to-links map together.
+        let mut template_to_links_map: LinkedHashMap<ast::PolicyID, LinkedHashSet<ast::PolicyID>> =
+            LinkedHashMap::new();
         for template in &templates {
             template_to_links_map.insert(template.0.clone(), LinkedHashSet::new());
         }
-        for (link_id, link) in &links {
-            let template = link.template().id();
-            // Check that template-linked policy IDs do not collide with template IDs.
-            // This is enforced when using `ast::policy_set::PolicySet::link` to construct a
-            // policy set incrementally and should also be enforced here.
-            if !link.is_static() && templates.contains_key(link_id) {
-                return Err(ProtobufConversionError::InvalidValue(format!(
-                    "invalid policy set: {}",
-                    ast::ReificationError::Linking(ast::LinkingError::PolicyIdConflict {
-                        id: link_id.clone(),
-                    })
-                )));
-            }
-            match template_to_links_map.entry(template.clone()) {
-                Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
-                Entry::Vacant(_) => {
+        let mut links: LinkedHashMap<ast::PolicyID, ast::Policy> = LinkedHashMap::new();
+        for p in v.links {
+            // per docs in core.proto, for static policies, `link_id` is omitted/ignored,
+            // and the ID of the policy is the `template_id`.
+            let template_id = ast::PolicyID::from_string(&p.template_id);
+            if p.is_template_link {
+                let link_id = p
+                    .link_id
+                    .as_ref()
+                    .ok_or_else(|| ProtobufConversionError::missing("link_id"))?;
+                let link_id = ast::PolicyID::from_string(link_id);
+                if !link_ids.insert(link_id.clone()) {
                     return Err(ProtobufConversionError::InvalidValue(format!(
-                        "invalid policy set: {}",
-                        ast::ReificationError::NoSuchTemplate(template.clone())
+                        "link_id `{link_id}` conflicts with a policy id (link_id or template_id) in `links`"
                     )));
                 }
-            };
+                if templates.contains_key(&link_id) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "link_id `{link_id}` conflicts with a template_id in `templates`"
+                    )));
+                }
+                let policy = reify(p, &templates)?;
+                template_to_links_map
+                    .entry(template_id)
+                    .or_insert_with(LinkedHashSet::new)
+                    .insert(link_id.clone());
+                links.insert(link_id, policy);
+            } else {
+                // the policy id is the template id (see protobuf docs)
+                if !link_ids.insert(template_id.clone()) {
+                    return Err(ProtobufConversionError::InvalidValue(format!(
+                        "template_id `{template_id}` of a static link conflicts with a policy id (link_id or template_id) in `links`"
+                    )));
+                }
+                let policy = reify(p, &templates)?;
+                template_to_links_map
+                    .entry(template_id.clone())
+                    .or_insert_with(LinkedHashSet::new)
+                    .insert(template_id.clone());
+                links.insert(template_id, policy);
+            }
         }
 
         Ok(ast::PolicySet::from_raw_components(
@@ -631,6 +574,29 @@ mod test {
             annotations: Default::default(),
             effect: models::Effect::Permit.into(),
             principal_constraint: Some(principal_or_resource_constraint_any()),
+            action_constraint: Some(action_constraint_any()),
+            resource_constraint: Some(principal_or_resource_constraint_any()),
+            non_scope_constraints: None,
+        }
+    }
+
+    /// A `TemplateBody` model with the given id and a `?principal` slot.
+    fn slotted_template_body(id: &str) -> models::TemplateBody {
+        models::TemplateBody {
+            id: id.to_string(),
+            annotations: Default::default(),
+            effect: models::Effect::Permit.into(),
+            principal_constraint: Some(models::PrincipalOrResourceConstraint {
+                data: Some(models::principal_or_resource_constraint::Data::Eq(
+                    models::principal_or_resource_constraint::EqMessage {
+                        er: Some(models::EntityReference {
+                            data: Some(models::entity_reference::Data::Slot(
+                                models::entity_reference::Slot::Unit.into(),
+                            )),
+                        }),
+                    },
+                )),
+            }),
             action_constraint: Some(action_constraint_any()),
             resource_constraint: Some(principal_or_resource_constraint_any()),
             non_scope_constraints: None,
@@ -814,18 +780,37 @@ mod test {
             ast::TemplateBody::try_from(models::TemplateBody::from(&tb)).unwrap()
         );
 
-        let policy = ast::LiteralPolicy::template_linked_policy(
+        // Test reify roundtrip: ast::Policy -> models::Policy -> reify
+        // We need a template with a principal slot for the linked policy.
+        let slotted_tb = ast::TemplateBody::new(
             ast::PolicyID::from_string("template"),
+            None,
+            ast::Annotations::from_iter([]),
+            ast::Effect::Permit,
+            ast::PrincipalConstraint::is_eq_slot(),
+            ac1.clone(),
+            rc.clone(),
+            None,
+        );
+        let slotted_template = Arc::new(ast::Template::from(slotted_tb));
+        let templates = LinkedHashMap::from_iter([(
+            ast::PolicyID::from_string("template"),
+            slotted_template.clone(),
+        )]);
+        let linked_policy = ast::Template::link(
+            slotted_template,
             ast::PolicyID::from_string("id"),
             HashMap::from_iter([(
                 ast::SlotId::principal(),
                 ast::EntityUID::with_eid_and_type("A", "eid").unwrap(),
             )]),
-        );
-        assert_eq!(
-            policy,
-            ast::LiteralPolicy::try_from(models::Policy::from(&policy)).unwrap()
-        );
+        )
+        .unwrap();
+        let model = models::Policy::from(&linked_policy);
+        let roundtripped = reify(model, &templates).unwrap();
+        assert_eq!(linked_policy.id(), roundtripped.id());
+        assert_eq!(linked_policy.template().id(), roundtripped.template().id());
+        assert_eq!(linked_policy.env(), roundtripped.env());
 
         let tb = ast::TemplateBody::new(
             ast::PolicyID::from_string("\0\n \' \"+-$^!"),
@@ -842,18 +827,39 @@ mod test {
             ast::TemplateBody::try_from(models::TemplateBody::from(&tb)).unwrap()
         );
 
-        let policy = ast::LiteralPolicy::template_linked_policy(
+        // Test reify roundtrip with special characters in IDs
+        let slotted_tb2 = ast::TemplateBody::new(
             ast::PolicyID::from_string("template\0\n \' \"+-$^!"),
+            None,
+            ast::Annotations::from_iter([]),
+            ast::Effect::Permit,
+            ast::PrincipalConstraint::is_eq_slot(),
+            ast::ActionConstraint::Any,
+            ast::ResourceConstraint::any(),
+            None,
+        );
+        let slotted_template2 = Arc::new(ast::Template::from(slotted_tb2));
+        let templates2 = LinkedHashMap::from_iter([(
+            ast::PolicyID::from_string("template\0\n \' \"+-$^!"),
+            slotted_template2.clone(),
+        )]);
+        let linked_policy2 = ast::Template::link(
+            slotted_template2,
             ast::PolicyID::from_string("link\0\n \' \"+-$^!"),
             HashMap::from_iter([(
                 ast::SlotId::principal(),
                 ast::EntityUID::with_eid_and_type("A", "eid").unwrap(),
             )]),
-        );
+        )
+        .unwrap();
+        let model2 = models::Policy::from(&linked_policy2);
+        let roundtripped2 = reify(model2, &templates2).unwrap();
+        assert_eq!(linked_policy2.id(), roundtripped2.id());
         assert_eq!(
-            policy,
-            ast::LiteralPolicy::try_from(models::Policy::from(&policy)).unwrap()
+            linked_policy2.template().id(),
+            roundtripped2.template().id()
         );
+        assert_eq!(linked_policy2.env(), roundtripped2.env());
     }
 
     #[test]
@@ -1128,7 +1134,7 @@ mod test {
     }
 
     #[test]
-    fn literal_policy_try_from_template_link_missing_link_id() {
+    fn reify_rejects_template_link_missing_link_id() {
         let bad = models::Policy {
             template_id: "t".to_string(),
             link_id: None,
@@ -1136,8 +1142,14 @@ mod test {
             principal_euid: None,
             resource_euid: None,
         };
+        let templates = LinkedHashMap::from_iter([(
+            ast::PolicyID::from_string("t"),
+            Arc::new(ast::Template::from(
+                ast::TemplateBody::try_from(trivial_template_body("t")).unwrap(),
+            )),
+        )]);
         assert_matches!(
-            ast::LiteralPolicy::try_from(bad),
+            reify(bad, &templates),
             Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
         );
     }
@@ -1220,14 +1232,14 @@ mod test {
         };
         assert_matches!(
             ast::PolicySet::try_from(bad),
-            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("references non-existent template")
+            Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("no such template")
         );
     }
 
     #[test]
     fn literal_policy_set_rejects_duplicate_template_link_ids() {
         let bad = models::PolicySet {
-            templates: vec![trivial_template_body("t")],
+            templates: vec![slotted_template_body("t")],
             links: vec![
                 template_link("t", "same_link"),
                 template_link("t", "same_link"),

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -26,46 +26,89 @@ use std::{
     sync::Arc,
 };
 
-/// Convert a [`models::Policy`] to an [`ast::Policy`] given a set of `templates`.
-/// Returns an error when any of the invariants of [`ast::Policy`] would be violated,
-/// or the template referenced by the model doesn't exist in the set of templates.
-fn reify(
+/// Convert a template-link [`models::Policy`] to an [`ast::Policy`] given a set of
+/// `templates`.
+///
+/// Returns an error when:
+/// - the link id is not in `v` (should have been a static policy),
+/// - the set of `link_ids` already contains a link with the same id,
+/// - the link id conflicts with a template id,
+/// - any of the invariants of [`ast::Policy`] would be violated,
+/// - the template referenced by the model doesn't exist in the set of templates.
+fn reify_template_link(
     v: models::Policy,
+    link_ids: &mut HashSet<ast::PolicyID>,
     templates: &LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
 ) -> Result<ast::Policy, ProtobufConversionError> {
     let template_id = ast::PolicyID::from_string(v.template_id);
     let template = templates.get(&template_id).ok_or_else(|| {
         ProtobufConversionError::InvalidValue(format!("no such template: {template_id}"))
     })?;
-
-    if v.is_template_link {
-        let mut values: ast::SlotEnv = HashMap::new();
-        if let Some(principal_euid) = v.principal_euid {
-            values.insert(
-                ast::SlotId::principal(),
-                ast::EntityUID::try_from(principal_euid)?,
-            );
-        }
-        if let Some(resource_euid) = v.resource_euid {
-            values.insert(
-                ast::SlotId::resource(),
-                ast::EntityUID::try_from(resource_euid)?,
-            );
-        }
-
-        let link_id = ast::PolicyID::from_string(
-            v.link_id
-                .as_ref()
-                .ok_or_else(|| ProtobufConversionError::missing("link_id"))?,
-        );
-        ast::Template::link(template.clone(), link_id, values).map_err(|e| {
-            ProtobufConversionError::InvalidValue(format!("failed to convert to policy: {e}"))
-        })
-    } else {
-        ast::Template::try_as_policy(template.clone()).map_err(|e| {
-            ProtobufConversionError::InvalidValue(format!("failed to convert a static policy: {e}"))
-        })
+    let link_id = v
+        .link_id
+        .as_ref()
+        .ok_or_else(|| ProtobufConversionError::missing("link_id"))?;
+    let link_id = ast::PolicyID::from_string(link_id);
+    if !link_ids.insert(link_id.clone()) {
+        return Err(ProtobufConversionError::InvalidValue(format!(
+            "link_id `{link_id}` conflicts with a policy id (link_id or template_id) in `links`"
+        )));
     }
+    if templates.contains_key(&link_id) {
+        return Err(ProtobufConversionError::InvalidValue(format!(
+            "link_id `{link_id}` conflicts with a template_id in `templates`"
+        )));
+    }
+
+    let mut values: ast::SlotEnv = HashMap::new();
+    if let Some(principal_euid) = v.principal_euid {
+        values.insert(
+            ast::SlotId::principal(),
+            ast::EntityUID::try_from(principal_euid)?,
+        );
+    }
+    if let Some(resource_euid) = v.resource_euid {
+        values.insert(
+            ast::SlotId::resource(),
+            ast::EntityUID::try_from(resource_euid)?,
+        );
+    }
+
+    let link_id = ast::PolicyID::from_string(
+        v.link_id
+            .as_ref()
+            .ok_or_else(|| ProtobufConversionError::missing("link_id"))?,
+    );
+    ast::Template::link(template.clone(), link_id, values).map_err(|e| {
+        ProtobufConversionError::InvalidValue(format!("failed to convert to policy: {e}"))
+    })
+}
+
+/// Convert a template-link [`models::Policy`] to an [`ast::Policy`] given a set of
+/// `templates`, in the context of an already existing set of `link_ids`.
+///
+/// Returns an error when:
+/// - the static policy id (`v.template_id`) conflicts with an id in `link_ids`,
+/// - any of the invariants of [`ast::Policy`] would be violated,
+/// - the template referenced by the model doesn't exist in the set of templates.
+fn reify_static_policy(
+    v: models::Policy,
+    link_ids: &mut HashSet<ast::PolicyID>,
+    templates: &LinkedHashMap<ast::PolicyID, Arc<ast::Template>>,
+) -> Result<ast::Policy, ProtobufConversionError> {
+    let template_id = ast::PolicyID::from_string(v.template_id);
+    // the policy id is the template id (see protobuf docs)
+    if !link_ids.insert(template_id.clone()) {
+        return Err(ProtobufConversionError::InvalidValue(format!(
+                        "template_id `{template_id}` of a static link conflicts with a policy id (link_id or template_id) in `links`"
+                    )));
+    }
+    let template = templates.get(&template_id).ok_or_else(|| {
+        ProtobufConversionError::InvalidValue(format!("no such template: {template_id}"))
+    })?;
+    ast::Template::try_as_policy(template.clone()).map_err(|e| {
+        ProtobufConversionError::InvalidValue(format!("failed to convert a static policy: {e}"))
+    })
 }
 
 impl From<&ast::Policy> for models::Policy {
@@ -457,35 +500,16 @@ impl TryFrom<models::PolicySet> for ast::PolicySet {
             // and the ID of the policy is the `template_id`.
             let template_id = ast::PolicyID::from_string(&p.template_id);
             if p.is_template_link {
-                let link_id = p
-                    .link_id
-                    .as_ref()
-                    .ok_or_else(|| ProtobufConversionError::missing("link_id"))?;
-                let link_id = ast::PolicyID::from_string(link_id);
-                if !link_ids.insert(link_id.clone()) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "link_id `{link_id}` conflicts with a policy id (link_id or template_id) in `links`"
-                    )));
-                }
-                if templates.contains_key(&link_id) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "link_id `{link_id}` conflicts with a template_id in `templates`"
-                    )));
-                }
-                let policy = reify(p, &templates)?;
+                let policy = reify_template_link(p, &mut link_ids, &templates)?;
+                // The id of the policy is policy id, the underlying template id is template_id
                 template_to_links_map
                     .entry(template_id)
                     .or_insert_with(LinkedHashSet::new)
-                    .insert(link_id.clone());
-                links.insert(link_id, policy);
+                    .insert(policy.id().clone());
+                links.insert(policy.id().clone(), policy);
             } else {
-                // the policy id is the template id (see protobuf docs)
-                if !link_ids.insert(template_id.clone()) {
-                    return Err(ProtobufConversionError::InvalidValue(format!(
-                        "template_id `{template_id}` of a static link conflicts with a policy id (link_id or template_id) in `links`"
-                    )));
-                }
-                let policy = reify(p, &templates)?;
+                let policy = reify_static_policy(p, &mut link_ids, &templates)?;
+                // The policy and the template id are the same, it's template_id
                 template_to_links_map
                     .entry(template_id.clone())
                     .or_insert_with(LinkedHashSet::new)
@@ -828,7 +852,8 @@ mod test {
         // Test reify roundtrip: ast::Policy -> models::Policy -> reify
         let (linked_policy, templates) = make_linked_policy("template", "id", "A", "eid");
         let model = models::Policy::from(&linked_policy);
-        let roundtripped = reify(model, &templates).unwrap();
+        let mut link_ids = HashSet::new();
+        let roundtripped = reify_template_link(model, &mut link_ids, &templates).unwrap();
         assert_eq!(linked_policy, roundtripped);
 
         let tb = ast::TemplateBody::new(
@@ -850,7 +875,8 @@ mod test {
         let (linked_policy2, templates2) =
             make_linked_policy("template\0\n \' \"+-$^!", "link\0\n \' \"+-$^!", "A", "eid");
         let model2 = models::Policy::from(&linked_policy2);
-        let roundtripped2 = reify(model2, &templates2).unwrap();
+        let mut link_ids = HashSet::new();
+        let roundtripped2 = reify_template_link(model2, &mut link_ids, &templates2).unwrap();
         assert_eq!(linked_policy2, roundtripped2);
     }
 
@@ -1140,8 +1166,9 @@ mod test {
                 ast::TemplateBody::try_from(trivial_template_body("t")).unwrap(),
             )),
         )]);
+        let mut link_ids = HashSet::new();
         assert_matches!(
-            reify(bad, &templates),
+            reify_template_link(bad, &mut link_ids, &templates),
             Err(ProtobufConversionError::MissingField(f)) if f == "link_id"
         );
     }
@@ -1163,8 +1190,9 @@ mod test {
                 eid: "alice".to_string(),
             }),
         };
+        let mut link_ids = HashSet::new();
         assert_matches!(
-            reify(bad, &templates),
+            reify_template_link(bad, &mut link_ids, &templates),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("failed to convert to policy")
         );
     }
@@ -1180,8 +1208,9 @@ mod test {
             principal_euid: None,
             resource_euid: None,
         };
+        let mut link_ids = HashSet::new();
         assert_matches!(
-            reify(bad, &templates),
+            reify_static_policy(bad, &mut link_ids, &templates),
             Err(ProtobufConversionError::InvalidValue(msg)) if msg.contains("failed to convert a static policy")
         );
     }


### PR DESCRIPTION
## Description of changes

This part 2 of https://github.com/cedar-policy/cedar/pull/2469:
- removes the `LiteralPolicySet` struct that was used as an intermediate between `models::PolicySet` and `ast::PolicySet`.
- merges the validation steps for `PolicySet` that were copy-pasted in the previous PR,
- merges the validation steps for `Policy` that were separated by `LiteralPolicy`. 

The `Policy` invariants on slot well formedness is now entirely in the Template to Policy conversion (`try_as_policy` enforces the same as `link` of `ast::Template`). 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
-  [] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
