### PR TITLE
Remove unnecessary use of educe

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -229,8 +229,7 @@ impl EntityUIDImpl {
 }
 
 /// Unique ID for an entity. These represent entities in the AST.
-#[derive(Educe, Debug, Clone)]
-#[educe(PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EntityUID {
     /// Unique ID for an entity. These represent entities in the AST
     EntityUID(EntityUIDImpl),
@@ -1018,6 +1017,17 @@ mod test {
         let serialized = serde_json::to_string(&entity_type).unwrap();
 
         assert_eq!(serialized, r#""some_entity_type""#);
+    }
+
+    #[test]
+    fn euid_ordering_matches_type_then_eid() {
+        let euid1 = EntityUID::from_str("AA::\"zzz\"").unwrap();
+        let euid2 = EntityUID::from_str("B::\"aaa\"").unwrap();
+        // The type is the primary sort key: `AA` < `B` regardless of eid.
+        assert!(euid1 < euid2);
+        let euid3 = EntityUID::from_str("AA::\"aaa\"").unwrap();
+        // The eid is the tie-breaker when the types are equal.
+        assert!(euid3 < euid1);
     }
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -19,6 +19,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Added missing validation check when decoding a protobuf policy set that template-linked policy IDs do not collide with template IDs. (#2441)
 - `PolicySet::from_pst` now returns an error if a map key doesn't match the id of its corresponding template or policy, instead of silently accepting the malformed input (#2444).
 - For the experimental `tpe` feature, fixed `PartialEntities::from_json_value` to return an error given two entities with duplicate ids.
+- Fixed issue where the derived implementations of `Ord` and `PartialOrd` for `EntityUid`s did not order instances lexicographically by type, then by entity id (#2463, #2483).
 
 ### Added
 - Public syntax tree (`pst`) support for `variadic-is-in-range` feature: a variadic `isInRange` is modelled by a `pst::Expr::VariadicOp{...}` in the PST (#2380).


### PR DESCRIPTION
## Description of changes
Prior to version v0.7.1 educe's derived implementation of `Ord`/`PartialOrd` relied on undefined behavior for enums and the fix for this changed that behavior of impacted enums. We upgraded to educe 0.7.4 in https://github.com/cedar-policy/cedar/pull/2463. This PR documents the impact of this upgrade in the change log, adds a test confirming that the new derived implementation does not have the same issue as the old one, and removes an unneeded use of educe in favor of the standard library's derive macro.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
