### PR TITLE
TPE align record/set/ext-fun evaluation

### DIFF
--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -435,12 +435,12 @@ impl Evaluator<'_> {
                 let args: Vec<_> = args.iter().map(|a| self.interpret(a)).collect();
                 // If the arguments are all concrete values, we proceed to evaluate the function call
                 if args.iter().all(Residual::is_concrete) {
-                    let vals : Vec<_> = args.iter().map(|a|{
+                    let vals : Vec<_> = args.into_iter().map(|a|{
                         #[expect(
                             clippy::unwrap_used,
                             reason = "`if` condition guarantees that all set elements are concrete, so `Value::try_from` cannot error"
                         )]
-                        Value::try_from(a.clone()).unwrap()
+                        Value::try_from(a).unwrap()
                     }).collect();
                     // Attempt to look up the extension function and apply it
                     // Failed lookup or application errors both lead to
@@ -463,12 +463,12 @@ impl Evaluator<'_> {
             ResidualKind::Set(es) => {
                 let es: Vec<_> = es.iter().map(|e| self.interpret(e)).collect();
                 if es.iter().all(Residual::is_concrete) {
-                    let vals = es.iter().map(|a|{
+                    let vals = es.into_iter().map(|a|{
                         #[expect(
                             clippy::unwrap_used,
                             reason = "`if` condition guarantees that all set elements are concrete, so `Value::try_from` cannot error"
                         )]
-                        Value::try_from(a.clone()).unwrap()
+                        Value::try_from(a).unwrap()
                     });
                     mk_concrete(Value::set(vals, None))
                 } else if es.iter().any(Residual::is_error) {
@@ -1316,8 +1316,6 @@ mod tests {
         let schema = parse_schema(
             r#"entity E { s?: String }; entity User { b: Bool }; action get appliesTo {principal: E, resource: User, context: {x: String}};"#,
         );
-        // `User::""` has known attributes while `E::"e"` omits `attrs`, marking
-        // them unknown.
         let entities = PartialEntities::from_json_value(
             serde_json::json!([
                 {

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -357,33 +357,6 @@ impl Evaluator<'_> {
                     (_, _) => binapp_residual(arg1, arg2),
                 }
             }
-            ResidualKind::ExtensionFunctionApp { fn_name, args } => {
-                let args = args.iter().map(|a| self.interpret(a)).collect::<Vec<_>>();
-                // If the arguments are all concrete values, we proceed to
-                // evaluate the function call
-                if let Ok(vals) = args
-                    .iter()
-                    .map(|a| Value::try_from(a.clone()))
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                {
-                    // Attempt to look up the extension function and apply it
-                    // Failed lookup or application errors both lead to
-                    // `Residual::Error` of appropriate types
-                    if let Ok(ext_fn) = self.extensions.func(fn_name) {
-                        if let Ok(PartialValue::Value(value)) = ext_fn.call(&vals) {
-                            return mk_concrete(normalize_ext_value(value));
-                        }
-                    }
-                    mk_error()
-                } else if args.iter().any(|r| matches!(r, Residual::Error(_))) {
-                    mk_error()
-                } else {
-                    mk_residual(ResidualKind::ExtensionFunctionApp {
-                        fn_name: fn_name.clone(),
-                        args: Arc::new(args),
-                    })
-                }
-            }
             ResidualKind::GetAttr { expr, attr } => {
                 let expr = self.interpret(expr);
                 match &expr {
@@ -458,18 +431,47 @@ impl Evaluator<'_> {
                     Residual::Error(_) => mk_error(),
                 }
             }
-            ResidualKind::Set(es) => {
-                let es = es.iter().map(|a| self.interpret(a)).collect::<Vec<_>>();
-                if let Ok(vals) = es
-                    .iter()
-                    .map(|a| Value::try_from(a.clone()))
-                    .collect::<std::result::Result<Vec<_>, _>>()
-                {
-                    mk_concrete(Value {
-                        value: ValueKind::Set(Set::new(vals)),
-                        loc: None,
+            ResidualKind::ExtensionFunctionApp { fn_name, args } => {
+                let args: Vec<_> = args.iter().map(|a| self.interpret(a)).collect();
+                // If the arguments are all concrete values, we proceed to evaluate the function call
+                if args.iter().all(Residual::is_concrete) {
+                    let vals : Vec<_> = args.iter().map(|a|{
+                        #[expect(
+                            clippy::unwrap_used,
+                            reason = "`if` condition guarantees that all set elements are concrete, so `Value::try_from` cannot error"
+                        )]
+                        Value::try_from(a.clone()).unwrap()
+                    }).collect();
+                    // Attempt to look up the extension function and apply it
+                    // Failed lookup or application errors both lead to
+                    // `Residual::Error` of appropriate types
+                    if let Ok(ext_fn) = self.extensions.func(fn_name) {
+                        if let Ok(PartialValue::Value(value)) = ext_fn.call(&vals) {
+                            return mk_concrete(normalize_ext_value(value));
+                        }
+                    }
+                    mk_error()
+                } else if args.iter().any(Residual::is_error) {
+                    mk_error()
+                } else {
+                    mk_residual(ResidualKind::ExtensionFunctionApp {
+                        fn_name: fn_name.clone(),
+                        args: Arc::new(args),
                     })
-                } else if es.iter().any(|r| matches!(r, Residual::Error(_))) {
+                }
+            }
+            ResidualKind::Set(es) => {
+                let es: Vec<_> = es.iter().map(|e| self.interpret(e)).collect();
+                if es.iter().all(Residual::is_concrete) {
+                    let vals = es.iter().map(|a|{
+                        #[expect(
+                            clippy::unwrap_used,
+                            reason = "`if` condition guarantees that all set elements are concrete, so `Value::try_from` cannot error"
+                        )]
+                        Value::try_from(a.clone()).unwrap()
+                    });
+                    mk_concrete(Value::set(vals, None))
+                } else if es.iter().any(Residual::is_error) {
                     mk_error()
                 } else {
                     mk_residual(ResidualKind::Set(Arc::new(es)))
@@ -477,28 +479,21 @@ impl Evaluator<'_> {
             }
             ResidualKind::Record(m) => {
                 let record: BTreeMap<_, _> = m
-                    .as_ref()
                     .iter()
                     .map(|(a, e)| (a.clone(), self.interpret(e)))
                     .collect();
-                if record
-                    .iter()
-                    .all(|(_, r)| matches!(r, Residual::Concrete { .. }))
-                {
+                if record.iter().all(|(_, r)| r.is_concrete()) {
                     let m = record
                         .into_iter()
                         .map(|(a, r)| {
                             #[expect(
                                 clippy::unwrap_used,
-                                reason = "`if` condition guarantees that all attributes are concrete, so `Value::try_from` cannot error"
+                                reason = "`if` condition guarantees that all attribute values are concrete, so `Value::try_from` cannot error"
                             )]
                             (a, Value::try_from(r).unwrap())
-                        }).collect::<BTreeMap<_, _>>();
-                    mk_concrete(Value {
-                        value: ValueKind::Record(Arc::new(m)),
-                        loc: None,
-                    })
-                } else if record.iter().any(|(_, r)| matches!(r, Residual::Error(_))) {
+                        });
+                    mk_concrete(Value::record(m, None))
+                } else if record.iter().any(|(_, r)| r.is_error()) {
                     mk_error()
                 } else {
                     mk_residual(ResidualKind::Record(Arc::new(record)))

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -1312,6 +1312,74 @@ mod tests {
     }
 
     #[test]
+    fn test_has_get_optional_attr() {
+        let schema = parse_schema(
+            r#"entity E { s?: String }; entity User { b: Bool }; action get appliesTo {principal: E, resource: User, context: {x: String}};"#,
+        );
+        // `User::""` has known attributes while `E::"e"` omits `attrs`, marking
+        // them unknown.
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "E", "id": "0" },
+                    "attrs": { "s": "foo" },
+                },
+                {
+                    "uid": { "type": "E", "id": "1" },
+                    "attrs": { },
+                },
+                {
+                    "uid": { "type": "E", "id": "2" },
+                },
+            ]),
+            &schema,
+        )
+        .unwrap();
+        let req = PartialRequest::new(
+            parse_partial_euid("E"),
+            r#"Action::"get""#.parse().unwrap(),
+            parse_partial_euid("User"),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal has s && principal.s == context.x"#),
+            @"(principal has s) && ((principal.s) == (context.x))"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"0" has s && E::"0".s == context.x"#),
+            @r#""foo" == (context.x)"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(resource.b && E::"0" has s) && E::"0".s == context.x"#),
+            @r#"(resource.b) && ("foo" == (context.x))"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"1" has s && E::"1".s == context.x"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(resource.b && E::"1" has s) && E::"1".s == context.x"#),
+            @"((resource.b) && false) && (error())"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"2" has s && E::"2".s == context.x"#),
+            @r#"(E::"2" has s) && ((E::"2".s) == (context.x))"#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"E::"3" has s && E::"3".s == context.x"#),
+            @r#"(E::"3" has s) && ((E::"3".s) == (context.x))"#
+        );
+    }
+
+    #[test]
     fn test_set() {
         let eval = Evaluator {
             request: &concrete_user_req(),

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -1363,6 +1363,7 @@ mod tests {
             interpret_typed_str_to_str(r#"E::"1" has s && E::"1".s == context.x"#),
             @"false"
         );
+        // Residual `resource.b` means we can't eliminate `error` expression even though it's unreachable
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(resource.b && E::"1" has s) && E::"1".s == context.x"#),
             @"((resource.b) && false) && (error())"
@@ -2015,6 +2016,12 @@ mod tests {
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"undefined".hasTag("s") && E::"undefined".getTag("s") == "bar" "#),
             @r#"E::"undefined".hasTag("s")"#
+        );
+
+        // Residual on the left prevents eliminating `error()` expression even through it's unreachable
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"User::"none_tags".hasTag("tag") && User::"none_tags".getTag("tag") == "foo" && User::"some_tags".hasTag("bogus") && User::"some_tags".getTag("bogus") == "bar" "#),
+            @r#"(((User::"none_tags".hasTag("tag")) && ((User::"none_tags".getTag("tag")) == "foo")) && false) && (error())"#
         );
     }
 

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -170,7 +170,7 @@ impl Residual {
 
 impl TryFrom<Residual> for Value {
     type Error = ();
-    /// INVARIANT: TPE evaluator assumes this function cannot error if `value` matches `Residual::Concrete { .. }`
+    /// INVARIANT: TPE evaluator assumes this function cannot error if `value.is_concrete()`
     fn try_from(value: Residual) -> std::result::Result<Self, Self::Error> {
         match value {
             Residual::Concrete { value, .. } => Ok(value),
@@ -476,6 +476,16 @@ impl Residual {
     /// If a residual is an error
     pub fn is_error(&self) -> bool {
         matches!(self, Residual::Error { .. })
+    }
+
+    /// If a residual is a concrete value
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, Residual::Concrete { .. })
+    }
+
+    /// If a residual is still partially unknown
+    pub fn is_partial(&self) -> bool {
+        matches!(self, Residual::Partial { .. })
     }
 }
 


### PR DESCRIPTION
## Description of changes

Follow up to record TPE change in #2489. Aligns set element and function argument evaluation to use the same pattern. Also move the function case next to the set and record cases to make the parallel structure more obvious 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
