### PR TITLE
make proto encode faillible on message depth

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -28,6 +28,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ### Changed
 
+- The experimental protobuf `encode` method now returns `Result<Vec<u8>, EncodeError>` instead of `Vec<u8>`. Encoding rejects expressions and schema types whose nesting depth would exceed prost's decode recursion limit, returning `EncodeError::MaxDepthExceeded`. This prevents a class of bugs where successfully encoded data could not be decoded.
 - The experimental protobuf decoding API now validates its inputs, checking structural invariants on entities, expressions, templates, policy sets, and schemas. Additionally, `Entities::decode` now computes the transitive closure instead of assuming it is already computed. These changes may result in lower performance for protobuf decoding. The previous, unvalidated behavior is available via the new `decode_unchecked` methods (e.g., `Entities::decode_unchecked`) for trusted encoded data.
 - For the experimental `tpe` feature, `TpeResponse::residual_policies` is updated to return only _non-trivial_ residuals and
   `TpeResponse::nontrivial_residual_policies` is deprecated. The previous behavior (iterating all residuals including trivial ones)

--- a/cedar-policy/src/proto.rs
+++ b/cedar-policy/src/proto.rs
@@ -56,3 +56,7 @@ mod api;
 
 /// `Protobuf` trait and associated utilities
 pub mod traits;
+
+/// Shared test helpers for constructing protobuf model values.
+#[cfg(test)]
+pub(crate) mod test_utils;

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -148,6 +148,7 @@ impl traits::Protobuf for api::PolicySet {
 
 #[cfg(test)]
 mod roundtrip_test {
+    use super::models;
     use prost::Message as _;
     use std::{collections::HashMap, str::FromStr};
 
@@ -155,11 +156,11 @@ mod roundtrip_test {
     /// Checks that the input API policy set is equal to the converted policy set.
     fn roundtrip_policies(policies: crate::PolicySet) {
         // API -> Protobuf model
-        let policies_proto = crate::proto::models::PolicySet::from(&policies);
+        let policies_proto = models::PolicySet::from(&policies);
         // Protobuf model -> Protobuf bytes
         let buf = policies_proto.encode_to_vec();
         // Protobuf bytes -> Protobuf model
-        let roundtripped_proto = crate::proto::models::PolicySet::decode(&buf[..])
+        let roundtripped_proto = models::PolicySet::decode(&buf[..])
             .expect("Failed to deserialize PolicySet from protobuf");
         // -> Protobuf model -> API
         let roundtripped = crate::PolicySet::try_from(roundtripped_proto)
@@ -484,88 +485,215 @@ mod decode_test {
 
 #[cfg(test)]
 mod encode_test {
+    use super::models;
+    use super::traits::{EncodeCheck, EncodeError, Protobuf, MAX_ENCODE_DEPTH};
+    use crate::proto::test_utils::*;
+    use crate::Expression;
+    use cedar_policy_core::ast;
     use cool_asserts::assert_matches;
-    use std::collections::HashMap;
     use std::str::FromStr;
 
-    /// Build a deeply nested `models::Expr` of the form `!(!(!(...true...)))` with `n` levels
-    /// of `UnaryApp` nesting. The protobuf recursion cost is 1 (root `Expr`) + 2*n (each wrapper).
-    fn make_deep_unary_expr(n: usize) -> crate::proto::models::Expr {
-        use crate::proto::models::{self, expr};
-        let mut expr = models::Expr {
-            expr_kind: Some(expr::ExprKind::Lit(expr::Literal {
-                lit: Some(expr::literal::Lit::B(true)),
-            })),
-        };
+    // ================================================================
+    // Helpers for building deeply nested expressions of various kinds
+    // ================================================================
+
+    /// Build `n` levels of `!(!(...lit_bool(true)...))`.
+    fn deep_unary(n: usize) -> models::Expr {
+        let mut e = lit_bool(true);
         for _ in 0..n {
-            expr = models::Expr {
-                expr_kind: Some(expr::ExprKind::UApp(Box::new(expr::UnaryApp {
-                    op: expr::unary_app::Op::Not.into(),
-                    expr: Some(Box::new(expr)),
+            e = not(e);
+        }
+        e
+    }
+
+    /// Build `n` levels of `{k: {k: ...lit_bool(true)...}}`.
+    fn deep_record_expr(n: usize) -> models::Expr {
+        let mut e = lit_bool(true);
+        for _ in 0..n {
+            e = record([("k", e)]);
+        }
+        e
+    }
+
+    /// Build `n` levels of `if true then (if true then ... else false) else false`.
+    fn deep_if(n: usize) -> models::Expr {
+        let mut e = lit_bool(true);
+        for _ in 0..n {
+            e = if_then_else(lit_bool(true), e, lit_bool(false));
+        }
+        e
+    }
+
+    /// Build `n` levels of `true && (true && ...)`.
+    fn deep_and(n: usize) -> models::Expr {
+        let mut e = lit_bool(true);
+        for _ in 0..n {
+            e = models::Expr {
+                expr_kind: Some(models::expr::ExprKind::And(Box::new(models::expr::And {
+                    left: Some(Box::new(lit_bool(true))),
+                    right: Some(Box::new(e)),
                 }))),
             };
         }
-        expr
+        e
     }
 
-    /// Build a deeply nested `models::Expr` of the form `{key:{key:{..}..}}` with `n` levels
-    /// of `Record` nesting. The protobuf recursion cost is 1 (root `Expr`) + 2*n (each wrapper).
-    fn make_deep_record_expr(n: usize) -> crate::proto::models::Expr {
-        use crate::proto::models::{self, expr};
-        let mut expr = models::Expr {
-            expr_kind: Some(expr::ExprKind::Lit(expr::Literal {
-                lit: Some(expr::literal::Lit::B(true)),
-            })),
-        };
+    /// Build `n` levels of `true || (true || ...)`.
+    fn deep_or(n: usize) -> models::Expr {
+        let mut e = lit_bool(false);
         for _ in 0..n {
-            let mut items = HashMap::new();
-            items.insert("k".into(), expr);
-            expr = models::Expr {
-                expr_kind: Some(expr::ExprKind::Record(expr::Record { items })),
+            e = models::Expr {
+                expr_kind: Some(models::expr::ExprKind::Or(Box::new(models::expr::Or {
+                    left: Some(Box::new(lit_bool(true))),
+                    right: Some(Box::new(e)),
+                }))),
             };
         }
-        expr
+        e
     }
 
-    fn ok_at_depth(depth: usize, expect_ok: bool) {
-        use crate::proto::traits::{EncodeCheck, EncodeError};
-        let expr = make_deep_unary_expr(depth);
-        if expect_ok {
-            assert!(expr.check_for_encode().is_ok());
-        } else {
-            assert_matches!(expr.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
-        };
-        let expr_record = make_deep_record_expr(depth);
-        if expect_ok {
-            assert!(expr_record.check_for_encode().is_ok());
-        } else {
-            assert_matches!(
-                expr_record.check_for_encode(),
-                Err(EncodeError::MaxDepthExceeded)
-            );
-        };
+    /// Build `n` levels of `(... + 1) + 1`.
+    fn deep_binary(n: usize) -> models::Expr {
+        let mut e = lit_long(0);
+        for _ in 0..n {
+            e = binary(models::expr::binary_app::Op::Add, e, lit_long(1));
+        }
+        e
+    }
+
+    /// Build `n` levels of `ext(ext(...))`.
+    fn deep_ext(n: usize) -> models::Expr {
+        let mut e = lit_str("1.0");
+        for _ in 0..n {
+            e = ext_call("decimal", [e]);
+        }
+        e
+    }
+
+    /// Build `n` levels of `.attr.attr...`.
+    fn deep_get_attr(n: usize) -> models::Expr {
+        let mut e = var(models::expr::Var::Context);
+        for _ in 0..n {
+            e = get_attr(e, "x");
+        }
+        e
+    }
+
+    /// Build `n` levels of `has attr has attr ...`.
+    fn deep_has_attr(n: usize) -> models::Expr {
+        // has returns bool, so wrap: if (e has "x") then (inner has "x") else false
+        // Simpler: just chain `has` on nested get_attr
+        let mut e = var(models::expr::Var::Context);
+        for _ in 0..n {
+            e = has_attr(e, "x");
+        }
+        e
+    }
+
+    /// Build `n` levels of `like` wrapping.
+    fn deep_like(n: usize) -> models::Expr {
+        // `like` takes an expr child, so we can nest: like(like(...))
+        // But `like` returns bool... use if to re-wrap.
+        // Simpler: just nest the expr child of Like.
+        let mut e = lit_str("hello");
+        for _ in 0..n {
+            e = models::Expr {
+                expr_kind: Some(models::expr::ExprKind::Like(Box::new(models::expr::Like {
+                    expr: Some(Box::new(e)),
+                    pattern: vec![],
+                }))),
+            };
+        }
+        e
+    }
+
+    /// Build `n` levels of `is` wrapping.
+    fn deep_is(n: usize) -> models::Expr {
+        let mut e = var(models::expr::Var::Principal);
+        for _ in 0..n {
+            e = models::Expr {
+                expr_kind: Some(models::expr::ExprKind::Is(Box::new(models::expr::Is {
+                    expr: Some(Box::new(e)),
+                    entity_type: Some(name("User")),
+                }))),
+            };
+        }
+        e
+    }
+
+    /// Build `n` levels of nested sets: `[[[[...]]]]`.
+    fn deep_set(n: usize) -> models::Expr {
+        let mut e = lit_long(1);
+        for _ in 0..n {
+            e = set([e]);
+        }
+        e
     }
 
     /// Maximum nesting levels that fit within `MAX_ENCODE_DEPTH`.
-    /// Each `UnaryApp` nesting costs 2 prost levels; root `Expr` costs 1.
+    /// Each nesting costs 2 prost levels; root `Expr` costs 1.
     /// So max nestings = (`MAX_ENCODE_DEPTH` - 1) / 2.
-    const MAX_NESTING: usize = (crate::proto::traits::MAX_ENCODE_DEPTH - 1) / 2;
+    const MAX_NESTING: usize = (MAX_ENCODE_DEPTH - 1) / 2;
 
-    #[test]
-    fn encode_expression_within_depth_limit() {
-        ok_at_depth(MAX_NESTING, true);
+    // ================================================================
+    // Depth limit tests for all expression variants
+    // ================================================================
+
+    /// Assert that the given expression passes or fails the encode check.
+    /// When `expect_ok`, also verifies the encode→decode roundtrip succeeds
+    /// (i.e., prost can decode what we encoded).
+    #[track_caller]
+    fn assert_encode_check(name: &str, expr: &models::Expr, expect_ok: bool) {
+        if expect_ok {
+            assert!(
+                expr.check_for_encode().is_ok(),
+                "{name}: expected Ok but got MaxDepthExceeded"
+            );
+            // Verify prost can actually decode the encoded bytes.
+            let bytes = prost::Message::encode_to_vec(expr);
+            assert!(
+                <models::Expr as prost::Message>::decode(&bytes[..]).is_ok(),
+                "{name}: decoding failed despite depth check",
+            );
+        } else {
+            assert_matches!(
+                expr.check_for_encode(),
+                Err(EncodeError::MaxDepthExceeded),
+                "{name} did not error with MaxDepthExceeded"
+            );
+        }
     }
 
     #[test]
-    fn encode_expression_exceeds_depth_limit() {
-        ok_at_depth(MAX_NESTING + 1, false);
+    fn depth_all_expr_variants_at_limit() {
+        let builders: &[(&str, fn(usize) -> models::Expr, usize)] = &[
+            ("unary", deep_unary, MAX_NESTING),
+            ("record", deep_record_expr, (MAX_ENCODE_DEPTH - 1) / 3),
+            ("if", deep_if, MAX_NESTING),
+            ("and", deep_and, MAX_NESTING),
+            ("or", deep_or, MAX_NESTING),
+            ("binary", deep_binary, MAX_NESTING),
+            ("ext", deep_ext, MAX_NESTING),
+            ("get_attr", deep_get_attr, MAX_NESTING),
+            ("has_attr", deep_has_attr, MAX_NESTING),
+            ("like", deep_like, MAX_NESTING),
+            ("is", deep_is, MAX_NESTING),
+            ("set", deep_set, MAX_NESTING),
+        ];
+        for (name, builder, limit) in builders {
+            let ok = builder(*limit);
+            assert_encode_check(name, &ok, true);
+            let bad = builder(*limit + 1);
+            assert_encode_check(name, &bad, false);
+        }
     }
+
+    // ================================================================
+    // Full API encode path tests
+    // ================================================================
 
     #[test]
     fn encode_expression_api_returns_error_on_deep_expr() {
-        use crate::proto::traits::{EncodeError, Protobuf};
-        // Build a deep AST expression and test the full encode path via the API type.
-        use cedar_policy_core::ast;
         let mut e = ast::Expr::var(ast::Var::Principal);
         for _ in 0..=MAX_NESTING {
             e = ast::Expr::not(e);
@@ -576,9 +704,6 @@ mod encode_test {
 
     #[test]
     fn encode_policyset_with_deep_condition_fails() {
-        use crate::proto::traits::{EncodeError, Protobuf};
-        // Build a policy with an excessively deep when-condition.
-        use cedar_policy_core::ast;
         let mut e = ast::Expr::val(true);
         for _ in 0..=MAX_NESTING {
             e = ast::Expr::not(e);
@@ -601,159 +726,157 @@ mod encode_test {
 
     #[test]
     fn encode_entities_with_deep_attr_fails() {
-        use crate::proto::traits::{EncodeCheck, EncodeError};
-        // Build an Entity model with an attribute that is too deep.
-        let deep_expr = make_deep_unary_expr(MAX_NESTING + 1);
-        let entity = crate::proto::models::Entity {
-            uid: Some(crate::proto::models::EntityUid {
-                ty: Some(crate::proto::models::Name {
-                    id: "User".to_string(),
-                    path: vec![],
-                }),
-                eid: "alice".to_string(),
-            }),
-            attrs: HashMap::from([("deep_attr".to_string(), deep_expr)]),
-            ancestors: vec![],
-            tags: HashMap::new(),
+        let deep_expr = deep_unary(MAX_NESTING + 1);
+        let ent = entity("User", "alice", [("deep_attr", deep_expr)]);
+        assert_matches!(ent.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_entity_with_deep_tag_fails() {
+        let deep_expr = deep_unary(MAX_NESTING + 1);
+        let ent = entity_full("User", "alice", [], [], [("deep_tag", deep_expr)]);
+        assert_matches!(ent.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_request_with_deep_context_fails() {
+        let deep_expr = deep_unary(MAX_NESTING + 1);
+        let req = models::Request {
+            principal: Some(entity_uid("User", "alice")),
+            action: Some(entity_uid("Action", "read")),
+            resource: Some(entity_uid("Doc", "readme")),
+            context: [("deep".to_string(), deep_expr)].into_iter().collect(),
         };
+        assert_matches!(req.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_request_shallow_context_succeeds() {
+        let req = models::Request {
+            principal: Some(entity_uid("User", "alice")),
+            action: Some(entity_uid("Action", "read")),
+            resource: Some(entity_uid("Doc", "readme")),
+            context: [("flag".to_string(), lit_bool(true))].into_iter().collect(),
+        };
+        assert!(req.check_for_encode().is_ok());
+    }
+
+    // ================================================================
+    // Schema type depth tests
+    // ================================================================
+
+    /// Build `n` levels of `Set(Set(...Long...))`.
+    fn deep_set_type(n: usize) -> models::Type {
+        let mut ty = long_type();
+        for _ in 0..n {
+            ty = set_type(ty);
+        }
+        ty
+    }
+
+    /// Build `n` levels of `Record { x: Record { x: ... Long } }`.
+    fn deep_record_type(n: usize) -> models::Type {
+        let mut ty = long_type();
+        for _ in 0..n {
+            ty = record_type([("x", required(ty))]);
+        }
+        ty
+    }
+
+    #[test]
+    fn encode_schema_set_type_limit() {
+        // Set nesting costs 1 prost level per level, starting at depth 2
+        // (AttributeType + Type). Exceeds when 2 + n > MAX_ENCODE_DEPTH.
+        let max_set_depth = MAX_ENCODE_DEPTH - 2;
+        let ok_schema = schema([entity_decl(
+            "Foo",
+            [("a", required(deep_set_type(max_set_depth)))],
+        )]);
+        assert!(ok_schema.check_for_encode().is_ok());
+
+        let bad_schema = schema([entity_decl(
+            "Foo",
+            [("a", required(deep_set_type(max_set_depth + 1)))],
+        )]);
         assert_matches!(
-            entity.check_for_encode(),
+            bad_schema.check_for_encode(),
             Err(EncodeError::MaxDepthExceeded)
         );
     }
 
     #[test]
+    fn encode_schema_record_type_limit() {
+        // Record nesting costs 3 prost levels per level, starting at depth 2.
+        // Exceeds when 2 + 3*n > MAX_ENCODE_DEPTH.
+        let max_rec_depth = (MAX_ENCODE_DEPTH - 2) / 3;
+        let ok_schema = schema([entity_decl(
+            "Bar",
+            [("a", required(deep_record_type(max_rec_depth)))],
+        )]);
+        assert!(ok_schema.check_for_encode().is_ok());
+
+        let bad_schema = schema([entity_decl(
+            "Bar",
+            [("a", required(deep_record_type(max_rec_depth + 1)))],
+        )]);
+        assert_matches!(
+            bad_schema.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn encode_schema_tag_type_deep_fails() {
+        // Tags start at depth 1 (no AttributeType wrapper), so Set nesting
+        // exceeds at 1 + n > MAX_ENCODE_DEPTH → n > MAX_ENCODE_DEPTH - 1.
+        let bad_tag = deep_set_type(MAX_ENCODE_DEPTH);
+        let decl = entity_decl_full("Foo", [], [], Some(bad_tag));
+        let s = schema([decl]);
+        assert_matches!(s.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_schema_action_context_deep_fails() {
+        let deep_ty = deep_set_type(MAX_ENCODE_DEPTH);
+        let action = action_decl(
+            ("Action", "read"),
+            ["User"],
+            ["Doc"],
+            [("deep_ctx", required(deep_ty))],
+        );
+        let s = schema_full([], [action]);
+        assert_matches!(s.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_schema_shallow_type_succeeds() {
+        let (schema, _) =
+            crate::Schema::from_cedarschema_str("entity User { name: String, age: Long };")
+                .expect("parse schema");
+        assert!(schema.encode().is_ok());
+    }
+
+    // ================================================================
+    // Roundtrip test (encode at limit → decode succeeds)
+    // ================================================================
+
+    #[test]
     fn encode_shallow_expression_succeeds() {
-        use crate::proto::traits::Protobuf;
-        // A simple expression should encode fine.
         let expression = crate::Expression::from_str("1 + 2").expect("parse");
         assert!(expression.encode().is_ok());
     }
 
     #[test]
     fn encode_at_limit_roundtrips_through_prost() {
-        use crate::proto::traits::{EncodeCheck, Protobuf};
-        // Verify that an expression exactly at the limit can actually be decoded by prost.
-        let expr = make_deep_unary_expr(MAX_NESTING);
+        let expr = deep_unary(MAX_NESTING);
         assert!(expr.check_for_encode().is_ok());
         // Encode via the API and decode to confirm prost doesn't reject it.
-        use cedar_policy_core::ast;
         let mut e = ast::Expr::val(true);
         for _ in 0..MAX_NESTING {
             e = ast::Expr::not(e);
         }
         let expression = crate::Expression(e);
         let buf = expression.encode().expect("should encode within limit");
-        crate::Expression::decode(&buf[..]).expect("should decode within prost's recursion limit");
-    }
-
-    /// Build a deeply nested `models::Type` of the form `Set(Set(Set(...Long...)))`.
-    /// Each Set nesting costs 1 prost recursion level.
-    fn make_deep_set_type(n: usize) -> crate::proto::models::Type {
-        use crate::proto::models::{self, r#type};
-        let mut ty = models::Type {
-            data: Some(r#type::Data::Prim(r#type::Prim::Long.into())),
-        };
-        for _ in 0..n {
-            ty = models::Type {
-                data: Some(r#type::Data::SetElem(Box::new(ty))),
-            };
-        }
-        ty
-    }
-
-    /// Build a deeply nested record type: `Record { x: Record { x: ... Long } }`.
-    /// Each record nesting costs 3 prost recursion levels (`Record` + `AttributeType` + `Type`).
-    fn make_deep_record_type(n: usize) -> crate::proto::models::Type {
-        use crate::proto::models::{self, r#type};
-        let mut ty = models::Type {
-            data: Some(r#type::Data::Prim(r#type::Prim::Long.into())),
-        };
-        for _ in 0..n {
-            ty = models::Type {
-                data: Some(r#type::Data::Record(r#type::Record {
-                    attrs: std::collections::HashMap::from([(
-                        "x".to_string(),
-                        models::AttributeType {
-                            attr_type: Some(ty),
-                            is_required: true,
-                        },
-                    )]),
-                })),
-            };
-        }
-        ty
-    }
-
-    #[test]
-    fn encode_schema_deep_set_type_fails() {
-        use crate::proto::traits::{EncodeCheck, EncodeError, MAX_ENCODE_DEPTH};
-        // Set nesting: each level costs 1 prost level. Need > MAX_ENCODE_DEPTH levels.
-        let deep_type = make_deep_set_type(MAX_ENCODE_DEPTH + 1);
-        let schema = crate::proto::models::Schema {
-            entity_decls: vec![crate::proto::models::EntityDecl {
-                name: Some(crate::proto::models::Name {
-                    id: "Foo".to_string(),
-                    path: vec![],
-                }),
-                descendants: vec![],
-                attributes: std::collections::HashMap::from([(
-                    "attr".to_string(),
-                    crate::proto::models::AttributeType {
-                        attr_type: Some(deep_type),
-                        is_required: true,
-                    },
-                )]),
-                tags: None,
-                enum_choices: vec![],
-            }],
-            action_decls: vec![],
-        };
-        assert_matches!(
-            schema.check_for_encode(),
-            Err(EncodeError::MaxDepthExceeded)
-        );
-    }
-
-    #[test]
-    fn encode_schema_deep_record_type_fails() {
-        use crate::proto::traits::{EncodeCheck, EncodeError, MAX_ENCODE_DEPTH};
-        // Record nesting: each level costs 3 prost levels.
-        // Need (n * 3) > MAX_ENCODE_DEPTH from the starting depth inside validate_type_depth.
-        let levels = MAX_ENCODE_DEPTH / 3 + 1;
-        let deep_type = make_deep_record_type(levels);
-        let schema = crate::proto::models::Schema {
-            entity_decls: vec![crate::proto::models::EntityDecl {
-                name: Some(crate::proto::models::Name {
-                    id: "Bar".to_string(),
-                    path: vec![],
-                }),
-                descendants: vec![],
-                attributes: std::collections::HashMap::from([(
-                    "nested".to_string(),
-                    crate::proto::models::AttributeType {
-                        attr_type: Some(deep_type),
-                        is_required: true,
-                    },
-                )]),
-                tags: None,
-                enum_choices: vec![],
-            }],
-            action_decls: vec![],
-        };
-        assert_matches!(
-            schema.check_for_encode(),
-            Err(EncodeError::MaxDepthExceeded)
-        );
-    }
-
-    #[test]
-    fn encode_schema_shallow_type_succeeds() {
-        use crate::proto::traits::Protobuf;
-        // A simple schema should encode fine.
-        let (schema, _) =
-            crate::Schema::from_cedarschema_str("entity User { name: String, age: Long };")
-                .expect("parse schema");
-        assert!(schema.encode().is_ok());
+        Expression::decode(&buf[..]).expect("should decode within prost's recursion limit");
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -490,7 +490,7 @@ mod encode_test {
 
     /// Build a deeply nested `models::Expr` of the form `!(!(!(...true...)))` with `n` levels
     /// of `UnaryApp` nesting. The protobuf recursion cost is 1 (root `Expr`) + 2*n (each wrapper).
-    fn make_deep_expr(n: usize) -> crate::proto::models::Expr {
+    fn make_deep_unary_expr(n: usize) -> crate::proto::models::Expr {
         use crate::proto::models::{self, expr};
         let mut expr = models::Expr {
             expr_kind: Some(expr::ExprKind::Lit(expr::Literal {
@@ -508,6 +508,44 @@ mod encode_test {
         expr
     }
 
+    /// Build a deeply nested `models::Expr` of the form `{key:{key:{..}..}}` with `n` levels
+    /// of `Record` nesting. The protobuf recursion cost is 1 (root `Expr`) + 2*n (each wrapper).
+    fn make_deep_record_expr(n: usize) -> crate::proto::models::Expr {
+        use crate::proto::models::{self, expr};
+        let mut expr = models::Expr {
+            expr_kind: Some(expr::ExprKind::Lit(expr::Literal {
+                lit: Some(expr::literal::Lit::B(true)),
+            })),
+        };
+        for _ in 0..n {
+            let mut items = HashMap::new();
+            items.insert("k".into(), expr);
+            expr = models::Expr {
+                expr_kind: Some(expr::ExprKind::Record(expr::Record { items })),
+            };
+        }
+        expr
+    }
+
+    fn ok_at_depth(depth: usize, expect_ok: bool) {
+        use crate::proto::traits::{EncodeCheck, EncodeError};
+        let expr = make_deep_unary_expr(depth);
+        if expect_ok {
+            assert!(expr.check_for_encode().is_ok());
+        } else {
+            assert_matches!(expr.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        };
+        let expr_record = make_deep_record_expr(depth);
+        if expect_ok {
+            assert!(expr_record.check_for_encode().is_ok());
+        } else {
+            assert_matches!(
+                expr_record.check_for_encode(),
+                Err(EncodeError::MaxDepthExceeded)
+            );
+        };
+    }
+
     /// Maximum nesting levels that fit within `MAX_ENCODE_DEPTH`.
     /// Each `UnaryApp` nesting costs 2 prost levels; root `Expr` costs 1.
     /// So max nestings = (`MAX_ENCODE_DEPTH` - 1) / 2.
@@ -515,18 +553,12 @@ mod encode_test {
 
     #[test]
     fn encode_expression_within_depth_limit() {
-        use crate::proto::traits::EncodeCheck;
-        // Exactly at the limit should succeed
-        let expr = make_deep_expr(MAX_NESTING);
-        assert!(expr.check_for_encode().is_ok());
+        ok_at_depth(MAX_NESTING, true);
     }
 
     #[test]
     fn encode_expression_exceeds_depth_limit() {
-        use crate::proto::traits::{EncodeCheck, EncodeError};
-        // One past the limit should fail
-        let expr = make_deep_expr(MAX_NESTING + 1);
-        assert_matches!(expr.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        ok_at_depth(MAX_NESTING + 1, false);
     }
 
     #[test]
@@ -571,7 +603,7 @@ mod encode_test {
     fn encode_entities_with_deep_attr_fails() {
         use crate::proto::traits::{EncodeCheck, EncodeError};
         // Build an Entity model with an attribute that is too deep.
-        let deep_expr = make_deep_expr(MAX_NESTING + 1);
+        let deep_expr = make_deep_unary_expr(MAX_NESTING + 1);
         let entity = crate::proto::models::Entity {
             uid: Some(crate::proto::models::EntityUid {
                 ty: Some(crate::proto::models::Name {
@@ -602,7 +634,7 @@ mod encode_test {
     fn encode_at_limit_roundtrips_through_prost() {
         use crate::proto::traits::{EncodeCheck, Protobuf};
         // Verify that an expression exactly at the limit can actually be decoded by prost.
-        let expr = make_deep_expr(MAX_NESTING);
+        let expr = make_deep_unary_expr(MAX_NESTING);
         assert!(expr.check_for_encode().is_ok());
         // Encode via the API and decode to confirm prost doesn't reject it.
         use cedar_policy_core::ast;

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -592,15 +592,25 @@ mod encode_test {
 
     /// Build `n` levels of `like` wrapping.
     fn deep_like(n: usize) -> models::Expr {
+        use models::expr::{like, ExprKind, Like};
         // `like` takes an expr child, so we can nest: like(like(...))
         // But `like` returns bool... use if to re-wrap.
         // Simpler: just nest the expr child of Like.
         let mut e = lit_str("hello");
         for _ in 0..n {
             e = models::Expr {
-                expr_kind: Some(models::expr::ExprKind::Like(Box::new(models::expr::Like {
+                expr_kind: Some(ExprKind::Like(Box::new(Like {
                     expr: Some(Box::new(e)),
-                    pattern: vec![],
+                    pattern: vec![
+                        like::PatternElem {
+                            data: Some(like::pattern_elem::Data::Wildcard(
+                                like::pattern_elem::Wildcard::Unit.into(),
+                            )),
+                        },
+                        like::PatternElem {
+                            data: Some(like::pattern_elem::Data::C("x".to_string())),
+                        },
+                    ],
                 }))),
             };
         }
@@ -708,6 +718,46 @@ mod encode_test {
         }
     }
 
+    #[test]
+    fn depth_lit_euid_at_limit() {
+        // A lit_euid leaf adds 3 extra levels: (Literal(EntityUid(Name(..))))
+        // The leaf Expr is at depth 1 + 2*n, so the Name is at 1 + 2*n + 3.
+        // Max n where 1 + 2*n + 3 <= MAX_ENCODE_DEPTH: n = (MAX_ENCODE_DEPTH - 4) / 2
+        let max_euid_nesting = MAX_ENCODE_DEPTH / 2 - 2;
+
+        let mut ok = lit_euid("User", "alice");
+        for _ in 0..max_euid_nesting {
+            ok = not(ok);
+        }
+        assert_encode_check("lit_euid_ok", &ok, true, true);
+
+        let mut bad = lit_euid("User", "alice");
+        for _ in 0..=max_euid_nesting {
+            bad = not(bad);
+        }
+        assert_encode_check("lit_euid_bad", &bad, false, true);
+    }
+
+    #[test]
+    fn depth_ext_fn_name_without_args() {
+        // An ExtApp with no args but fn_name present should still be caught.
+        let target_depth = MAX_ENCODE_DEPTH - 1;
+        let nesting = (target_depth - 1) / 2;
+        let ext_no_args = models::Expr {
+            expr_kind: Some(models::expr::ExprKind::ExtApp(
+                models::expr::ExtensionFunctionApp {
+                    fn_name: Some(name("decimal")),
+                    args: vec![],
+                },
+            )),
+        };
+        let mut e = ext_no_args;
+        for _ in 0..nesting {
+            e = not(e);
+        }
+        assert_encode_check("ext_fn_name_no_args", &e, false, true);
+    }
+
     // ================================================================
     // Full API encode path tests
     // ================================================================
@@ -762,9 +812,9 @@ mod encode_test {
     fn encode_request_with_deep_context_fails() {
         let deep_expr = deep_unary(MAX_NESTING + 1);
         let req = models::Request {
-            principal: Some(entity_uid("User", "alice")),
-            action: Some(entity_uid("Action", "read")),
-            resource: Some(entity_uid("Doc", "readme")),
+            principal: Some(entity_uid(name("User"), "alice")),
+            action: Some(entity_uid(name("Action"), "read")),
+            resource: Some(entity_uid(qualified_name("Doc", &["MyApp"]), "readme")),
             context: [("deep".to_string(), deep_expr)].into_iter().collect(),
         };
         assert_matches!(req.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
@@ -773,9 +823,9 @@ mod encode_test {
     #[test]
     fn encode_request_shallow_context_succeeds() {
         let req = models::Request {
-            principal: Some(entity_uid("User", "alice")),
-            action: Some(entity_uid("Action", "read")),
-            resource: Some(entity_uid("Doc", "readme")),
+            principal: Some(entity_uid(name("User"), "alice")),
+            action: Some(entity_uid(name("Action"), "read")),
+            resource: Some(entity_uid(qualified_name("Doc", &["MyApp"]), "readme")),
             context: [("flag".to_string(), lit_bool(true))].into_iter().collect(),
         };
         assert!(req.check_for_encode().is_ok());
@@ -953,6 +1003,58 @@ mod encode_test {
         assert_matches!(bad.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
         // Just over the limit, we can still decode
         let bytes = prost::Message::encode_to_vec(&bad);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+    }
+
+    #[test]
+    fn encode_schema_entity_type_leaf_at_limit() {
+        // Entity/Ext leaf types contain a Name message at depth + 1.
+        // Through Schema → entity attributes: starting depth is 6.
+        // Set nesting of n gives the leaf Type at depth 6 + n.
+        // The Name inside Entity/Ext is at 6 + n + 1.
+        // Max n where 6 + n + 1 <= MAX_ENCODE_DEPTH: n = MAX_ENCODE_DEPTH - 7
+        let max_set_depth = MAX_ENCODE_DEPTH - 7;
+
+        // Build Set(Set(...Entity...)) with entity_type leaf
+        let mut ok_ty = entity_type("User");
+        for _ in 0..max_set_depth {
+            ok_ty = set_type(ok_ty);
+        }
+        let ok_schema = schema([entity_decl("Foo", [("a", required(ok_ty))])]);
+        assert!(ok_schema.check_for_encode().is_ok());
+
+        let mut bad_ty = entity_type("User");
+        for _ in 0..=max_set_depth {
+            bad_ty = set_type(bad_ty);
+        }
+        let bad_schema = schema([entity_decl("Foo", [("a", required(bad_ty))])]);
+        assert_matches!(
+            bad_schema.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+        // Just over the limit, prost can still decode
+        let bytes = prost::Message::encode_to_vec(&bad_schema);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+
+        // Same test with extension_type leaf
+        let mut ok_ext = extension_type("decimal");
+        for _ in 0..max_set_depth {
+            ok_ext = set_type(ok_ext);
+        }
+        let ok_schema = schema([entity_decl("Bar", [("b", required(ok_ext))])]);
+        assert!(ok_schema.check_for_encode().is_ok());
+
+        let mut bad_ext = extension_type("decimal");
+        for _ in 0..=max_set_depth {
+            bad_ext = set_type(bad_ext);
+        }
+        let bad_schema = schema([entity_decl("Bar", [("b", required(bad_ext))])]);
+        assert_matches!(
+            bad_schema.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+        // Just over the limit, prost can still decode
+        let bytes = prost::Message::encode_to_vec(&bad_schema);
         assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
     }
 

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -785,9 +785,11 @@ mod encode_test {
 
     #[test]
     fn encode_schema_set_type_limit() {
-        // Set nesting costs 1 prost level per level, starting at depth 2
-        // (AttributeType + Type). Exceeds when 2 + n > MAX_ENCODE_DEPTH.
-        let max_set_depth = MAX_ENCODE_DEPTH - 2;
+        // Set nesting costs 1 prost level per level. The starting depth for
+        // `check_type_depth_inner` when called through Schema → entity attributes is:
+        //   check_for_encode starts at init=1, Schema adds +3, check_type_depth adds +2 = 6.
+        // Exceeds when 6 + n > MAX_ENCODE_DEPTH.
+        let max_set_depth = MAX_ENCODE_DEPTH - 6;
         let ok_schema = schema([entity_decl(
             "Foo",
             [("a", required(deep_set_type(max_set_depth)))],
@@ -806,9 +808,11 @@ mod encode_test {
 
     #[test]
     fn encode_schema_record_type_limit() {
-        // Record nesting costs 3 prost levels per level, starting at depth 2.
-        // Exceeds when 2 + 3*n > MAX_ENCODE_DEPTH.
-        let max_rec_depth = (MAX_ENCODE_DEPTH - 2) / 3;
+        // Record nesting costs 3 prost levels per level. The starting depth for
+        // `check_type_depth_inner` through Schema → entity attributes is 6
+        // (init=1, Schema +3, check_type_depth +2).
+        // Exceeds when 6 + 3*n > MAX_ENCODE_DEPTH.
+        let max_rec_depth = (MAX_ENCODE_DEPTH - 6) / 3;
         let ok_schema = schema([entity_decl(
             "Bar",
             [("a", required(deep_record_type(max_rec_depth)))],

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -93,8 +93,8 @@ impl TryFrom<models::PolicySet> for api::PolicySet {
 macro_rules! standard_protobuf_impl {
     ( $api:ty, $model:ty) => {
         impl traits::Protobuf for $api {
-            fn encode(&self) -> Vec<u8> {
-                traits::encode_to_vec::<$model>(self)
+            fn encode(&self) -> Result<Vec<u8>, traits::EncodeError> {
+                traits::encode_to_vec::<$model, _>(self)
             }
             fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
                 traits::try_decode::<$model, _, _>(buf)
@@ -116,8 +116,8 @@ standard_protobuf_impl!(api::Request, models::Request);
 // nonstandard implementations of `traits::Protobuf`
 
 impl traits::Protobuf for api::Entities {
-    fn encode(&self) -> Vec<u8> {
-        traits::encode_to_vec::<models::Entities>(self)
+    fn encode(&self) -> Result<Vec<u8>, traits::EncodeError> {
+        traits::encode_to_vec::<models::Entities, _>(self)
     }
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
         // Uses the standard TryFrom path which computes TC via ComputeNow
@@ -138,8 +138,8 @@ impl traits::Protobuf for api::Entities {
 }
 
 impl traits::Protobuf for api::PolicySet {
-    fn encode(&self) -> Vec<u8> {
-        traits::encode_to_vec::<models::PolicySet>(self)
+    fn encode(&self) -> Result<Vec<u8>, traits::EncodeError> {
+        traits::encode_to_vec::<models::PolicySet, _>(self)
     }
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, traits::DecodeError> {
         traits::try_decode::<models::PolicySet, _, Self>(buf)
@@ -147,9 +147,7 @@ impl traits::Protobuf for api::PolicySet {
 }
 
 #[cfg(test)]
-mod test {
-    use crate::proto::traits::Protobuf;
-    use cool_asserts::assert_matches;
+mod roundtrip_test {
     use prost::Message as _;
     use std::{collections::HashMap, str::FromStr};
 
@@ -172,14 +170,6 @@ mod test {
     fn roundtrip_policies_text(text: &str) {
         let pset = crate::PolicySet::from_str(text).expect("Failed to parse policy set");
         roundtrip_policies(pset);
-    }
-
-    /// [`decode`] and [`decode_unchecked`] should produce the same data when they don't fail.
-    fn decode_eq_decode_unchecked<T: Protobuf + PartialEq>(x: T) {
-        let buf = x.encode();
-        let checked = T::decode(&buf[..]).expect("decode failed");
-        let unchecked = T::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
-        similar_asserts::assert_eq!(checked, unchecked);
     }
 
     #[test]
@@ -360,6 +350,22 @@ mod test {
             "#,
         );
     }
+}
+
+#[cfg(test)]
+mod decode_test {
+    use crate::proto::traits::Protobuf;
+    use cool_asserts::assert_matches;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    /// [`decode`] and [`decode_unchecked`] should produce the same data when they don't fail.
+    fn decode_eq_decode_unchecked<T: Protobuf + PartialEq>(x: T) {
+        let buf = x.encode().expect("encode failed");
+        let checked = T::decode(&buf[..]).expect("decode failed");
+        let unchecked = T::decode_unchecked(&buf[..]).expect("decode_unchecked failed");
+        similar_asserts::assert_eq!(checked, unchecked);
+    }
 
     /// Decoding arbitrary bytes must never panic — it should return `Err`.
     #[test]
@@ -407,9 +413,9 @@ mod test {
                 }),
                 eid: "x".to_string(),
             }),
-            attrs: Default::default(),
+            attrs: HashMap::new(),
             ancestors: vec![],
-            tags: Default::default(),
+            tags: HashMap::new(),
         };
         let buf = prost::Message::encode_to_vec(&model);
         assert_matches!(
@@ -473,5 +479,249 @@ mod test {
         )
         .expect("Failed to create request");
         decode_eq_decode_unchecked::<crate::Request>(request);
+    }
+}
+
+#[cfg(test)]
+mod encode_test {
+    use cool_asserts::assert_matches;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    /// Build a deeply nested `models::Expr` of the form `!(!(!(...true...)))` with `n` levels
+    /// of `UnaryApp` nesting. The protobuf recursion cost is 1 (root `Expr`) + 2*n (each wrapper).
+    fn make_deep_expr(n: usize) -> crate::proto::models::Expr {
+        use crate::proto::models::{self, expr};
+        let mut expr = models::Expr {
+            expr_kind: Some(expr::ExprKind::Lit(expr::Literal {
+                lit: Some(expr::literal::Lit::B(true)),
+            })),
+        };
+        for _ in 0..n {
+            expr = models::Expr {
+                expr_kind: Some(expr::ExprKind::UApp(Box::new(expr::UnaryApp {
+                    op: expr::unary_app::Op::Not.into(),
+                    expr: Some(Box::new(expr)),
+                }))),
+            };
+        }
+        expr
+    }
+
+    /// Maximum nesting levels that fit within `MAX_ENCODE_DEPTH`.
+    /// Each `UnaryApp` nesting costs 2 prost levels; root `Expr` costs 1.
+    /// So max nestings = (`MAX_ENCODE_DEPTH` - 1) / 2.
+    const MAX_NESTING: usize = (crate::proto::traits::MAX_ENCODE_DEPTH - 1) / 2;
+
+    #[test]
+    fn encode_expression_within_depth_limit() {
+        use crate::proto::traits::EncodeCheck;
+        // Exactly at the limit should succeed
+        let expr = make_deep_expr(MAX_NESTING);
+        assert!(expr.check_for_encode().is_ok());
+    }
+
+    #[test]
+    fn encode_expression_exceeds_depth_limit() {
+        use crate::proto::traits::{EncodeCheck, EncodeError};
+        // One past the limit should fail
+        let expr = make_deep_expr(MAX_NESTING + 1);
+        assert_matches!(expr.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_expression_api_returns_error_on_deep_expr() {
+        use crate::proto::traits::{EncodeError, Protobuf};
+        // Build a deep AST expression and test the full encode path via the API type.
+        use cedar_policy_core::ast;
+        let mut e = ast::Expr::var(ast::Var::Principal);
+        for _ in 0..=MAX_NESTING {
+            e = ast::Expr::not(e);
+        }
+        let expression = crate::Expression(e);
+        assert_matches!(expression.encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_policyset_with_deep_condition_fails() {
+        use crate::proto::traits::{EncodeError, Protobuf};
+        // Build a policy with an excessively deep when-condition.
+        use cedar_policy_core::ast;
+        let mut e = ast::Expr::val(true);
+        for _ in 0..=MAX_NESTING {
+            e = ast::Expr::not(e);
+        }
+        let template = ast::Template::new(
+            ast::PolicyID::from_string("deep_policy"),
+            None,
+            ast::Annotations::new(),
+            ast::Effect::Permit,
+            ast::PrincipalConstraint::any(),
+            ast::ActionConstraint::any(),
+            ast::ResourceConstraint::any(),
+            Some(e),
+        );
+        let mut pset = ast::PolicySet::new();
+        pset.add_template(template).expect("add template");
+        let api_pset = crate::PolicySet::from_ast(pset);
+        assert_matches!(api_pset.encode(), Err(EncodeError::MaxDepthExceeded));
+    }
+
+    #[test]
+    fn encode_entities_with_deep_attr_fails() {
+        use crate::proto::traits::{EncodeCheck, EncodeError};
+        // Build an Entity model with an attribute that is too deep.
+        let deep_expr = make_deep_expr(MAX_NESTING + 1);
+        let entity = crate::proto::models::Entity {
+            uid: Some(crate::proto::models::EntityUid {
+                ty: Some(crate::proto::models::Name {
+                    id: "User".to_string(),
+                    path: vec![],
+                }),
+                eid: "alice".to_string(),
+            }),
+            attrs: HashMap::from([("deep_attr".to_string(), deep_expr)]),
+            ancestors: vec![],
+            tags: HashMap::new(),
+        };
+        assert_matches!(
+            entity.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn encode_shallow_expression_succeeds() {
+        use crate::proto::traits::Protobuf;
+        // A simple expression should encode fine.
+        let expression = crate::Expression::from_str("1 + 2").expect("parse");
+        assert!(expression.encode().is_ok());
+    }
+
+    #[test]
+    fn encode_at_limit_roundtrips_through_prost() {
+        use crate::proto::traits::{EncodeCheck, Protobuf};
+        // Verify that an expression exactly at the limit can actually be decoded by prost.
+        let expr = make_deep_expr(MAX_NESTING);
+        assert!(expr.check_for_encode().is_ok());
+        // Encode via the API and decode to confirm prost doesn't reject it.
+        use cedar_policy_core::ast;
+        let mut e = ast::Expr::val(true);
+        for _ in 0..MAX_NESTING {
+            e = ast::Expr::not(e);
+        }
+        let expression = crate::Expression(e);
+        let buf = expression.encode().expect("should encode within limit");
+        crate::Expression::decode(&buf[..]).expect("should decode within prost's recursion limit");
+    }
+
+    /// Build a deeply nested `models::Type` of the form `Set(Set(Set(...Long...)))`.
+    /// Each Set nesting costs 1 prost recursion level.
+    fn make_deep_set_type(n: usize) -> crate::proto::models::Type {
+        use crate::proto::models::{self, r#type};
+        let mut ty = models::Type {
+            data: Some(r#type::Data::Prim(r#type::Prim::Long.into())),
+        };
+        for _ in 0..n {
+            ty = models::Type {
+                data: Some(r#type::Data::SetElem(Box::new(ty))),
+            };
+        }
+        ty
+    }
+
+    /// Build a deeply nested record type: `Record { x: Record { x: ... Long } }`.
+    /// Each record nesting costs 3 prost recursion levels (`Record` + `AttributeType` + `Type`).
+    fn make_deep_record_type(n: usize) -> crate::proto::models::Type {
+        use crate::proto::models::{self, r#type};
+        let mut ty = models::Type {
+            data: Some(r#type::Data::Prim(r#type::Prim::Long.into())),
+        };
+        for _ in 0..n {
+            ty = models::Type {
+                data: Some(r#type::Data::Record(r#type::Record {
+                    attrs: std::collections::HashMap::from([(
+                        "x".to_string(),
+                        models::AttributeType {
+                            attr_type: Some(ty),
+                            is_required: true,
+                        },
+                    )]),
+                })),
+            };
+        }
+        ty
+    }
+
+    #[test]
+    fn encode_schema_deep_set_type_fails() {
+        use crate::proto::traits::{EncodeCheck, EncodeError, MAX_ENCODE_DEPTH};
+        // Set nesting: each level costs 1 prost level. Need > MAX_ENCODE_DEPTH levels.
+        let deep_type = make_deep_set_type(MAX_ENCODE_DEPTH + 1);
+        let schema = crate::proto::models::Schema {
+            entity_decls: vec![crate::proto::models::EntityDecl {
+                name: Some(crate::proto::models::Name {
+                    id: "Foo".to_string(),
+                    path: vec![],
+                }),
+                descendants: vec![],
+                attributes: std::collections::HashMap::from([(
+                    "attr".to_string(),
+                    crate::proto::models::AttributeType {
+                        attr_type: Some(deep_type),
+                        is_required: true,
+                    },
+                )]),
+                tags: None,
+                enum_choices: vec![],
+            }],
+            action_decls: vec![],
+        };
+        assert_matches!(
+            schema.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn encode_schema_deep_record_type_fails() {
+        use crate::proto::traits::{EncodeCheck, EncodeError, MAX_ENCODE_DEPTH};
+        // Record nesting: each level costs 3 prost levels.
+        // Need (n * 3) > MAX_ENCODE_DEPTH from the starting depth inside validate_type_depth.
+        let levels = MAX_ENCODE_DEPTH / 3 + 1;
+        let deep_type = make_deep_record_type(levels);
+        let schema = crate::proto::models::Schema {
+            entity_decls: vec![crate::proto::models::EntityDecl {
+                name: Some(crate::proto::models::Name {
+                    id: "Bar".to_string(),
+                    path: vec![],
+                }),
+                descendants: vec![],
+                attributes: std::collections::HashMap::from([(
+                    "nested".to_string(),
+                    crate::proto::models::AttributeType {
+                        attr_type: Some(deep_type),
+                        is_required: true,
+                    },
+                )]),
+                tags: None,
+                enum_choices: vec![],
+            }],
+            action_decls: vec![],
+        };
+        assert_matches!(
+            schema.check_for_encode(),
+            Err(EncodeError::MaxDepthExceeded)
+        );
+    }
+
+    #[test]
+    fn encode_schema_shallow_type_succeeds() {
+        use crate::proto::traits::Protobuf;
+        // A simple schema should encode fine.
+        let (schema, _) =
+            crate::Schema::from_cedarschema_str("entity User { name: String, age: Long };")
+                .expect("parse schema");
+        assert!(schema.encode().is_ok());
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -642,8 +642,16 @@ mod encode_test {
     /// Assert that the given expression passes or fails the encode check.
     /// When `expect_ok`, also verifies the encode→decode roundtrip succeeds
     /// (i.e., prost can decode what we encoded).
+    /// When `expect_still_decodes` and `expect_ok` is false, this checks that
+    /// `check_for_encode` returns an [`EncodeError::MaxDepthExceeded`] but
+    /// the encodeing then decoding still succeeds.
     #[track_caller]
-    fn assert_encode_check(name: &str, expr: &models::Expr, expect_ok: bool) {
+    fn assert_encode_check(
+        name: &str,
+        expr: &models::Expr,
+        expect_ok: bool,
+        expect_still_decodes: bool,
+    ) {
         if expect_ok {
             assert!(
                 expr.check_for_encode().is_ok(),
@@ -661,6 +669,14 @@ mod encode_test {
                 Err(EncodeError::MaxDepthExceeded),
                 "{name} did not error with MaxDepthExceeded"
             );
+            // We still expect this to encode-decode
+            if expect_still_decodes {
+                let bytes = prost::Message::encode_to_vec(expr);
+                assert!(
+                    <models::Expr as prost::Message>::decode(&bytes[..]).is_ok(),
+                    "{name}: decoding failed when MaxDepthExceeded but expected to still decode",
+                );
+            }
         }
     }
 
@@ -682,9 +698,13 @@ mod encode_test {
         ];
         for (name, builder, limit) in builders {
             let ok = builder(*limit);
-            assert_encode_check(name, &ok, true);
+            assert_encode_check(name, &ok, true, true); // check succeeds, decodes
             let bad = builder(*limit + 1);
-            assert_encode_check(name, &bad, false);
+            assert_encode_check(name, &bad, false, true); // check fails, still decodes
+            let bad = builder(*limit + 2);
+            assert_encode_check(name, &bad, false, true); // check fails, still decodes
+            let bad = builder(*limit + 8);
+            assert_encode_check(name, &bad, false, false); // check fails, fails decode
         }
     }
 
@@ -804,15 +824,19 @@ mod encode_test {
             bad_schema.check_for_encode(),
             Err(EncodeError::MaxDepthExceeded)
         );
+        // Just over the limit, prost can still encode+decode (our limit is conservative)
+        let bytes = prost::Message::encode_to_vec(&bad_schema);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
     }
 
     #[test]
     fn encode_schema_record_type_limit() {
-        // Record nesting costs 3 prost levels per level. The starting depth for
-        // `check_type_depth_inner` through Schema → entity attributes is 6
+        // Record nesting costs 4 prost levels per level (Record msg + map entry +
+        // AttributeType + Type). The starting depth for `check_type_depth_inner`
+        // through Schema → entity attributes is 6
         // (init=1, Schema +3, check_type_depth +2).
-        // Exceeds when 6 + 3*n > MAX_ENCODE_DEPTH.
-        let max_rec_depth = (MAX_ENCODE_DEPTH - 6) / 3;
+        // Exceeds when 6 + 4*n > MAX_ENCODE_DEPTH.
+        let max_rec_depth = (MAX_ENCODE_DEPTH - 6) / 4;
         let ok_schema = schema([entity_decl(
             "Bar",
             [("a", required(deep_record_type(max_rec_depth)))],
@@ -827,29 +851,148 @@ mod encode_test {
             bad_schema.check_for_encode(),
             Err(EncodeError::MaxDepthExceeded)
         );
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&bad_schema);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
     }
 
     #[test]
-    fn encode_schema_tag_type_deep_fails() {
-        // Tags start at depth 1 (no AttributeType wrapper), so Set nesting
-        // exceeds at 1 + n > MAX_ENCODE_DEPTH → n > MAX_ENCODE_DEPTH - 1.
-        let bad_tag = deep_set_type(MAX_ENCODE_DEPTH);
-        let decl = entity_decl_full("Foo", [], [], Some(bad_tag));
-        let s = schema([decl]);
-        assert_matches!(s.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+    fn encode_schema_tag_set_type_limit() {
+        // Tags path: init=1, Schema impl passes init+3=4 to check_type_depth_inner.
+        // So Set nesting exceeds when 4 + n > MAX_ENCODE_DEPTH.
+        let max_tag_set = MAX_ENCODE_DEPTH - 4;
+        let ok_decl = entity_decl_full("Foo", [], [], Some(deep_set_type(max_tag_set)));
+        let ok = schema([ok_decl]);
+        assert!(ok.check_for_encode().is_ok());
+
+        let bad_decl = entity_decl_full("Foo", [], [], Some(deep_set_type(max_tag_set + 1)));
+        let bad = schema([bad_decl]);
+        assert_matches!(bad.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&bad);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
     }
 
     #[test]
-    fn encode_schema_action_context_deep_fails() {
-        let deep_ty = deep_set_type(MAX_ENCODE_DEPTH);
-        let action = action_decl(
+    fn encode_schema_tag_record_type_limit() {
+        // Tags path starts at depth 4; record nesting costs 4 per level.
+        // Exceeds when 4 + 4*n > MAX_ENCODE_DEPTH.
+        let max_tag_rec = (MAX_ENCODE_DEPTH - 4) / 4;
+        let ok_decl = entity_decl_full("Foo", [], [], Some(deep_record_type(max_tag_rec)));
+        let ok = schema([ok_decl]);
+        assert!(ok.check_for_encode().is_ok());
+
+        let bad_decl = entity_decl_full("Foo", [], [], Some(deep_record_type(max_tag_rec + 1)));
+        let bad = schema([bad_decl]);
+        assert_matches!(bad.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&bad);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+    }
+
+    #[test]
+    fn encode_schema_action_context_set_type_limit() {
+        // Action context path: init=1, Schema impl passes init+3=4 to check_type_depth,
+        // which adds +2 = 6 before entering check_type_depth_inner (same as entity attrs).
+        // Exceeds when 6 + n > MAX_ENCODE_DEPTH.
+        let max_ctx_set = MAX_ENCODE_DEPTH - 6;
+        let ok_action = action_decl(
             ("Action", "read"),
             ["User"],
             ["Doc"],
-            [("deep_ctx", required(deep_ty))],
+            [("ctx", required(deep_set_type(max_ctx_set)))],
         );
-        let s = schema_full([], [action]);
+        let ok = schema_full(
+            [entity_decl("User", []), entity_decl("Doc", [])],
+            [ok_action],
+        );
+        assert!(ok.check_for_encode().is_ok());
+
+        let bad_action = action_decl(
+            ("Action", "read"),
+            ["User"],
+            ["Doc"],
+            [("ctx", required(deep_set_type(max_ctx_set + 1)))],
+        );
+        let bad = schema_full(
+            [entity_decl("User", []), entity_decl("Doc", [])],
+            [bad_action],
+        );
+        assert_matches!(bad.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&bad);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+    }
+
+    #[test]
+    fn encode_schema_action_context_record_type_limit() {
+        // Action context starts at depth 6; record costs 4 per level.
+        let max_ctx_rec = (MAX_ENCODE_DEPTH - 6) / 4;
+        let ok_action = action_decl(
+            ("Action", "write"),
+            ["User"],
+            ["Doc"],
+            [("ctx", required(deep_record_type(max_ctx_rec)))],
+        );
+        let ok = schema_full(
+            [entity_decl("User", []), entity_decl("Doc", [])],
+            [ok_action],
+        );
+        assert!(ok.check_for_encode().is_ok());
+
+        let bad_action = action_decl(
+            ("Action", "write"),
+            ["User"],
+            ["Doc"],
+            [("ctx", required(deep_record_type(max_ctx_rec + 1)))],
+        );
+        let bad = schema_full(
+            [entity_decl("User", []), entity_decl("Doc", [])],
+            [bad_action],
+        );
+        assert_matches!(bad.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&bad);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+    }
+
+    #[test]
+    fn encode_schema_multiple_entities_one_deep_fails() {
+        // Only one entity has a deeply nested type; the check should still catch it.
+        let max_set_depth = MAX_ENCODE_DEPTH - 6;
+        let s = schema([
+            entity_decl("Shallow", [("x", required(long_type()))]),
+            entity_decl("Deep", [("a", required(deep_set_type(max_set_depth + 1)))]),
+        ]);
         assert_matches!(s.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&s);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
+    }
+
+    #[test]
+    fn encode_schema_multiple_actions_one_deep_fails() {
+        let max_ctx_set = MAX_ENCODE_DEPTH - 6;
+        let shallow_action = action_decl(
+            ("Action", "read"),
+            ["User"],
+            ["Doc"],
+            [("flag", required(bool_type()))],
+        );
+        let deep_action = action_decl(
+            ("Action", "write"),
+            ["User"],
+            ["Doc"],
+            [("ctx", required(deep_set_type(max_ctx_set + 1)))],
+        );
+        let s = schema_full(
+            [entity_decl("User", []), entity_decl("Doc", [])],
+            [shallow_action, deep_action],
+        );
+        assert_matches!(s.check_for_encode(), Err(EncodeError::MaxDepthExceeded));
+        // Just over the limit, we can still decode
+        let bytes = prost::Message::encode_to_vec(&s);
+        assert!(<models::Schema as prost::Message>::decode(&bytes[..]).is_ok());
     }
 
     #[test]
@@ -858,6 +1001,19 @@ mod encode_test {
             crate::Schema::from_cedarschema_str("entity User { name: String, age: Long };")
                 .expect("parse schema");
         assert!(schema.encode().is_ok());
+    }
+
+    #[test]
+    fn encode_schema_mixed_nesting_succeeds() {
+        let nested_type = record_type([
+            ("inner_set", required(set_type(set_type(long_type())))),
+            (
+                "inner_rec",
+                optional(record_type([("x", required(string_type()))])),
+            ),
+        ]);
+        let s = schema([entity_decl("Complex", [("data", required(nested_type))])]);
+        assert!(s.check_for_encode().is_ok());
     }
 
     // ================================================================

--- a/cedar-policy/src/proto/test_utils.rs
+++ b/cedar-policy/src/proto/test_utils.rs
@@ -56,9 +56,9 @@ pub fn qualified_name(id: &str, path: &[&str]) -> models::Name {
 /// ```ignore
 /// entity_uid("User", "alice") => EntityUid { ty: Name("User"), eid: "alice" }
 /// ```
-pub fn entity_uid(ty: &str, eid: &str) -> models::EntityUid {
+pub fn entity_uid(ty: models::Name, eid: &str) -> models::EntityUid {
     models::EntityUid {
-        ty: Some(name(ty)),
+        ty: Some(ty),
         eid: eid.to_string(),
     }
 }
@@ -181,7 +181,7 @@ pub fn lit_str(s: &str) -> models::Expr {
 pub fn lit_euid(ty: &str, eid: &str) -> models::Expr {
     models::Expr {
         expr_kind: Some(models::expr::ExprKind::Lit(models::expr::Literal {
-            lit: Some(models::expr::literal::Lit::Euid(entity_uid(ty, eid))),
+            lit: Some(models::expr::literal::Lit::Euid(entity_uid(name(ty), eid))),
         })),
     }
 }
@@ -199,18 +199,6 @@ pub fn not(expr: models::Expr) -> models::Expr {
         expr_kind: Some(models::expr::ExprKind::UApp(Box::new(
             models::expr::UnaryApp {
                 op: models::expr::unary_app::Op::Not.into(),
-                expr: Some(Box::new(expr)),
-            },
-        ))),
-    }
-}
-
-/// Unary negation: `-expr`.
-pub fn neg(expr: models::Expr) -> models::Expr {
-    models::Expr {
-        expr_kind: Some(models::expr::ExprKind::UApp(Box::new(
-            models::expr::UnaryApp {
-                op: models::expr::unary_app::Op::Neg.into(),
                 expr: Some(Box::new(expr)),
             },
         ))),
@@ -310,7 +298,7 @@ pub fn entity(
     attrs: impl IntoIterator<Item = (&'static str, models::Expr)>,
 ) -> models::Entity {
     models::Entity {
-        uid: Some(entity_uid(ty, eid)),
+        uid: Some(entity_uid(name(ty), eid)),
         attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         ancestors: vec![],
         tags: HashMap::new(),
@@ -326,7 +314,7 @@ pub fn entity_full(
     tags: impl IntoIterator<Item = (&'static str, models::Expr)>,
 ) -> models::Entity {
     models::Entity {
-        uid: Some(entity_uid(ty, eid)),
+        uid: Some(entity_uid(name(ty), eid)),
         attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         ancestors: ancestors.into_iter().collect(),
         tags: tags.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
@@ -390,7 +378,7 @@ pub fn action_decl(
     context: impl IntoIterator<Item = (&'static str, models::AttributeType)>,
 ) -> models::ActionDecl {
     models::ActionDecl {
-        name: Some(entity_uid(action_entity.0, action_entity.1)),
+        name: Some(entity_uid(name(action_entity.0), action_entity.1)),
         descendants: vec![],
         principal_types: principal_types.into_iter().map(name).collect(),
         resource_types: resource_types.into_iter().map(name).collect(),

--- a/cedar-policy/src/proto/test_utils.rs
+++ b/cedar-policy/src/proto/test_utils.rs
@@ -1,0 +1,402 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Shared test helpers for constructing protobuf model values.
+//!
+//! These helpers reduce boilerplate when writing tests that operate on
+//! `models::*` types directly.
+
+use super::models;
+use std::collections::HashMap;
+
+// ====================================================================
+// Name / EntityUid helpers
+// ====================================================================
+
+/// Create a `models::Name` with no namespace path.
+///
+/// ```ignore
+/// name("User") => Name { id: "User", path: [] }
+/// ```
+pub fn name(id: &str) -> models::Name {
+    models::Name {
+        id: id.to_string(),
+        path: vec![],
+    }
+}
+
+/// Create a `models::Name` with a namespace path.
+///
+/// ```ignore
+/// qualified_name("User", &["MyApp", "Types"])
+///   => Name { id: "User", path: ["MyApp", "Types"] }
+/// ```
+pub fn qualified_name(id: &str, path: &[&str]) -> models::Name {
+    models::Name {
+        id: id.to_string(),
+        path: path.iter().map(|s| (*s).to_string()).collect(),
+    }
+}
+
+/// Create a `models::EntityUid`.
+///
+/// ```ignore
+/// entity_uid("User", "alice") => EntityUid { ty: Name("User"), eid: "alice" }
+/// ```
+pub fn entity_uid(ty: &str, eid: &str) -> models::EntityUid {
+    models::EntityUid {
+        ty: Some(name(ty)),
+        eid: eid.to_string(),
+    }
+}
+
+// ====================================================================
+// Type helpers
+// ====================================================================
+
+/// Primitive `Bool` type.
+pub fn bool_type() -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Prim(
+            models::r#type::Prim::Bool.into(),
+        )),
+    }
+}
+
+/// Primitive `Long` type.
+pub fn long_type() -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Prim(
+            models::r#type::Prim::Long.into(),
+        )),
+    }
+}
+
+/// Primitive `String` type.
+pub fn string_type() -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Prim(
+            models::r#type::Prim::String.into(),
+        )),
+    }
+}
+
+/// `Set<element>` type.
+pub fn set_type(element: models::Type) -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::SetElem(Box::new(element))),
+    }
+}
+
+/// Entity reference type.
+pub fn entity_type(ty: &str) -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Entity(name(ty))),
+    }
+}
+
+/// Extension type (e.g., `"decimal"`, `"ipaddr"`).
+pub fn extension_type(ext_name: &str) -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Ext(name(ext_name))),
+    }
+}
+
+/// Record type with the given attributes.
+///
+/// ```ignore
+/// record_type([("age", required(long_type())), ("name", optional(string_type()))])
+/// ```
+pub fn record_type(
+    attrs: impl IntoIterator<Item = (&'static str, models::AttributeType)>,
+) -> models::Type {
+    models::Type {
+        data: Some(models::r#type::Data::Record(models::r#type::Record {
+            attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        })),
+    }
+}
+
+/// A required attribute of the given type.
+pub fn required(ty: models::Type) -> models::AttributeType {
+    models::AttributeType {
+        attr_type: Some(ty),
+        is_required: true,
+    }
+}
+
+/// An optional attribute of the given type.
+pub fn optional(ty: models::Type) -> models::AttributeType {
+    models::AttributeType {
+        attr_type: Some(ty),
+        is_required: false,
+    }
+}
+
+// ====================================================================
+// Expr helpers
+// ====================================================================
+
+/// Boolean literal expression.
+pub fn lit_bool(b: bool) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Lit(models::expr::Literal {
+            lit: Some(models::expr::literal::Lit::B(b)),
+        })),
+    }
+}
+
+/// Integer literal expression.
+pub fn lit_long(i: i64) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Lit(models::expr::Literal {
+            lit: Some(models::expr::literal::Lit::I(i)),
+        })),
+    }
+}
+
+/// String literal expression.
+pub fn lit_str(s: &str) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Lit(models::expr::Literal {
+            lit: Some(models::expr::literal::Lit::S(s.to_string())),
+        })),
+    }
+}
+
+/// Entity UID literal expression.
+pub fn lit_euid(ty: &str, eid: &str) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Lit(models::expr::Literal {
+            lit: Some(models::expr::literal::Lit::Euid(entity_uid(ty, eid))),
+        })),
+    }
+}
+
+/// Variable expression (`principal`, `action`, `resource`, `context`).
+pub fn var(v: models::expr::Var) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Var(v.into())),
+    }
+}
+
+/// Unary not: `!expr`.
+pub fn not(expr: models::Expr) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::UApp(Box::new(
+            models::expr::UnaryApp {
+                op: models::expr::unary_app::Op::Not.into(),
+                expr: Some(Box::new(expr)),
+            },
+        ))),
+    }
+}
+
+/// Unary negation: `-expr`.
+pub fn neg(expr: models::Expr) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::UApp(Box::new(
+            models::expr::UnaryApp {
+                op: models::expr::unary_app::Op::Neg.into(),
+                expr: Some(Box::new(expr)),
+            },
+        ))),
+    }
+}
+
+/// Binary operation.
+pub fn binary(
+    op: models::expr::binary_app::Op,
+    left: models::Expr,
+    right: models::Expr,
+) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::BApp(Box::new(
+            models::expr::BinaryApp {
+                op: op.into(),
+                left: Some(Box::new(left)),
+                right: Some(Box::new(right)),
+            },
+        ))),
+    }
+}
+
+/// If-then-else expression.
+pub fn if_then_else(test: models::Expr, then: models::Expr, els: models::Expr) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::If(Box::new(models::expr::If {
+            test_expr: Some(Box::new(test)),
+            then_expr: Some(Box::new(then)),
+            else_expr: Some(Box::new(els)),
+        }))),
+    }
+}
+
+/// Attribute access: `expr.attr`.
+pub fn get_attr(expr: models::Expr, attr: &str) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::GetAttr(Box::new(
+            models::expr::GetAttr {
+                expr: Some(Box::new(expr)),
+                attr: attr.to_string(),
+            },
+        ))),
+    }
+}
+
+/// Has-attribute test: `expr has attr`.
+pub fn has_attr(expr: models::Expr, attr: &str) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::HasAttr(Box::new(
+            models::expr::HasAttr {
+                expr: Some(Box::new(expr)),
+                attr: attr.to_string(),
+            },
+        ))),
+    }
+}
+
+/// Set literal: `[elems...]`.
+pub fn set(elems: impl IntoIterator<Item = models::Expr>) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Set(models::expr::Set {
+            elements: elems.into_iter().collect(),
+        })),
+    }
+}
+
+/// Record literal: `{ key: value, ... }`.
+pub fn record(items: impl IntoIterator<Item = (&'static str, models::Expr)>) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::Record(models::expr::Record {
+            items: items.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        })),
+    }
+}
+
+/// Extension function call.
+pub fn ext_call(fn_name: &str, args: impl IntoIterator<Item = models::Expr>) -> models::Expr {
+    models::Expr {
+        expr_kind: Some(models::expr::ExprKind::ExtApp(
+            models::expr::ExtensionFunctionApp {
+                fn_name: Some(name(fn_name)),
+                args: args.into_iter().collect(),
+            },
+        )),
+    }
+}
+
+// ====================================================================
+// Entity / EntityDecl / Schema helpers
+// ====================================================================
+
+/// Create a `models::Entity` with the given uid, attributes, and no ancestors/tags.
+pub fn entity(
+    ty: &str,
+    eid: &str,
+    attrs: impl IntoIterator<Item = (&'static str, models::Expr)>,
+) -> models::Entity {
+    models::Entity {
+        uid: Some(entity_uid(ty, eid)),
+        attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        ancestors: vec![],
+        tags: HashMap::new(),
+    }
+}
+
+/// Create a `models::Entity` with attributes, ancestors, and tags.
+pub fn entity_full(
+    ty: &str,
+    eid: &str,
+    attrs: impl IntoIterator<Item = (&'static str, models::Expr)>,
+    ancestors: impl IntoIterator<Item = models::EntityUid>,
+    tags: impl IntoIterator<Item = (&'static str, models::Expr)>,
+) -> models::Entity {
+    models::Entity {
+        uid: Some(entity_uid(ty, eid)),
+        attrs: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        ancestors: ancestors.into_iter().collect(),
+        tags: tags.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+    }
+}
+
+/// Create a simple `models::EntityDecl` with the given name and attributes.
+pub fn entity_decl(
+    ty: &str,
+    attrs: impl IntoIterator<Item = (&'static str, models::AttributeType)>,
+) -> models::EntityDecl {
+    models::EntityDecl {
+        name: Some(name(ty)),
+        descendants: vec![],
+        attributes: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        tags: None,
+        enum_choices: vec![],
+    }
+}
+
+/// Create an `models::EntityDecl` with all fields.
+pub fn entity_decl_full(
+    ty: &str,
+    descendants: impl IntoIterator<Item = &'static str>,
+    attrs: impl IntoIterator<Item = (&'static str, models::AttributeType)>,
+    tags: Option<models::Type>,
+) -> models::EntityDecl {
+    models::EntityDecl {
+        name: Some(name(ty)),
+        descendants: descendants.into_iter().map(name).collect(),
+        attributes: attrs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+        tags,
+        enum_choices: vec![],
+    }
+}
+
+/// Create a `models::Schema` with entity declarations only.
+pub fn schema(entity_decls: impl IntoIterator<Item = models::EntityDecl>) -> models::Schema {
+    models::Schema {
+        entity_decls: entity_decls.into_iter().collect(),
+        action_decls: vec![],
+    }
+}
+
+/// Create a `models::Schema` with both entity and action declarations.
+pub fn schema_full(
+    entity_decls: impl IntoIterator<Item = models::EntityDecl>,
+    action_decls: impl IntoIterator<Item = models::ActionDecl>,
+) -> models::Schema {
+    models::Schema {
+        entity_decls: entity_decls.into_iter().collect(),
+        action_decls: action_decls.into_iter().collect(),
+    }
+}
+
+/// Create a `models::ActionDecl`.
+pub fn action_decl(
+    action_entity: (&str, &str),
+    principal_types: impl IntoIterator<Item = &'static str>,
+    resource_types: impl IntoIterator<Item = &'static str>,
+    context: impl IntoIterator<Item = (&'static str, models::AttributeType)>,
+) -> models::ActionDecl {
+    models::ActionDecl {
+        name: Some(entity_uid(action_entity.0, action_entity.1)),
+        descendants: vec![],
+        principal_types: principal_types.into_iter().map(name).collect(),
+        resource_types: resource_types.into_iter().map(name).collect(),
+        context: context
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect(),
+    }
+}

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -48,6 +48,46 @@ impl From<ProtobufConversionError> for DecodeError {
     }
 }
 
+/// Error type for protobuf encoding failures
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EncodeError {
+    /// The input data contains too many recursion levels to be encoded
+    #[error("data structure depth exceeds maximum encodable depth of {MAX_ENCODE_DEPTH}")]
+    MaxDepthExceeded,
+    /// The protobuf message could not be encoded (e.g., buffer too small)
+    #[error(transparent)]
+    Proto(#[from] prost::EncodeError),
+}
+
+/// Maximum allowed protobuf recursion depth for encoding.
+///
+/// Prost's decoder has a hardcoded recursion limit of 100, where each nested
+/// message entry counts as one level. We use this limit when calculating the
+/// depth of a `prost::Message` (i.e. the `models::...`), not the depth of
+/// syntax tree (e.g. type or expression).
+/// Typically, the depth of a model is twice the one of the internal representation's
+/// tree.
+///
+/// We set this to 90 to leave a small margin (10 levels) for outer wrappers
+/// like `TemplateBody` or `Entity` that contain an `Expr` field.
+pub const MAX_ENCODE_DEPTH: usize = 90;
+
+/// A trait for protobuf model types that require validation before encoding.
+///
+/// Model types implement this to perform structural checks (such as depth limits)
+/// before the protobuf encoding step. Types that need no pre-encode validation
+/// implement this as a no-op returning `Ok(())`.
+pub trait EncodeCheck {
+    /// Validate that this model is safe to encode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError`] if the model violates encoding constraints
+    /// (e.g., exceeds the maximum nesting depth).
+    fn check_for_encode(&self) -> Result<(), EncodeError>;
+}
+
 /// A trait for objects that have a `try_validate` method returning `self` if the object is
 /// valid.
 pub trait TryValidate: Sized {
@@ -79,7 +119,12 @@ mod private {
 /// Trait allowing serializing and deserializing in protobuf format.
 pub trait Protobuf: Sized + TryValidate + private::Sealed {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
-    fn encode(&self) -> Vec<u8>;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError::MaxDepthExceeded`] if the data structure has too many
+    /// recursion levels to be safely encoded and decoded by prost.
+    fn encode(&self) -> Result<Vec<u8>, EncodeError>;
     /// Decode the binary data in `buf`, producing something of type `Self`
     ///
     /// # Errors
@@ -108,23 +153,54 @@ pub trait Protobuf: Sized + TryValidate + private::Sealed {
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError>;
 }
 
-/// Encode `thing` into `buf` using the protobuf format `M`
+/// Encode `thing` into a freshly-allocated buffer using the protobuf format `M`
 ///
-/// `Err` is only returned if `buf` has insufficient space.
+/// # Errors
+///
+/// Returns [`EncodeError`] if the model fails pre-encode validation
+/// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]).
 #[expect(
     dead_code,
     reason = "experimental feature, we might have use for this one in the future"
 )]
-pub(crate) fn encode<M: prost::Message>(
-    thing: impl Into<M>,
+#[expect(
+    clippy::multiple_bound_locations,
+    clippy::type_repetition_in_bounds,
+    reason = "HRTB requires where clause"
+)]
+pub(crate) fn encode_with_buf<M: prost::Message + EncodeCheck, T>(
+    thing: &T,
     buf: &mut impl prost::bytes::BufMut,
-) -> Result<(), prost::EncodeError> {
-    thing.into().encode(buf)
+) -> Result<(), EncodeError>
+where
+    for<'a> M: From<&'a T>,
+{
+    let model = M::from(thing);
+    model.check_for_encode()?;
+    model.encode(buf)?;
+    Ok(())
 }
 
 /// Encode `thing` into a freshly-allocated buffer using the protobuf format `M`
-pub(crate) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
-    thing.into().encode_to_vec()
+///
+/// # Errors
+///
+/// Returns [`EncodeError`] if the model fails pre-encoding validation
+/// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]).
+#[expect(
+    clippy::multiple_bound_locations,
+    clippy::type_repetition_in_bounds,
+    reason = "HRTB requires where clause"
+)]
+pub(crate) fn encode_to_vec<M: prost::Message + EncodeCheck, T>(
+    thing: &T,
+) -> Result<Vec<u8>, EncodeError>
+where
+    for<'a> M: From<&'a T>,
+{
+    let model = M::from(thing);
+    model.check_for_encode()?;
+    Ok(model.encode_to_vec())
 }
 
 use std::{default::Default, fmt::Display};
@@ -153,6 +229,10 @@ pub(crate) fn try_decode<
         .try_into()
         .map_err(|e: E| DecodeError::Conversion(e.into()))
 }
+
+// ====================================================================
+// TryValidate implementations for api types
+// ====================================================================
 
 impl TryValidate for api::PolicySet {
     type Err = PolicySetValidationError;
@@ -222,4 +302,239 @@ impl TryValidate for api::EntityNamespace {
         // EntityNamespace also doesn't need additional validation
         Ok(self)
     }
+}
+
+// ====================================================================
+// EncodeCheck implementations for protobuf model types.
+// Encoding checks are implemented on the protobuf model type rather than
+// the AST/Validator level type to get a more predictable outcome: it is easier to
+// know how much recursion is needed to decode the protobuf representation
+// at this level than at the expression/type level.
+// ====================================================================
+
+use super::models;
+
+impl EncodeCheck for models::Expr {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        // Iterative depth-first traversal measuring protobuf recursion depth.
+        let mut stack: Vec<(&Self, usize)> = vec![(self, 1)];
+
+        while let Some((expr, depth)) = stack.pop() {
+            if depth > MAX_ENCODE_DEPTH {
+                return Err(EncodeError::MaxDepthExceeded);
+            }
+
+            if let Some(ref kind) = expr.expr_kind {
+                use models::expr::ExprKind;
+                // Prost counts each message entry as one recursion level. For our Expr
+                // schema, entering an Expr costs 1 level, and entering the variant
+                // wrapper message (BinaryApp, UnaryApp, If, etc.) costs another 1 level.
+                let child_depth = depth + 2;
+                match kind {
+                    ExprKind::Lit(_) | ExprKind::Var(_) | ExprKind::Slot(_) => {}
+                    ExprKind::If(if_expr) => {
+                        if let Some(ref e) = if_expr.test_expr {
+                            stack.push((e, child_depth));
+                        }
+                        if let Some(ref e) = if_expr.then_expr {
+                            stack.push((e, child_depth));
+                        }
+                        if let Some(ref e) = if_expr.else_expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::And(bin) => {
+                        if let Some(ref e) = bin.left {
+                            stack.push((e, child_depth));
+                        }
+                        if let Some(ref e) = bin.right {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::Or(bin) => {
+                        if let Some(ref e) = bin.left {
+                            stack.push((e, child_depth));
+                        }
+                        if let Some(ref e) = bin.right {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::UApp(unary) => {
+                        if let Some(ref e) = unary.expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::BApp(binary) => {
+                        if let Some(ref e) = binary.left {
+                            stack.push((e, child_depth));
+                        }
+                        if let Some(ref e) = binary.right {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::ExtApp(ext) => {
+                        for arg in &ext.args {
+                            stack.push((arg, child_depth));
+                        }
+                    }
+                    ExprKind::GetAttr(get) => {
+                        if let Some(ref e) = get.expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::HasAttr(has) => {
+                        if let Some(ref e) = has.expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::Like(like) => {
+                        if let Some(ref e) = like.expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::Is(is) => {
+                        if let Some(ref e) = is.expr {
+                            stack.push((e, child_depth));
+                        }
+                    }
+                    ExprKind::Set(set) => {
+                        for elem in &set.elements {
+                            stack.push((elem, child_depth));
+                        }
+                    }
+                    ExprKind::Record(record) => {
+                        for value in record.items.values() {
+                            stack.push((value, child_depth));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::Entity {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        // Validate all attribute and tag expressions
+        for expr in self.attrs.values().chain(self.tags.values()) {
+            expr.check_for_encode()?;
+        }
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::Entities {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        for entity in &self.entities {
+            entity.check_for_encode()?;
+        }
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::TemplateBody {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        // Validate the non-scope constraint expression within the template body
+        if let Some(ref expr) = self.non_scope_constraints {
+            expr.check_for_encode()?;
+        }
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::PolicySet {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        for template in &self.templates {
+            template.check_for_encode()?;
+        }
+        Ok(())
+    }
+}
+
+/// Trivial `EncodeCheck` for model types that have no recursive structure
+/// requiring depth checks.
+impl EncodeCheck for models::Name {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::Request {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        // The context field contains expressions that may be deeply nested
+        for expr in self.context.values() {
+            expr.check_for_encode()?;
+        }
+        Ok(())
+    }
+}
+
+impl EncodeCheck for models::Schema {
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        for entity_decl in &self.entity_decls {
+            for attr_type in entity_decl.attributes.values() {
+                check_type_depth(attr_type)?;
+            }
+            if let Some(ref tag_type) = entity_decl.tags {
+                check_type_depth_inner(tag_type, 1)?;
+            }
+        }
+        for action_decl in &self.action_decls {
+            for attr_type in action_decl.context.values() {
+                check_type_depth(attr_type)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validate that an [`AttributeType`](models::AttributeType) doesn't exceed
+/// the prost recursion budget.
+///
+/// Prost recursion cost from an `AttributeType`:
+/// +1 (`AttributeType` message) + cost of inner `Type`
+fn check_type_depth(attr_type: &models::AttributeType) -> Result<(), EncodeError> {
+    if let Some(ref ty) = attr_type.attr_type {
+        // AttributeType itself costs 1 prost level, then the Type inside costs 1 more
+        check_type_depth_inner(ty, 2)?;
+    }
+    Ok(())
+}
+
+/// Iteratively check `Type` nesting depth in prost recursion terms.
+///
+/// Prost recursion costs per `Type` variant:
+/// - `SetElem(Box<Type>)`: the child `Type` is directly nested → +1 per level
+/// - `Record`: +1 (`Record` message) + 1 (`AttributeType` message) + 1 (child `Type`) = +3
+/// - Primitive/Entity/Extension: terminal, no recursion
+fn check_type_depth_inner(root: &models::Type, starting_depth: usize) -> Result<(), EncodeError> {
+    // Stack of (Type, prost_depth)
+    let mut stack: Vec<(&models::Type, usize)> = vec![(root, starting_depth)];
+
+    while let Some((ty, depth)) = stack.pop() {
+        if depth > MAX_ENCODE_DEPTH {
+            return Err(EncodeError::MaxDepthExceeded);
+        }
+
+        if let Some(ref data) = ty.data {
+            use models::r#type::Data;
+            match data {
+                Data::Prim(_) | Data::Entity(_) | Data::Ext(_) => {}
+                Data::SetElem(inner_type) => {
+                    // set_elem is directly a Type field: +1 prost level
+                    stack.push((inner_type, depth + 1));
+                }
+                Data::Record(record) => {
+                    // Record message (+1) -> map entry -> AttributeType (+1) -> Type (+1) = +3
+                    for attr_type in record.attrs.values() {
+                        if let Some(ref inner_ty) = attr_type.attr_type {
+                            stack.push((inner_ty, depth + 3));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
 }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -125,6 +125,7 @@ pub trait Protobuf: Sized + TryValidate + private::Sealed {
     /// Returns [`EncodeError::MaxDepthExceeded`] if the data structure has too many
     /// recursion levels to be safely encoded and decoded by prost.
     fn encode(&self) -> Result<Vec<u8>, EncodeError>;
+
     /// Decode the binary data in `buf`, producing something of type `Self`
     ///
     /// # Errors
@@ -153,12 +154,13 @@ pub trait Protobuf: Sized + TryValidate + private::Sealed {
     fn decode_unchecked(buf: impl prost::bytes::Buf) -> Result<Self, DecodeError>;
 }
 
-/// Encode `thing` into a freshly-allocated buffer using the protobuf format `M`
+/// Encode `thing` into a caller provided buffer using the protobuf format `M`
 ///
 /// # Errors
 ///
-/// Returns [`EncodeError`] if the model fails pre-encode validation
-/// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]).
+/// Returns [`EncodeError`] if the model fails pre-encode checks
+/// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]) or the
+/// user-provided buffer does not have enough capacity.
 #[expect(
     dead_code,
     reason = "experimental feature, we might have use for this one in the future"

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -79,13 +79,24 @@ pub const MAX_ENCODE_DEPTH: usize = 90;
 /// before the protobuf encoding step. Types that need no pre-encode validation
 /// implement this as a no-op returning `Ok(())`.
 pub trait EncodeCheck {
-    /// Validate that this model is safe to encode.
+    /// Check that this model is safe to encode.
     ///
     /// # Errors
     ///
     /// Returns [`EncodeError`] if the model violates encoding constraints
     /// (e.g., exceeds the maximum nesting depth).
-    fn check_for_encode(&self) -> Result<(), EncodeError>;
+    fn check_for_encode(&self) -> Result<(), EncodeError> {
+        self.check_for_encode_from_depth(1)
+    }
+
+    /// Check that this model is safe to encode, assuming an `init` recursion
+    /// level.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodeError`] if the model violates encoding constraints
+    /// (e.g., exceeds the maximum nesting depth).
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError>;
 }
 
 /// A trait for objects that have a `try_validate` method returning `self` if the object is
@@ -317,9 +328,9 @@ impl TryValidate for api::EntityNamespace {
 use super::models;
 
 impl EncodeCheck for models::Expr {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Iterative depth-first traversal measuring protobuf recursion depth.
-        let mut stack: Vec<(&Self, usize)> = vec![(self, 1)];
+        let mut stack: Vec<(&Self, usize)> = vec![(self, init)];
 
         while let Some((expr, depth)) = stack.pop() {
             if depth > MAX_ENCODE_DEPTH {
@@ -420,38 +431,38 @@ impl EncodeCheck for models::Expr {
 }
 
 impl EncodeCheck for models::Entity {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Validate all attribute and tag expressions
         for expr in self.attrs.values().chain(self.tags.values()) {
-            expr.check_for_encode()?;
+            expr.check_for_encode_from_depth(init + 2)?;
         }
         Ok(())
     }
 }
 
 impl EncodeCheck for models::Entities {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         for entity in &self.entities {
-            entity.check_for_encode()?;
+            entity.check_for_encode_from_depth(init + 1)?;
         }
         Ok(())
     }
 }
 
 impl EncodeCheck for models::TemplateBody {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Validate the non-scope constraint expression within the template body
         if let Some(ref expr) = self.non_scope_constraints {
-            expr.check_for_encode()?;
+            expr.check_for_encode_from_depth(init + 1)?;
         }
         Ok(())
     }
 }
 
 impl EncodeCheck for models::PolicySet {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         for template in &self.templates {
-            template.check_for_encode()?;
+            template.check_for_encode_from_depth(init + 1)?;
         }
         Ok(())
     }
@@ -460,34 +471,34 @@ impl EncodeCheck for models::PolicySet {
 /// Trivial `EncodeCheck` for model types that have no recursive structure
 /// requiring depth checks.
 impl EncodeCheck for models::Name {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, _init: usize) -> Result<(), EncodeError> {
         Ok(())
     }
 }
 
 impl EncodeCheck for models::Request {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // The context field contains expressions that may be deeply nested
         for expr in self.context.values() {
-            expr.check_for_encode()?;
+            expr.check_for_encode_from_depth(init + 2)?;
         }
         Ok(())
     }
 }
 
 impl EncodeCheck for models::Schema {
-    fn check_for_encode(&self) -> Result<(), EncodeError> {
+    fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         for entity_decl in &self.entity_decls {
             for attr_type in entity_decl.attributes.values() {
-                check_type_depth(attr_type)?;
+                check_type_depth(attr_type, init + 3)?;
             }
             if let Some(ref tag_type) = entity_decl.tags {
-                check_type_depth_inner(tag_type, 1)?;
+                check_type_depth_inner(tag_type, init + 3)?;
             }
         }
         for action_decl in &self.action_decls {
             for attr_type in action_decl.context.values() {
-                check_type_depth(attr_type)?;
+                check_type_depth(attr_type, init + 3)?;
             }
         }
         Ok(())
@@ -499,10 +510,10 @@ impl EncodeCheck for models::Schema {
 ///
 /// Prost recursion cost from an `AttributeType`:
 /// +1 (`AttributeType` message) + cost of inner `Type`
-fn check_type_depth(attr_type: &models::AttributeType) -> Result<(), EncodeError> {
+fn check_type_depth(attr_type: &models::AttributeType, init: usize) -> Result<(), EncodeError> {
     if let Some(ref ty) = attr_type.attr_type {
         // AttributeType itself costs 1 prost level, then the Type inside costs 1 more
-        check_type_depth_inner(ty, 2)?;
+        check_type_depth_inner(ty, init + 2)?;
     }
     Ok(())
 }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -194,10 +194,7 @@ pub(crate) fn encode_with_buf<M: prost::Message + EncodeCheck + for<'a> From<&'a
 /// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]).
 pub(crate) fn encode_to_vec<M: prost::Message + EncodeCheck + for<'a> From<&'a T>, T>(
     thing: &T,
-) -> Result<Vec<u8>, EncodeError>
-where
-    for<'a> M: From<&'a T>,
-{
+) -> Result<Vec<u8>, EncodeError> {
     let model = M::from(thing);
     model.check_for_encode()?;
     Ok(model.encode_to_vec())
@@ -315,6 +312,10 @@ impl TryValidate for api::EntityNamespace {
 use super::models;
 
 impl EncodeCheck for models::Expr {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "many variants in expr and more readable that way"
+    )]
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Iterative depth-first traversal measuring protobuf recursion depth.
         let mut stack: Vec<(&Self, usize)> = vec![(self, init)];
@@ -331,7 +332,16 @@ impl EncodeCheck for models::Expr {
                 // wrapper message (BinaryApp, UnaryApp, If, etc.) costs another 1 level.
                 let child_depth = depth + 2;
                 match kind {
-                    ExprKind::Lit(_) | ExprKind::Var(_) | ExprKind::Slot(_) => {}
+                    ExprKind::Lit(lit) => {
+                        // A literal EUid adds 3: (Literal (EntityUuid (Name ...))
+                        if let Some(models::expr::literal::Lit::Euid(_)) = lit.lit {
+                            let euid_name_depth = depth + 3;
+                            if euid_name_depth > MAX_ENCODE_DEPTH {
+                                return Err(EncodeError::MaxDepthExceeded);
+                            }
+                        }
+                    }
+                    ExprKind::Var(_) | ExprKind::Slot(_) => {}
                     ExprKind::If(if_expr) => {
                         if let Some(ref e) = if_expr.test_expr {
                             stack.push((e, child_depth));
@@ -376,6 +386,13 @@ impl EncodeCheck for models::Expr {
                         for arg in &ext.args {
                             stack.push((arg, child_depth));
                         }
+                        // a `fn_name` adds 2 : (ExtApp(Name(..)).
+                        if ext.fn_name.is_some() {
+                            let name_depth = depth + 2;
+                            if name_depth > MAX_ENCODE_DEPTH {
+                                return Err(EncodeError::MaxDepthExceeded);
+                            }
+                        }
                     }
                     ExprKind::GetAttr(get) => {
                         if let Some(ref e) = get.expr {
@@ -391,10 +408,24 @@ impl EncodeCheck for models::Expr {
                         if let Some(ref e) = like.expr {
                             stack.push((e, child_depth));
                         }
+                        // PatternElem adds 2 (Like(Vec<PatternElem>(..))
+                        if !like.pattern.is_empty() {
+                            let pattern_depth = depth + 2;
+                            if pattern_depth > MAX_ENCODE_DEPTH {
+                                return Err(EncodeError::MaxDepthExceeded);
+                            }
+                        }
                     }
                     ExprKind::Is(is) => {
                         if let Some(ref e) = is.expr {
                             stack.push((e, child_depth));
+                        }
+                        // `entity_type` adds 2 (Is (Name (..)))
+                        if is.entity_type.is_some() {
+                            let name_depth = depth + 2;
+                            if name_depth > MAX_ENCODE_DEPTH {
+                                return Err(EncodeError::MaxDepthExceeded);
+                            }
                         }
                     }
                     ExprKind::Set(set) => {
@@ -532,7 +563,14 @@ fn check_type_depth_inner(root: &models::Type, starting_depth: usize) -> Result<
         if let Some(ref data) = ty.data {
             use models::r#type::Data;
             match data {
-                Data::Prim(_) | Data::Entity(_) | Data::Ext(_) => {}
+                Data::Prim(_) => {}
+                Data::Entity(_) | Data::Ext(_) => {
+                    // Entity/Ext adds 1: (Name(..))
+                    let name_depth = depth + 1;
+                    if name_depth > MAX_ENCODE_DEPTH {
+                        return Err(EncodeError::MaxDepthExceeded);
+                    }
+                }
                 Data::SetElem(inner_type) => {
                     // set_elem is directly a Type field: +1 prost level
                     stack.push((inner_type, depth + 1));

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -176,18 +176,10 @@ pub trait Protobuf: Sized + TryValidate + private::Sealed {
     dead_code,
     reason = "experimental feature, we might have use for this one in the future"
 )]
-#[expect(
-    clippy::multiple_bound_locations,
-    clippy::type_repetition_in_bounds,
-    reason = "HRTB requires where clause"
-)]
-pub(crate) fn encode_with_buf<M: prost::Message + EncodeCheck, T>(
+pub(crate) fn encode_with_buf<M: prost::Message + EncodeCheck + for<'a> From<&'a T>, T>(
     thing: &T,
     buf: &mut impl prost::bytes::BufMut,
-) -> Result<(), EncodeError>
-where
-    for<'a> M: From<&'a T>,
-{
+) -> Result<(), EncodeError> {
     let model = M::from(thing);
     model.check_for_encode()?;
     model.encode(buf)?;
@@ -200,12 +192,7 @@ where
 ///
 /// Returns [`EncodeError`] if the model fails pre-encoding validation
 /// (e.g., expression depth exceeds [`MAX_ENCODE_DEPTH`]).
-#[expect(
-    clippy::multiple_bound_locations,
-    clippy::type_repetition_in_bounds,
-    reason = "HRTB requires where clause"
-)]
-pub(crate) fn encode_to_vec<M: prost::Message + EncodeCheck, T>(
+pub(crate) fn encode_to_vec<M: prost::Message + EncodeCheck + for<'a> From<&'a T>, T>(
     thing: &T,
 ) -> Result<Vec<u8>, EncodeError>
 where
@@ -434,6 +421,7 @@ impl EncodeCheck for models::Entity {
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Validate all attribute and tag expressions
         for expr in self.attrs.values().chain(self.tags.values()) {
+            // Map: +1 for entering the list, +1 for entering the map entry
             expr.check_for_encode_from_depth(init + 2)?;
         }
         Ok(())
@@ -453,6 +441,7 @@ impl EncodeCheck for models::TemplateBody {
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // Validate the non-scope constraint expression within the template body
         if let Some(ref expr) = self.non_scope_constraints {
+            // List: +1 for entering the list
             expr.check_for_encode_from_depth(init + 1)?;
         }
         Ok(())
@@ -462,6 +451,7 @@ impl EncodeCheck for models::TemplateBody {
 impl EncodeCheck for models::PolicySet {
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         for template in &self.templates {
+            // List: +1 for entering the list
             template.check_for_encode_from_depth(init + 1)?;
         }
         Ok(())
@@ -480,6 +470,7 @@ impl EncodeCheck for models::Request {
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         // The context field contains expressions that may be deeply nested
         for expr in self.context.values() {
+            // Map: +1 for entering the list, +1 for entering the map entry
             expr.check_for_encode_from_depth(init + 2)?;
         }
         Ok(())
@@ -489,15 +480,20 @@ impl EncodeCheck for models::Request {
 impl EncodeCheck for models::Schema {
     fn check_for_encode_from_depth(&self, init: usize) -> Result<(), EncodeError> {
         for entity_decl in &self.entity_decls {
+            // + 1 for entering entity decls
             for attr_type in entity_decl.attributes.values() {
+                // Map: +1 for entering the list, +1 for entering the map entry
                 check_type_depth(attr_type, init + 3)?;
             }
             if let Some(ref tag_type) = entity_decl.tags {
+                // Map: +1 for entering the list, +1 for entering the map entry
                 check_type_depth_inner(tag_type, init + 3)?;
             }
         }
         for action_decl in &self.action_decls {
+            // + 1 for entering action decls list
             for attr_type in action_decl.context.values() {
+                // Map: +1 for entering the list, +1 for entering the map entry
                 check_type_depth(attr_type, init + 3)?;
             }
         }
@@ -542,10 +538,10 @@ fn check_type_depth_inner(root: &models::Type, starting_depth: usize) -> Result<
                     stack.push((inner_type, depth + 1));
                 }
                 Data::Record(record) => {
-                    // Record message (+1) -> map entry -> AttributeType (+1) -> Type (+1) = +3
+                    // Record message (+1) -> map entry (+1) -> AttributeType (+1) -> Type (+1) = +4
                     for attr_type in record.attrs.values() {
                         if let Some(ref inner_ty) = attr_type.attr_type {
-                            stack.push((inner_ty, depth + 3));
+                            stack.push((inner_ty, depth + 4));
                         }
                     }
                 }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -405,8 +405,11 @@ impl EncodeCheck for models::Expr {
                         }
                     }
                     ExprKind::Record(record) => {
+                        // map<string, Expr> adds an extra map-entry wrapper message:
+                        // Record (+1) → map entry (+1) → Expr (+1) = +3 from parent Expr
+                        let record_child_depth = depth + 3;
                         for value in record.items.values() {
-                            stack.push((value, child_depth));
+                            stack.push((value, record_child_depth));
                         }
                     }
                 }

--- a/cedar-policy/tests/proto_generate_test_files.rs
+++ b/cedar-policy/tests/proto_generate_test_files.rs
@@ -42,7 +42,7 @@ const BASE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/proto_test_files"
 fn write_test_files(dir: &str, ext: &str, name: &str, value: &impl Protobuf, contents: &str) {
     let dir = Path::new(BASE).join(dir);
     create_dir_all(&dir).unwrap();
-    write(dir.join(format!("{name}.pb")), value.encode()).unwrap();
+    write(dir.join(format!("{name}.pb")), value.encode().unwrap()).unwrap();
     write(dir.join(format!("{name}.{ext}")), contents).unwrap();
 }
 


### PR DESCRIPTION
## Description of changes

Makes the protobuf experimental feature's `encode` API faillible based on encoded message depth. This prevents problems where you could encode a structure successfully and then encounter an error while decoding it.

The depth check is on the `models::` type rather than API type because it is easier to predict whether decode will fail at that level.

The changes are:
- a new trait `EncodeCheck` in `traits.rs`
- implementations of the trait in `traits.rs` for all the `models::` types,
- tests in `api.rs` testing the depth bounds, and importantly, that decode doesn't panic under the boundary

Matching PR for fuzzing targets:
https://github.com/cedar-policy/cedar-spec/pull/987


<img width="870" height="411" alt="Screenshot 2026-07-21 at 5 30 50 PM" src="https://github.com/user-attachments/assets/abd59a69-c71f-4037-8115-3859751d790d" />




The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
