### PR TITLE
don't desugar extended has in cedar to json conversion

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4629,51 +4629,10 @@ mod test {
                        {
                            "kind": "when",
                            "body": {
-                               "&&": {
-                                   "left": {
-                                       "&&": {
-                                           "left": {
-                                               "has": {
-                                                   "left": {
-                                                       "Var": "principal",
-                                                   },
-                                                   "attr": "a"
-                                               }
-                                           },
-                                           "right": {
-                                               "has": {
-                                                   "left": {
-                                                       ".": {
-                                                           "left": {
-                                                               "Var": "principal",
-                                                           },
-                                                           "attr": "a",
-                                                       },
-                                                   },
-                                                   "attr": "b"
-                                               }
-                                           },
-                                       }
-                                   },
-                                   "right": {
-                                       "has": {
-                                           "left": {
-                                               ".": {
-                                                   "left": {
-                                                       ".": {
-                                                           "left": {
-                                                               "Var": "principal",
-                                                           },
-                                                           "attr": "a"
-                                                       }
-                                                   },
-                                                   "attr": "b",
-                                               }
-                                           },
-                                           "attr": "c",
-                                       }
-                                   },
-                               },
+                               "has": {
+                                   "left": { "Var": "principal" },
+                                   "attr": ["a", "b", "c"]
+                               }
                            },
                        }
                    ]

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -692,6 +692,23 @@ impl ExprBuilder for Builder {
         Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Simple { left: expr, attr }))
     }
 
+    /// `left has attr1.attr2. ...` (with an Arc)
+    fn extended_has_attr_arc(self, expr: Arc<Self::Expr>, attrs: NonEmpty<SmolStr>) -> Self::Expr {
+        // Single attribute == a simple has
+        if attrs.tail.is_empty() {
+            Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Simple {
+                left: expr,
+                attr: attrs.head,
+            }))
+        } else {
+            // Extended has form
+            Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Extended {
+                left: expr,
+                attr: attrs,
+            }))
+        }
+    }
+
     /// `left like pattern`
     fn like(self, expr: Expr, pattern: ast::Pattern) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Like {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,6 +14,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 Cedar Language Version: TBD
 
+### Changed
+
+- During conversion from Cedar to JSON, extended `has` form is preserved instead of being desugared, resulting in smaller JSON policies (#2490).
+
 ## [4.12.0] - Coming soon
 
 Cedar Language Version: 4.5

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -8353,10 +8353,10 @@ mod policy_manipulation_functions_tests {
             r#"permit(principal, action, resource) when { User::"Bob" has attr };"#,
             mapping.clone(),
         );
-        // Since there's no extended has in AST, the result of the substitution has the desugared has
+        // Extended `has` is preserved through the EST roundtrip
         assert_entity_sub(
             r#"permit(principal, action, resource) when { User::"Alice" has attr.andNested };"#,
-            r#"permit(principal, action, resource) when { (User::"Bob" has attr) && ((User::"Bob".attr) has andNested) };"#,
+            r#"permit(principal, action, resource) when { User::"Bob" has attr.andNested };"#,
             mapping.clone(),
         );
         // But staying in the EST doesn't result in desugaring
@@ -9359,15 +9359,21 @@ mod to_json {
     use crate::Policy;
 
     #[test]
-    fn extended_has_not_in_to_json() {
+    fn extended_has_in_to_json() {
         let policy_cedar =
             r#"permit(principal, action, resource) when { context has user.profile };"#;
         let policy = Policy::parse(None, policy_cedar).unwrap();
         let json = policy.to_json().unwrap();
         let json_str = json.to_string();
-        // Should not contain array form of extended has
-        assert!(!json_str.contains(r#""attr":["#));
-        assert!(!json_str.contains(r#"["user","profile","email"]"#));
+        assert!(
+            json_str.contains(r#""attr":["user","profile"]"#),
+            "expected extended has array form, got: {json_str}"
+        );
+        // Round-trips back to the same policy text
+        assert_eq!(
+            Policy::from_json(None, json).unwrap().to_string(),
+            policy.to_string()
+        );
     }
 }
 


### PR DESCRIPTION
This changes how the extended `has` in Cedar gets translated to JSON, taking advantage of the extended has in JSON. 
The API is the same but users that translate policies will see a different (more compact) output now. 

If this is accepted, we'll need to look at some DRT targets whether the can be made to check full roundtrip more tightly. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
