### PR TITLE
Fixes RustEngine::validate_request inverts success/failure semantics

### DIFF
--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -358,7 +358,7 @@ impl CedarTestImplementation for RustEngine {
             req.build()
         });
         let response = TestValidationResult {
-            errors: res.map(|r| vec![r.to_string()]).unwrap_or_default(),
+            errors: res.err().map(|e| vec![e.to_string()]).unwrap_or_default(),
             timing_info: HashMap::from([("validate_request".into(), Micros(dur.as_micros()))]),
         };
         TestResult::Success(response)
@@ -370,5 +370,73 @@ impl CedarTestImplementation for RustEngine {
 
     fn validation_comparison_mode(&self) -> ValidationComparisonMode {
         ValidationComparisonMode::AgreeOnAll
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cedar_policy::{Context, EntityUid};
+    use std::str::FromStr;
+
+    fn test_schema() -> Schema {
+        Schema::from_cedarschema_str(
+            r#"
+            entity User;
+            entity Photo;
+            action View appliesTo {
+                principal: User,
+                resource: Photo,
+            };
+        "#,
+        )
+        .expect("schema should parse")
+        .0
+    }
+
+    #[test]
+    fn validate_request_valid_reports_passed() {
+        let schema = test_schema();
+        let request = Request::new(
+            EntityUid::from_str(r#"User::"alice""#).unwrap(),
+            EntityUid::from_str(r#"Action::"View""#).unwrap(),
+            EntityUid::from_str(r#"Photo::"vacation""#).unwrap(),
+            Context::empty(),
+            None,
+        )
+        .expect("request should be constructable");
+
+        let result = RustEngine::new()
+            .validate_request(&schema, &request)
+            .expect("validate_request should return Success");
+
+        assert!(
+            result.validation_passed(),
+            "expected a schema-valid request to pass validation, got errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn validate_request_invalid_reports_failed() {
+        let schema = test_schema();
+        // Use an entity type not declared in the schema so validation fails.
+        let request = Request::new(
+            EntityUid::from_str(r#"Admin::"bob""#).unwrap(),
+            EntityUid::from_str(r#"Action::"View""#).unwrap(),
+            EntityUid::from_str(r#"Photo::"vacation""#).unwrap(),
+            Context::empty(),
+            None,
+        )
+        .expect("request should be constructable");
+
+        let result = RustEngine::new()
+            .validate_request(&schema, &request)
+            .expect("validate_request should return Success");
+
+        assert!(
+            !result.validation_passed(),
+            "expected a schema-invalid request to fail validation, but no errors were reported"
+        );
     }
 }


### PR DESCRIPTION
## Description of changes
Fixed issues where RustEngine::validate_request inverts success/failure semantics.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
