### PR TITLE
typecheck: cache env-independent subtrees across request envs

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -300,6 +300,40 @@ impl<T> Expr<T> {
         matches!(&self.expr_kind, ExprKind::Slot(_))
     }
 
+    /// Whether this node *directly* reads the request environment — i.e. it is
+    /// a `Var`, a template `Slot`, or an `Unknown`. Such a node can typecheck
+    /// to a different type in each request environment.
+    ///
+    /// A node whose whole subtree contains no such leaf is *env-independent*:
+    /// it typechecks identically in every environment, so the validator
+    /// typechecks it once and reuses the result across the request-env
+    /// cross-product (see `EnvMemo` in `validator::typecheck`).
+    ///
+    /// This is an exhaustive match with no wildcard arm on purpose: a future
+    /// env-referencing `ExprKind` must fail to compile here until it is
+    /// classified, rather than silently defaulting to env-independent and being
+    /// cached with the wrong type.
+    pub(crate) fn references_request_env(&self) -> bool {
+        match &self.expr_kind {
+            ExprKind::Var(_) | ExprKind::Slot(_) | ExprKind::Unknown(_) => true,
+            ExprKind::Lit(_)
+            | ExprKind::If { .. }
+            | ExprKind::And { .. }
+            | ExprKind::Or { .. }
+            | ExprKind::UnaryApp { .. }
+            | ExprKind::BinaryApp { .. }
+            | ExprKind::GetAttr { .. }
+            | ExprKind::HasAttr { .. }
+            | ExprKind::Like { .. }
+            | ExprKind::Is { .. }
+            | ExprKind::ExtensionFunctionApp { .. }
+            | ExprKind::Set(_)
+            | ExprKind::Record(_) => false,
+            #[cfg(feature = "tolerant-ast")]
+            ExprKind::Error { .. } => false,
+        }
+    }
+
     /// Check whether this expression is a set of entity references
     ///
     /// This is used for policy scopes, where some syntax is

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -25,6 +25,9 @@ use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 pub(crate) use typecheck_answer::TypecheckAnswer;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{borrow::Cow, collections::HashSet};
 
@@ -59,6 +62,235 @@ pub enum PolicyCheck {
     Irrelevant(Vec<ValidationError>, Expr<Option<Type>>),
     /// Policy will have errors
     Fail(Vec<ValidationError>),
+}
+
+/// Identity key for an AST node: its address.
+///
+/// Keying is per syntactic position, not per shape: two occurrences of an
+/// identical sub-expression can typecheck differently (different capabilities
+/// or source locations), so they must stay distinct. This holds only while
+/// each position has its own address; `ExprKind` children are `Arc<Expr>`, so
+/// sharing one `Arc` across two positions would alias them. Parsed ASTs are
+/// trees, so this holds today, and `mark_env_dep_walk` asserts it (in all
+/// builds) while populating a memo.
+///
+/// The address is only hashed and compared, never dereferenced. The keyed
+/// `Expr` must outlive the memo: `condition()` returns a fresh `Expr`, so
+/// `typecheck_policy` holds one `cond` for the whole cross-product and keys the
+/// memo on it. `EnvMemo` borrows that `cond` via `PhantomData`, making this
+/// compiler-enforced.
+type NodeId = *const Expr;
+
+fn expr_key(e: &Expr) -> NodeId {
+    e as NodeId
+}
+
+/// A cached typecheck result for an env-independent node: the typed expression
+/// to clone on a hit, tagged with whether it was a typecheck success or fail.
+#[derive(Clone)]
+enum CachedResult {
+    Success(Expr<Option<Type>>),
+    Fail(Expr<Option<Type>>),
+}
+
+/// Memoizes typechecking results for env-independent AST nodes.  An
+/// env-independent node — one that does not transitively reference `Var`,
+/// `Slot`, or `Unknown` — produces the same type in every request env, so it
+/// is typechecked once and reused for the rest of the cross-product.
+///
+/// This encapsulates the interior mutability: callers see plain `cacheable` /
+/// `get` / `put` methods, never a `RefCell` borrow.
+///
+/// `Clone` is required because the per-env closure in
+/// `apply_typecheck_fn_by_request_env` captures the memo and must be `Fn +
+/// Clone`.  Only the empty `default()` memo is ever cloned; the populated memo
+/// from `new` is shared by reference within a single `typecheck_policy` call.
+/// The manual `Clone` impl below asserts that invariant in all builds.
+#[derive(Default)]
+struct EnvMemo<'a> {
+    /// Whether caching is active.  `false` for the `default()` no-op memo used
+    /// by single-env entry points: there every node is visited once per
+    /// traversal, so a cache would only add pointless inserts and clones.
+    enabled: bool,
+    /// Nodes that are env-dependent, and therefore must be re-typechecked in
+    /// every env (never cached).
+    dep: HashSet<NodeId>,
+    /// Typed results for env-independent nodes.  `RefCell` because
+    /// `typecheck()` takes `&self`.
+    cache: RefCell<HashMap<NodeId, CachedResult>>,
+    /// Ties the memo's lifetime to the `cond` it keys into.  `NodeId` is a raw
+    /// `*const Expr` pointing into `cond`, so without this the borrow checker
+    /// cannot stop `cond` being dropped or rebuilt while cached keys still
+    /// reference it — a silent stale-pointer hit.  This phantom borrow makes
+    /// "`cond` outlives the memo" a compile error to violate; `default()` (the
+    /// no-op memo) simply picks an unconstrained lifetime.
+    _cond: PhantomData<&'a Expr>,
+}
+
+impl<'a> Clone for EnvMemo<'a> {
+    fn clone(&self) -> Self {
+        // Cloning a populated memo would give each clone an independent cache
+        // and silently lose the cross-env sharing that is the whole point.
+        // `assert!` (not `debug_assert!`): the consequence of violation is a
+        // silent correctness regression, not a crash, so guard it in release too.
+        assert!(
+            !self.enabled,
+            "cloning a populated EnvMemo loses cross-env cache sharing"
+        );
+        Self {
+            enabled: self.enabled,
+            dep: self.dep.clone(),
+            cache: self.cache.clone(),
+            _cond: PhantomData,
+        }
+    }
+}
+
+impl<'a> EnvMemo<'a> {
+    /// Build a memo for `cond`, marking every env-dependent node up front.
+    ///
+    /// Enabling contract: a populated (enabled) memo makes a cache hit return
+    /// the first env's answer verbatim — no `prior_capability`, no per-env
+    /// `type_errors`. That is sound only for a caller that (a) aggregates errors
+    /// env-agnostically (as `typecheck_policy` does, deduping into a `HashSet`,
+    /// so a first-env error still surfaces) and (b) never inspects the per-env
+    /// capability or per-env error list of a cached node. Any new caller that
+    /// enables the memo must honour both; a caller needing faithful per-env
+    /// diagnostics must use `EnvMemo::default()` instead.
+    fn new(cond: &'a Expr) -> Self {
+        let mut dep = HashSet::new();
+        mark_env_dep_walk(cond, &mut dep);
+        Self {
+            enabled: true,
+            dep,
+            cache: RefCell::new(HashMap::new()),
+            _cond: PhantomData,
+        }
+    }
+
+    /// Is `e` env-independent, and therefore safe to cache across envs?
+    fn cacheable(&self, e: &Expr) -> bool {
+        // `enabled` distinguishes the `default()` no-op memo (single-env
+        // callers) from a real one. It can't be replaced by `dep.is_empty()`:
+        // a fully env-independent condition also has empty `dep` but must cache.
+        self.enabled && !self.dep.contains(&expr_key(e))
+    }
+
+    /// Fetch a cached result for env-independent node `e`, if present.
+    /// The returned answer is fully owned (empty capability, cloned expr), so
+    /// its lifetime `'b` is unconstrained by design.
+    fn get<'b>(&self, e: &Expr) -> Option<TypecheckAnswer<'b>> {
+        self.cache
+            .borrow()
+            .get(&expr_key(e))
+            .map(|cached| match cached {
+                CachedResult::Success(ty) => TypecheckAnswer::success(ty.clone()),
+                CachedResult::Fail(ty) => TypecheckAnswer::fail(ty.clone()),
+            })
+    }
+
+    /// Record the typechecking result for env-independent node `e`.
+    /// `RecursionLimit`/error answers carry no typed expr and are not cached.
+    fn put(&self, e: &Expr, ans: &TypecheckAnswer<'_>) {
+        let entry = match ans {
+            TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
+                CachedResult::Success(expr_type.clone())
+            }
+            TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
+                CachedResult::Fail(expr_recovery_type.clone())
+            }
+            _ => return,
+        };
+        self.cache.borrow_mut().insert(expr_key(e), entry);
+    }
+}
+
+/// Push `expr`'s immediate sub-expressions onto `out`.
+fn push_children<'a>(expr: &'a Expr, out: &mut Vec<&'a Expr>) {
+    match expr.expr_kind() {
+        // Leaf nodes: no children.
+        ExprKind::Lit(_) | ExprKind::Var(_) | ExprKind::Slot(_) | ExprKind::Unknown(_) => {}
+        ExprKind::If {
+            test_expr,
+            then_expr,
+            else_expr,
+        } => {
+            out.push(test_expr);
+            out.push(then_expr);
+            out.push(else_expr);
+        }
+        ExprKind::And { left, right } | ExprKind::Or { left, right } => {
+            out.push(left);
+            out.push(right);
+        }
+        ExprKind::UnaryApp { arg, .. } => out.push(arg),
+        ExprKind::BinaryApp { arg1, arg2, .. } => {
+            out.push(arg1);
+            out.push(arg2);
+        }
+        ExprKind::GetAttr { expr: sub, .. }
+        | ExprKind::HasAttr { expr: sub, .. }
+        | ExprKind::Like { expr: sub, .. }
+        | ExprKind::Is { expr: sub, .. } => out.push(sub),
+        ExprKind::ExtensionFunctionApp { args, .. } | ExprKind::Set(args) => {
+            out.extend(args.as_ref().iter());
+        }
+        ExprKind::Record(map) => {
+            out.extend(map.values());
+        }
+        #[cfg(feature = "tolerant-ast")]
+        ExprKind::Error { .. } => {}
+    }
+}
+
+/// Insert into `dep` every node of `root` that is env-dependent — i.e. whose
+/// subtree transitively references `Var`, `Slot`, or `Unknown`.
+///
+/// Iterative (heap work-list) rather than recursive: this runs from
+/// `EnvMemo::new` before `typecheck`'s own `stacker` guard would apply, so a
+/// deeply nested policy must not be able to overflow the stack here.
+fn mark_env_dep_walk(root: &Expr, dep: &mut HashSet<NodeId>) {
+    // Pass 1: pre-order collect, so every node precedes its descendants.
+    // `seen` also guards the no-aliasing invariant that `NodeId` keying relies
+    // on: distinct syntactic positions must have distinct addresses. If a
+    // future AST change shared an `Arc<Expr>` across positions (dedup/CSE, an
+    // interned literal), two positions would collide on one key and the second
+    // would silently read the first's cached type. Assert always-on, not just
+    // in debug: a wrong type is a silent soundness regression rather than a
+    // crash, and this costs O(n) once per policy — cheap next to typechecking.
+    let mut order: Vec<&Expr> = Vec::new();
+    let mut seen: HashSet<NodeId> = HashSet::new();
+    let mut stack: Vec<&Expr> = vec![root];
+    while let Some(n) = stack.pop() {
+        assert!(
+            seen.insert(expr_key(n)),
+            "aliased AST node in policy condition: NodeId cache keying \
+             requires distinct positions to have distinct addresses"
+        );
+        order.push(n);
+        push_children(n, &mut stack);
+    }
+    // Pass 2: walk in reverse (every node after its descendants), so a child's
+    // membership in `dep` is already decided when its parent is processed. A
+    // node is env-dependent if it is a `Var`/`Slot`/`Unknown` leaf or any child
+    // is env-dependent.
+    let mut children: Vec<&Expr> = Vec::new();
+    for &n in order.iter().rev() {
+        // A node is env-dependent if it directly reads the request env, or if
+        // any child is env-dependent. `references_request_env` (in `ast::expr`)
+        // owns the direct classification as an exhaustive, wildcard-free match,
+        // so a new env-referencing `ExprKind` is a compile error there until
+        // classified — it can never silently default to env-independent here.
+        let mut env_dependent = n.references_request_env();
+        if !env_dependent {
+            children.clear();
+            push_children(n, &mut children);
+            env_dependent = children.iter().copied().any(|c| dep.contains(&expr_key(c)));
+        }
+        if env_dependent {
+            dep.insert(expr_key(n));
+        }
+    }
 }
 
 /// This structure implements typechecking for Cedar policies through the
@@ -101,21 +333,35 @@ impl<'a> Typechecker<'a> {
         // is computed, so peak live memory is O(one condition) rather than
         // O(envs * condition).
         let cond = t.condition();
+        // Flatten the env cross-product into one lazy stream so we can peek
+        // whether there is more than one env before building the memo.
+        let mut envs = self
+            .schema
+            .unlinked_request_envs(self.mode)
+            .flat_map(move |unlinked_e| self.link_request_env(unlinked_e, t))
+            .peekable();
+        // The cache only pays off across multiple envs; with 0 or 1 env it
+        // yields no reuse, so skip the up-front condition walk and use a no-op
+        // memo. `peek` pulls at most one extra env, preserving O(1) live envs.
+        let first = envs.next();
+        let memo = if first.is_some() && envs.peek().is_some() {
+            EnvMemo::new(&cond)
+        } else {
+            EnvMemo::default()
+        };
         let mut all_false = true;
         let mut all_succ = true;
-        for unlinked_e in self.schema.unlinked_request_envs(self.mode) {
-            for linked_e in self.link_request_env(unlinked_e, t) {
-                match self.single_env_typechecking(&linked_e, t.id(), &cond) {
-                    PolicyCheck::Success(_) => all_false = false,
-                    PolicyCheck::Irrelevant(err, _) => {
-                        all_succ = all_succ && err.is_empty();
-                        type_errors.extend(err);
-                    }
-                    PolicyCheck::Fail(err) => {
-                        type_errors.extend(err);
-                        all_false = false;
-                        all_succ = false;
-                    }
+        for linked_e in first.into_iter().chain(envs) {
+            match self.single_env_typechecking(&linked_e, t.id(), &cond, &memo) {
+                PolicyCheck::Success(_) => all_false = false,
+                PolicyCheck::Irrelevant(err, _) => {
+                    all_succ = all_succ && err.is_empty();
+                    type_errors.extend(err);
+                }
+                PolicyCheck::Fail(err) => {
+                    type_errors.extend(err);
+                    all_false = false;
+                    all_succ = false;
                 }
             }
         }
@@ -147,8 +393,9 @@ impl<'a> Typechecker<'a> {
         &'b self,
         t: &'b Template,
     ) -> impl Iterator<Item = (RequestEnv<'b>, PolicyCheck)> + 'b {
+        let empty_memo = EnvMemo::default();
         self.apply_typecheck_fn_by_request_env(t, move |request_env, policy_id, expr| {
-            self.single_env_typechecking(request_env, policy_id, expr)
+            self.single_env_typechecking(request_env, policy_id, expr, &empty_memo)
         })
     }
 
@@ -157,6 +404,7 @@ impl<'a> Typechecker<'a> {
         request_env: &RequestEnv<'_>,
         policy_id: &PolicyID,
         expr: &Expr,
+        memo: &EnvMemo<'_>,
     ) -> PolicyCheck {
         let mut type_errors = Vec::new();
         let single_env_typechecker = SingleEnvTypechecker {
@@ -165,6 +413,7 @@ impl<'a> Typechecker<'a> {
             mode: self.mode,
             policy_id,
             request_env,
+            memo,
         };
         let empty_prior_capability = CapabilitySet::new();
         let ans = single_env_typechecker.expect_type(
@@ -200,7 +449,8 @@ impl<'a> Typechecker<'a> {
         t: &'b Template,
         request_env: &RequestEnv<'b>,
     ) -> PolicyCheck {
-        self.single_env_typechecking(request_env, t.id(), &t.condition())
+        let empty_memo = EnvMemo::default();
+        self.single_env_typechecking(request_env, t.id(), &t.condition(), &empty_memo)
     }
 
     /// Apply `typecheck_fn` to the given policy in every schema-defined request
@@ -329,6 +579,9 @@ struct SingleEnvTypechecker<'a> {
     policy_id: &'a PolicyID,
     /// The single env which we're performing typechecking for
     request_env: &'a RequestEnv<'a>,
+    /// Memoizes typechecking of env-independent nodes across the request-env
+    /// cross-product (populated on the first env, reused thereafter).
+    memo: &'a EnvMemo<'a>,
 }
 
 impl<'a> SingleEnvTypechecker<'a> {
@@ -342,11 +595,39 @@ impl<'a> SingleEnvTypechecker<'a> {
         e: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
-        // We assume there's enough space if we cannot determine it with `remaining_stack`
         if stacker::remaining_stack().unwrap_or(REQUIRED_STACK_SPACE) < REQUIRED_STACK_SPACE {
             return TypecheckAnswer::RecursionLimit;
         }
 
+        // Env-independent nodes produce identical types in every env: typecheck
+        // once, reuse thereafter. A hit returns the cached answer directly,
+        // ignoring `prior_capability` and emitting no `type_errors`. Safe
+        // because a capability on an env-independent base is only consumed by
+        // env-independent (cached) nodes, and `typecheck_policy` — the only
+        // caller that enables the memo — dedups errors across envs, so a
+        // first-env error still survives.
+        let cacheable = self.memo.cacheable(e);
+        if cacheable {
+            if let Some(cached) = self.memo.get(e) {
+                return cached;
+            }
+        }
+
+        let ans = self.typecheck_inner(prior_capability, e, type_errors);
+
+        if cacheable {
+            self.memo.put(e, &ans);
+        }
+
+        ans
+    }
+
+    fn typecheck_inner<'b>(
+        &self,
+        prior_capability: &CapabilitySet<'b>,
+        e: &'b Expr,
+        type_errors: &mut Vec<ValidationError>,
+    ) -> TypecheckAnswer<'b> {
         match e.expr_kind() {
             // Principal, resource, and context have types defined by
             // the request type.

--- a/cedar-policy-core/src/validator/typecheck/test/policy.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/policy.rs
@@ -108,6 +108,69 @@ fn simple_schema_file() -> json_schema::NamespaceDefinition<RawName> {
     .expect("Expected valid schema")
 }
 
+/// Two-env schema (User + Admin principals) with an optional attribute, for
+/// exercising the env-independent subtree cache across a multi-env cross product.
+fn schema_with_optional_multi_env() -> json_schema::NamespaceDefinition<RawName> {
+    serde_json::from_value(serde_json::json!(
+        {
+            "entityTypes": {
+                "User": {
+                    "shape": {
+                        "type": "Record",
+                        "attributes": {
+                            "nickname": { "type": "String", "required": false }
+                        }
+                    }
+                },
+                "Admin": { "shape": { "type": "Record", "attributes": {} } },
+                "Photo": { "shape": { "type": "Record", "attributes": {} } }
+            },
+            "actions": {
+                "view": {
+                    "appliesTo": {
+                        "principalTypes": ["User", "Admin"],
+                        "resourceTypes": ["Photo"]
+                    }
+                }
+            }
+        }
+    ))
+    .expect("Expected valid schema")
+}
+
+/// Regression test for the env-independent subtree cache (#2439): a policy
+/// mixing env-dependent (`principal`) and env-independent (`1 + 1 == 2`)
+/// sub-expressions must typecheck across every env in the cross product, where
+/// the env-independent subtree is typechecked once and reused across envs.
+#[test]
+fn env_independent_cache_mixed_policy_typechecks() {
+    assert_policy_typechecks(
+        simple_schema_file(),
+        parse_policy(
+            None,
+            r#"permit(principal, action, resource) when { 1 + 1 == 2 && principal has name };"#,
+        )
+        .expect("Policy should parse."),
+    );
+}
+
+/// Regression test for the cache's capability invariant: a cache hit reuses a
+/// cached env-independent node and ignores `prior_capability`. A capability on
+/// an env-independent base (an entity literal) is only ever consumed by
+/// env-independent nodes, so reuse stays sound. Exercised across a 2-env cross
+/// product with an optional attribute reached through a `has` guard.
+#[test]
+fn env_independent_cache_capability_on_entity_literal() {
+    assert_policy_typechecks(
+        schema_with_optional_multi_env(),
+        parse_policy(
+            None,
+            r#"permit(principal, action, resource) when { User::"alice" has nickname && User::"alice".nickname == "bob" };"#,
+        )
+        .expect("Policy should parse."),
+    );
+}
+
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typechecks_permissive_simple_schema(p: impl Into<Arc<Template>>) {
     assert_policy_typechecks_for_mode(simple_schema_file(), p, ValidationMode::Permissive)

--- a/cedar-policy-core/src/validator/typecheck/test/strict.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/strict.rs
@@ -36,6 +36,7 @@ use crate::validator::{
     RawName, ValidationError, ValidationMode,
 };
 
+use super::super::EnvMemo;
 use super::test_utils::{
     assert_exactly_one_diagnostic, assert_policy_typecheck_fails, expr_id_placeholder, get_loc,
 };
@@ -48,12 +49,14 @@ fn assert_typechecks_strict(
     expected_type: Type,
 ) {
     let schema = schema.try_into().expect("Failed to construct schema.");
+    let no_memo = EnvMemo::default();
     let typechecker = SingleEnvTypechecker {
         schema: &schema,
         extensions: ExtensionSchemas::all_available(),
         mode: ValidationMode::Strict,
         policy_id: &expr_id_placeholder(),
         request_env,
+        memo: &no_memo,
     };
     let mut errs = Vec::new();
     let answer =
@@ -75,12 +78,14 @@ fn assert_strict_type_error(
     expected_error: ValidationError,
 ) {
     let schema = schema.try_into().expect("Failed to construct schema.");
+    let no_memo = EnvMemo::default();
     let typechecker = SingleEnvTypechecker {
         schema: &schema,
         extensions: ExtensionSchemas::all_available(),
         mode: ValidationMode::Strict,
         policy_id: &expr_id_placeholder(),
         request_env,
+        memo: &no_memo,
     };
     let mut errs = Vec::new();
     let answer =
@@ -168,12 +173,14 @@ where
 fn strict_typecheck_catches_regular_type_error() {
     with_simple_schema_and_request(|s, q| {
         let schema = s.try_into().expect("Failed to construct schema.");
+        let no_memo = EnvMemo::default();
         let typechecker = SingleEnvTypechecker {
             schema: &schema,
             extensions: ExtensionSchemas::all_available(),
             mode: ValidationMode::Strict,
             policy_id: &expr_id_placeholder(),
             request_env: &q,
+            memo: &no_memo,
         };
         let mut errs = Vec::new();
         typechecker.expect_type(

--- a/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/test_utils.rs
@@ -26,6 +26,7 @@ use crate::entities::{err::EntitiesError, Entities, EntityJsonParser, TCComputat
 use crate::extensions::Extensions;
 use crate::parser::Loc;
 
+use super::super::EnvMemo;
 use crate::validator::{
     json_schema,
     typecheck::{SingleEnvTypechecker, TypecheckAnswer, Typechecker},
@@ -119,12 +120,14 @@ impl Typechecker<'_> {
         policy_id: &'a PolicyID,
         unique_type_errors: &mut HashSet<ValidationError>,
     ) -> TypecheckAnswer<'a> {
+        let no_memo = EnvMemo::default();
         let typechecker = SingleEnvTypechecker {
             schema: self.schema,
             extensions: self.extensions,
             mode: self.mode,
             policy_id,
             request_env,
+            memo: &no_memo,
         };
         let mut type_errors = Vec::new();
         let ans = typechecker.typecheck(&CapabilitySet::new(), e, &mut type_errors);


### PR DESCRIPTION
## Description of changes
Caches the typechecking result of environment-independent sub-expressions across request environments when validating a policy. Behavior-preserving optimization internal to cedar-policy-core's validator (continuation of #2439).

A policy condition is typechecked once per request environment in the principal × action × resource cross-product. An up-front tree walk classifies each condition node: a node whose subtree references the request environment (Var, Slot, or Unknown) is environment-dependent and re-typechecked in every environment; every other node produces the same type in every environment, so it's typechecked once, cached, and reused across the remaining environments instead of being re-typechecked from scratch.

I don't believe that this requires spec or DRT changes since this is about an efficiency gain in processing without changing how things are processed procedurally.

I'm open to refactors or any design considerations you may have on this one. Local benchmarks show policies with many static values (e.g. hundreds of IP CIDRs) validate much faster against multi-environment schemas, since constant subtrees are typechecked once rather than per environment.

There could be a version of this that is more intertwined with the typecheck pass, but that mixed the caching determination with the typechecker code, which is sensitive to edit imo.

## Issue #, if available
This is a continuation of #2439 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.