### PR TITLE
allow refs to action entity types in schema try_validate

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1196,7 +1196,7 @@ impl ValidatorSchema {
         for ty in self.leaf_types().unique() {
             if let Type::Entity(EntityKind::Entity(lub)) = ty {
                 for e in lub.iter() {
-                    if !self.entity_types.contains_key(e) {
+                    if !self.is_known_entity_type(e) {
                         undeclared.push(e.clone());
                     }
                 }
@@ -1749,7 +1749,7 @@ pub(crate) mod test {
     };
 
     use crate::validator::json_schema;
-    use crate::validator::types::Type;
+    use crate::validator::types::{AttributeType, Type};
 
     use crate::test_utils::{expect_err, ExpectedErrorMessageBuilder};
     use cool_asserts::assert_matches;
@@ -2370,6 +2370,31 @@ pub(crate) mod test {
             schema.try_validate(),
             Err(SchemaError::ActionEntityTypeDeclared(_))
         );
+    }
+
+    /// `check_references_wf` should accept entity attributes that reference Action entity types
+    #[test]
+    fn try_validate_accepts_action_entity_type_reference_in_attribute() {
+        let user_type = EntityType::from_normalized_str("User").unwrap();
+        let action_type = EntityType::from_normalized_str("Foo::Action").unwrap();
+
+        // User entity type has an attribute of type Entity that references Foo::Action
+        let attr_type =
+            AttributeType::required_attribute(Arc::new(Type::named_entity_reference(action_type)));
+        let schema = ValidatorSchema::new(
+            [ValidatorEntityType::new_standard(
+                user_type,
+                [],
+                Attributes::with_attributes([("last_action".into(), attr_type)]),
+                OpenTag::ClosedAttributes,
+                None,
+                None,
+            )],
+            [],
+        );
+
+        // Should succeed — Action entity types are valid references
+        assert_matches!(schema.try_validate(), Ok(_));
     }
 
     /// Regression test: enum entity types reachable only via transitive

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,6 +14,9 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 Cedar Language Version: TBD
 
+### Fixed
+- In the experimental `protobufs` feature, the `Schema::decode` function now accepts schemas that reference `Action` entity types not defined in the schema. This was previously  rejected (#2491).
+
 ## [4.12.0] - Coming soon
 
 Cedar Language Version: 4.5


### PR DESCRIPTION
The try_validate method of the ValidatorSchema was previously rejecting schemas that should be valid: schemas that references Action entity types that are not defined in the schema.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
