### PR TITLE
Pretty expressive formatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,12 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,7 +443,7 @@ dependencies = [
  "itertools 0.15.0",
  "logos",
  "miette",
- "pretty",
+ "pretty-expressive",
  "regex",
  "smol_str",
 ]
@@ -1945,14 +1939,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty"
-version = "0.12.5"
+name = "pretty-expressive"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+checksum = "2f08d8824fb9414967ece3bf1254d988b8328c641fb4dc8e17f0372f268fcbf5"
 dependencies = [
- "arrayvec",
- "typed-arena",
- "unicode-width 0.2.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -3055,12 +3047,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/cedar-policy-cli/THIRD_PARTY_LICENSES.txt
+++ b/cedar-policy-cli/THIRD_PARTY_LICENSES.txt
@@ -18,8 +18,8 @@ Copyright (c) 2014-2022 Steven Fackler, Yuki Okushi
 Copyright (c) 2019 Yevhenii Reizner
 ** precomputed-hash
 Copyright (c) 2017 Emilio Cobos Álvarez
-** pretty
-Copyright (c) 2014 Jonathan Sterling and Darin Morrison
+** pretty-expressive
+Copyright (c) 2025 Matt Moriarity
 ** redox_syscall
 Copyright (c) 2017 Redox OS Developers
 ** redox_users
@@ -32,8 +32,6 @@ Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
 Copyright (c) 2018 Akash Kurdekar
 ** textwrap
 Copyright (c) 2016 Martin Geisler
-** typed-arena
-Copyright (c) 2018 The typed-arena developers
 ** serde-wasm-bindgen
 Copyright (c) 2019 Cloudflare, Inc.
 

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 
 [dependencies]
 cedar-policy-core = { version = "=4.12.0", path = "../cedar-policy-core" }
-pretty = "0.12.5"
+pretty-expressive = "1.0.0"
 logos = "0.16.0"
 itertools = "0.15"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-policy-formatter/README.md
+++ b/cedar-policy-formatter/README.md
@@ -1,6 +1,6 @@
 # Cedar Policy Formatter
 
-This package contains a simple formatter library for Cedar policies based on the [`pretty`](https://docs.rs/pretty/latest/pretty/index.html#) crate. We integrate it into [Cedar CLI](../cedar-policy-cli) so that you can format your Cedar policies directly. You can also use it as a library in your Cedar applications.
+This package contains a simple formatter library for Cedar policies based on the [`pretty-expressive`](https://docs.rs/pretty-expressive) crate. We integrate it into [Cedar CLI](../cedar-policy-cli) so that you can format your Cedar policies directly. You can also use it as a library in your Cedar applications.
 
 Please share your opinions about the format using a [feature request](https://github.com/cedar-policy/cedar/issues/new?assignees=&labels=pending-triage&template=feature_request.yml). And report any bugs you find using a [bug report](https://github.com/cedar-policy/cedar/issues/new?assignees=&labels=pending-triage&template=bug_report.yml).
 

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -265,35 +265,70 @@ impl Doc for Node<Option<And>> {
     }
 }
 
+/// Return whether this additive expression is a member chain containing a
+/// function call, without any surrounding arithmetic or unary operator.
+fn is_member_call_expression(expression: &Node<Option<Add>>) -> bool {
+    let Some(addition) = expression.as_inner() else {
+        return false;
+    };
+    if !addition.extended.is_empty() {
+        return false;
+    }
+    let Some(multiplication) = addition.initial.as_inner() else {
+        return false;
+    };
+    if !multiplication.extended.is_empty() {
+        return false;
+    }
+    let Some(unary) = multiplication.initial.as_inner() else {
+        return false;
+    };
+    if unary.op.is_some() {
+        return false;
+    }
+    let Some(member) = unary.item.as_inner() else {
+        return false;
+    };
+    member
+        .access
+        .iter()
+        .any(|access| matches!(access.as_inner(), Some(MemAccess::Call(_))))
+}
+
 impl Doc for Node<Option<Relation>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         match e {
-            Relation::Common { initial, extended } => {
-                match extended.as_slice() {
-                    [] => initial.to_doc(context),
-                    [(op, n)] =>
-                    // do not group due to the limitation of current design
-                    {
-                        Some(
-                            initial
-                                .to_doc(context)?
-                                .append(RcDoc::space())
-                                .append(add_comment(
-                                    RcDoc::as_string(op),
-                                    get_comment_after_end(
-                                        initial.loc.as_ref().map(|loc| loc.span),
-                                        &mut context.tokens,
-                                    )?,
-                                    RcDoc::nil(),
-                                ))
-                                .append(RcDoc::space())
-                                .append(n.to_doc(context)),
-                        )
-                    }
-                    _ => None,
+            Relation::Common { initial, extended } => match extended.as_slice() {
+                [] => initial.to_doc(context),
+                [(op, rhs)] => {
+                    // A comparison break is useful when it keeps two call
+                    // expressions intact. Offering it for every relation can
+                    // instead flatten records or long access chains merely to
+                    // place a short scalar operand on its own line.
+                    let after_operator =
+                        if is_member_call_expression(initial) && is_member_call_expression(rhs) {
+                            RcDoc::line().group().nest(context.config.indent_width)
+                        } else {
+                            RcDoc::space()
+                        };
+                    Some(
+                        initial
+                            .to_doc(context)?
+                            .append(RcDoc::space())
+                            .append(add_comment(
+                                RcDoc::as_string(op),
+                                get_comment_after_end(
+                                    initial.loc.as_ref().map(|loc| loc.span),
+                                    &mut context.tokens,
+                                )?,
+                                after_operator,
+                            ))
+                            .append(rhs.to_doc(context)),
+                    )
                 }
-            }
+                _ => None,
+            },
             Relation::Has { target, field } => Some(
                 target
                     .to_doc(context)?

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -723,6 +723,10 @@ impl Doc for Node<Option<Primary>> {
                             ))
                         })?
                         .0;
+                    // `pretty-expressive` emits indentation with the newline,
+                    // unlike `pretty`, which looked ahead to the next document.
+                    // Keep the closing newline outside the nested record body
+                    // so `}` returns to the parent indentation level.
                     RcDoc::line()
                         .append(inits)
                         .nest(context.config.indent_width)

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -17,8 +17,8 @@
 use super::utils::*;
 use super::Context;
 
+use super::pretty::RcDoc;
 use cedar_policy_core::parser::{cst::*, Node};
-use pretty::RcDoc;
 
 use super::token::Comment;
 
@@ -480,7 +480,7 @@ impl Doc for Node<Option<Unary>> {
                                     ))
                                 })
                                 .collect::<Option<Vec<RcDoc<'_>>>>()?,
-                            RcDoc::nil(),
+                            &RcDoc::nil(),
                         )
                         .append(e.item.as_inner()?.to_doc(context)?),
                     )
@@ -500,7 +500,7 @@ impl Doc for Member {
                 .append(
                     RcDoc::intersperse(
                         self.access.iter().map(|ac| ac.to_doc(context)),
-                        RcDoc::line_(),
+                        &RcDoc::line_(),
                     )
                     .nest(context.config.indent_width),
                 )
@@ -723,7 +723,11 @@ impl Doc for Node<Option<Primary>> {
                             ))
                         })?
                         .0;
-                    RcDoc::line().append(inits).append(RcDoc::line()).group()
+                    RcDoc::line()
+                        .append(inits)
+                        .nest(context.config.indent_width)
+                        .append(RcDoc::line())
+                        .group()
                 },
                 add_comment(
                     RcDoc::text("{"),
@@ -738,7 +742,7 @@ impl Doc for Node<Option<Primary>> {
                     get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 ),
-                context.config.indent_width,
+                0,
             )),
             Primary::Slot(slot) => slot.to_doc(context),
         }
@@ -888,7 +892,7 @@ impl Doc for Node<Option<Policy>> {
 
         let anno_doc = RcDoc::intersperse(
             policy.annotations.iter().map(|a| a.to_doc(context)),
-            RcDoc::nil(),
+            &RcDoc::nil(),
         );
         let eff_leading_comment = get_leading_comment_at_start(
             policy.effect.loc.as_ref().map(|loc| loc.span),
@@ -955,7 +959,7 @@ impl Doc for Node<Option<Policy>> {
         };
         let conds = &policy.conds;
         let cond_doc =
-            RcDoc::intersperse(conds.iter().map(|c| c.to_doc(context)), RcDoc::hardline());
+            RcDoc::intersperse(conds.iter().map(|c| c.to_doc(context)), &RcDoc::hardline());
         Some(
             anno_doc
                 .append(

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -146,6 +146,19 @@ mod tests {
     use std::fs;
 
     use super::*;
+    use crate::pprint::token::Token;
+
+    fn string_tokens(source: &str) -> Vec<String> {
+        get_token_stream(source)
+            .expect("valid Cedar source should tokenize")
+            .0
+            .into_iter()
+            .filter_map(|wrapped| match wrapped.token {
+                Token::Str(text) => Some(text.to_string()),
+                _ => None,
+            })
+            .collect()
+    }
 
     #[test]
     fn test_soundness_check() {
@@ -188,6 +201,21 @@ mod tests {
         permit (principal, action, resource)
         when { "b"};"#;
         soundness_check(p2, &parse_policyset(p1).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_preserve_multiline_string_source() {
+        let source = include_str!("../../tests/blank_lines.cedar");
+        let config = Config {
+            line_width: 80,
+            indent_width: 2,
+        };
+
+        let original_strings = string_tokens(source);
+        assert!(original_strings.iter().any(|text| text.contains('\n')));
+
+        let formatted = policies_str_to_pretty(source, &config).unwrap();
+        assert_eq!(string_tokens(&formatted), original_strings);
     }
 
     #[test]

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -219,6 +219,120 @@ mod tests {
     }
 
     #[test]
+    fn test_comparison_break_cost_boundaries() {
+        const SOURCE: &str = r#"permit (principal, action, resource)
+when {
+  duration("6h") <= context.now.datetime.offset(context.now.localTimeOffset).toTime()
+};
+"#;
+        const MEMBER_BROKEN: &str = r#"permit (principal, action, resource)
+when
+{
+  duration("6h") <= context.now
+    .datetime
+    .offset
+    (
+      context.now.localTimeOffset
+    )
+    .toTime
+    ()
+};
+"#;
+        const COMPARISON_BROKEN: &str = r#"permit (principal, action, resource)
+when
+{
+  duration("6h") <=
+    context.now.datetime.offset(context.now.localTimeOffset).toTime()
+};
+"#;
+        const FLAT: &str = r#"permit (principal, action, resource)
+when
+{
+  duration("6h") <= context.now.datetime.offset(context.now.localTimeOffset).toTime()
+};
+"#;
+
+        for (line_width, expected) in [
+            (68, MEMBER_BROKEN),
+            (69, COMPARISON_BROKEN),
+            (84, COMPARISON_BROKEN),
+            (85, FLAT),
+        ] {
+            let config = Config {
+                line_width,
+                indent_width: 2,
+            };
+            let formatted = policies_str_to_pretty(SOURCE, &config).unwrap();
+            assert_eq!(
+                formatted, expected,
+                "unexpected layout at width {line_width}"
+            );
+            assert_eq!(
+                policies_str_to_pretty(&formatted, &config).unwrap(),
+                expected,
+                "layout is not idempotent at width {line_width}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_comparison_breaks_before_either_operand_shape() {
+        const SOURCE: &str = r#"permit (principal, action, resource)
+when {
+  duration("6h") <= context.now.datetime.offset(context.now.localTimeOffset).toTime() &&
+  context.now.datetime.offset(context.now.localTimeOffset).toTime() <= duration("21h")
+};
+"#;
+        const EXPECTED: &str = r#"permit (principal, action, resource)
+when
+{
+  duration("6h") <=
+    context.now.datetime.offset(context.now.localTimeOffset).toTime() &&
+  context.now.datetime.offset(context.now.localTimeOffset).toTime() <=
+    duration("21h")
+};
+"#;
+        let config = Config {
+            line_width: 80,
+            indent_width: 2,
+        };
+
+        let formatted = policies_str_to_pretty(SOURCE, &config).unwrap();
+        assert_eq!(formatted, EXPECTED);
+        assert_eq!(
+            policies_str_to_pretty(&formatted, &config).unwrap(),
+            EXPECTED
+        );
+    }
+
+    #[test]
+    fn test_comparison_break_with_operator_comment() {
+        const SOURCE: &str = r#"permit(principal, action, resource) when {
+  duration("6h") <= // keep the rhs separate
+  duration("7h")
+};
+"#;
+        const EXPECTED: &str = r#"permit (principal, action, resource)
+when
+{
+  duration("6h") <= // keep the rhs separate
+  duration("7h")
+};
+"#;
+        let config = Config {
+            line_width: 80,
+            indent_width: 2,
+        };
+
+        let formatted = policies_str_to_pretty(SOURCE, &config).unwrap();
+        assert_eq!(formatted, EXPECTED);
+        assert_eq!(
+            policies_str_to_pretty(&formatted, &config).unwrap(),
+            EXPECTED
+        );
+    }
+
+    #[test]
     fn test_add_trailing_newline() {
         // The formatter should add a trailing newline.
         // This behavior isn't tested by the snapshots below because `insta`

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -105,6 +105,7 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
 }
 
 pub fn policies_str_to_pretty(ps: &str, config: &Config) -> Result<String> {
+    // `pretty-expressive::nest` accepts only unsigned indentation offsets.
     if config.indent_width < 0 {
         return Err(miette!("indent width must be non-negative"));
     }

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -30,14 +30,11 @@ use super::config::{self, Config};
 use super::doc::*;
 
 fn tree_to_pretty<T: Doc>(t: &T, context: &mut config::Context<'_, '_>) -> Result<String> {
-    let mut w = Vec::new();
     let config = context.config;
     let doc = t.to_doc(context);
     doc.ok_or_else(|| miette!("failed to produce doc"))?
-        .render(config.line_width, &mut w)
-        .map_err(|err| miette!(format!("failed to render doc: {err}")))?;
-    String::from_utf8(w)
-        .map_err(|err| miette!(format!("failed to convert rendered doc to string: {err}")))
+        .render(config.line_width)
+        .map_err(|err| miette!(format!("failed to render doc: {err}")))
 }
 
 fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
@@ -108,6 +105,9 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
 }
 
 pub fn policies_str_to_pretty(ps: &str, config: &Config) -> Result<String> {
+    if config.indent_width < 0 {
+        return Err(miette!("indent width must be non-negative"));
+    }
     let cst = parse_policies(ps).wrap_err("cannot parse input policies")?;
     let ast = cst.to_policyset().wrap_err("cannot parse input policies")?;
     let (tokens, end_of_file_comment) =
@@ -240,6 +240,20 @@ mod tests {
         assert_eq!(policies_str_to_pretty(p3, &config).unwrap(), formatted_p);
         assert_eq!(policies_str_to_pretty(p4, &config).unwrap(), formatted_p);
         assert_eq!(policies_str_to_pretty(p5, &config).unwrap(), formatted_p);
+    }
+
+    #[test]
+    fn test_reject_negative_indent_width() {
+        let config = Config {
+            line_width: 80,
+            indent_width: -1,
+        };
+
+        let error = policies_str_to_pretty("permit (principal, action, resource);", &config)
+            .expect_err("negative indentation should be rejected");
+        assert!(error
+            .to_string()
+            .contains("indent width must be non-negative"));
     }
 
     #[test]

--- a/cedar-policy-formatter/src/pprint/mod.rs
+++ b/cedar-policy-formatter/src/pprint/mod.rs
@@ -20,5 +20,6 @@ mod config;
 pub use config::*;
 mod doc;
 pub mod lexer;
+mod pretty;
 pub mod token;
 mod utils;

--- a/cedar-policy-formatter/src/pprint/pretty.rs
+++ b/cedar-policy-formatter/src/pprint/pretty.rs
@@ -1,0 +1,227 @@
+use std::marker::PhantomData;
+
+use pretty_expressive::{self, Doc};
+
+#[derive(Clone, Debug)]
+pub struct RcDoc<'src> {
+    doc: Doc,
+    contains_full: bool,
+    trailing_hardline: bool,
+    is_empty: bool,
+    source: PhantomData<&'src str>,
+}
+
+pub trait IntoRcDoc<'src> {
+    fn into_rc_doc(self) -> RcDoc<'src>;
+}
+
+impl<'src> IntoRcDoc<'src> for RcDoc<'src> {
+    fn into_rc_doc(self) -> RcDoc<'src> {
+        self
+    }
+}
+
+impl<'src> IntoRcDoc<'src> for Option<RcDoc<'src>> {
+    fn into_rc_doc(self) -> RcDoc<'src> {
+        self.unwrap_or_else(RcDoc::nil)
+    }
+}
+
+impl<'src> RcDoc<'src> {
+    fn new(doc: Doc, is_empty: bool) -> Self {
+        Self {
+            doc,
+            contains_full: false,
+            trailing_hardline: false,
+            is_empty,
+            source: PhantomData,
+        }
+    }
+
+    fn with_state(doc: Doc, contains_full: bool, trailing_hardline: bool, is_empty: bool) -> Self {
+        Self {
+            doc,
+            contains_full,
+            trailing_hardline,
+            is_empty,
+            source: PhantomData,
+        }
+    }
+
+    pub fn nil() -> Self {
+        Self::new(pretty_expressive::text(""), true)
+    }
+
+    pub fn text(text: impl Into<String>) -> Self {
+        let text = text.into();
+        if text.is_empty() {
+            return Self::nil();
+        }
+        if !text.contains('\n') {
+            return Self::new(pretty_expressive::text(text), false);
+        }
+
+        let mut lines = text.split('\n');
+        let first_line: Doc = pretty_expressive::text(lines.next().unwrap_or_default());
+        let multiline = lines.fold(first_line, |document, line| {
+            document & pretty_expressive::hard_nl() & pretty_expressive::text(line)
+        });
+        Self::new(pretty_expressive::reset(multiline), false)
+    }
+
+    pub fn as_string<T: ToString + ?Sized>(value: &T) -> Self {
+        Self::text(value.to_string())
+    }
+
+    pub fn space() -> Self {
+        Self::new(pretty_expressive::space(), false)
+    }
+
+    pub fn line() -> Self {
+        Self::new(pretty_expressive::nl(), false)
+    }
+
+    pub fn line_() -> Self {
+        Self::new(pretty_expressive::brk(), false)
+    }
+
+    pub fn hardline() -> Self {
+        Self::new(pretty_expressive::hard_nl(), false)
+    }
+
+    pub fn trailing_hardline() -> Self {
+        Self::with_state(pretty_expressive::text(""), false, true, false)
+    }
+
+    pub fn append(self, other: impl IntoRcDoc<'src>) -> Self {
+        let other = other.into_rc_doc();
+        if self.is_empty {
+            return other;
+        }
+        if other.is_empty {
+            return self;
+        }
+
+        let document = if self.trailing_hardline {
+            self.doc & pretty_expressive::hard_nl()
+        } else {
+            self.doc
+        };
+        Self::with_state(
+            document & other.doc,
+            self.contains_full || other.contains_full,
+            other.trailing_hardline,
+            false,
+        )
+    }
+
+    pub fn group(self) -> Self {
+        if self.contains_full || self.trailing_hardline {
+            self
+        } else {
+            Self::with_state(
+                pretty_expressive::group(self.doc),
+                false,
+                self.trailing_hardline,
+                self.is_empty,
+            )
+        }
+    }
+
+    pub fn nest(self, offset: isize) -> Self {
+        let Ok(offset) = usize::try_from(offset) else {
+            return Self::new(pretty_expressive::fail(), false);
+        };
+        Self::with_state(
+            pretty_expressive::nest(offset, self.doc),
+            self.contains_full,
+            self.trailing_hardline,
+            self.is_empty,
+        )
+    }
+
+    pub fn full(self) -> Self {
+        Self::with_state(
+            pretty_expressive::full(self.doc),
+            true,
+            self.trailing_hardline,
+            false,
+        )
+    }
+
+    pub fn intersperse<I, D>(documents: I, separator: &Self) -> Self
+    where
+        I: IntoIterator<Item = D>,
+        D: IntoRcDoc<'src>,
+    {
+        let mut documents = documents.into_iter().map(IntoRcDoc::into_rc_doc);
+        let Some(first) = documents.next() else {
+            return Self::nil();
+        };
+        documents.fold(first, |document, next| {
+            document.append(separator.clone()).append(next)
+        })
+    }
+
+    pub fn render(&self, line_width: usize) -> pretty_expressive::Result<String> {
+        let document = if self.trailing_hardline {
+            self.doc.clone() & pretty_expressive::hard_nl()
+        } else {
+            self.doc.clone()
+        };
+        document
+            .validate(line_width)
+            .map(|layout| layout.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RcDoc;
+
+    #[test]
+    fn full_is_preserved_by_grouping() {
+        let document = RcDoc::text("// comment")
+            .full()
+            .append(RcDoc::line())
+            .append(RcDoc::text("next"))
+            .group();
+
+        assert_eq!(document.render(80).unwrap(), "// comment\nnext");
+    }
+
+    #[test]
+    fn full_rejects_following_text() {
+        let document = RcDoc::text("// comment")
+            .full()
+            .append(RcDoc::text(" next"));
+
+        assert!(document.render(80).is_err());
+    }
+
+    #[test]
+    fn multiline_text_temporarily_resets_indentation() {
+        let document = RcDoc::hardline()
+            .append(RcDoc::text("a\n  b"))
+            .append(RcDoc::hardline())
+            .append(RcDoc::text("c"))
+            .nest(4);
+
+        assert_eq!(document.render(80).unwrap(), "\n    a\n  b\n    c");
+    }
+
+    #[test]
+    fn trailing_hardline_escapes_inner_nesting() {
+        let inner = RcDoc::text("value")
+            .append(RcDoc::space())
+            .append(RcDoc::text("// comment").full())
+            .append(RcDoc::trailing_hardline())
+            .nest(2);
+        let document = RcDoc::hardline()
+            .append(inner)
+            .append(RcDoc::text(","))
+            .nest(2);
+
+        assert_eq!(document.render(80).unwrap(), "\n  value // comment\n  ,");
+    }
+}

--- a/cedar-policy-formatter/src/pprint/pretty.rs
+++ b/cedar-policy-formatter/src/pprint/pretty.rs
@@ -1,16 +1,41 @@
+//! Compatibility layer between Cedar's existing `pretty::RcDoc`-style document
+//! builders and `pretty-expressive`.
+//!
+//! Most operations map directly, but line comments and nested trailing
+//! newlines require extra state. The old printer chose indentation by looking
+//! at the document following a newline, while `pretty-expressive` emits the
+//! current nesting indentation as soon as it renders the newline.
+
 use std::marker::PhantomData;
 
 use pretty_expressive::{self, Doc};
 
+/// A Cedar document backed by `pretty-expressive`.
+///
+/// The lifetime parameter is retained so the existing formatter document API
+/// does not need to change, even though `pretty-expressive::Doc` owns its text.
 #[derive(Clone, Debug)]
 pub struct RcDoc<'src> {
     doc: Doc,
+    // `pretty_expressive::flatten` removes `Full` nodes. Track them separately
+    // so `group` cannot select a flattened layout that places code after a
+    // line comment.
     contains_full: bool,
+    // Keep a comment's terminal newline outside the current `Doc`. This lets
+    // `nest` indent the comment body without also indenting the token that
+    // follows the comment on the next line.
     trailing_hardline: bool,
+    // `None` documents were treated as `nil` by the old API. Tracking known
+    // emptiness preserves that identity without prematurely materializing a
+    // deferred trailing hardline.
     is_empty: bool,
+    // `pretty-expressive` owns strings, but Cedar's document trait exposes this
+    // source lifetime. Retain it at the type level for API compatibility.
     source: PhantomData<&'src str>,
 }
 
+/// Convert values accepted by the old append API into a concrete document.
+/// In particular, `None` remains equivalent to `RcDoc::nil()`.
 pub trait IntoRcDoc<'src> {
     fn into_rc_doc(self) -> RcDoc<'src>;
 }
@@ -61,6 +86,9 @@ impl<'src> RcDoc<'src> {
             return Self::new(pretty_expressive::text(text), false);
         }
 
+        // `pretty_expressive::text` must contain exactly one logical line.
+        // Model embedded source newlines explicitly, and reset indentation so
+        // multiline strings and entity IDs retain their original whitespace.
         let mut lines = text.split('\n');
         let first_line: Doc = pretty_expressive::text(lines.next().unwrap_or_default());
         let multiline = lines.fold(first_line, |document, line| {
@@ -89,6 +117,10 @@ impl<'src> RcDoc<'src> {
         Self::new(pretty_expressive::hard_nl(), false)
     }
 
+    /// Create a hardline that is materialized after the current nesting scope.
+    ///
+    /// This is specifically for terminal line-comment newlines. Ordinary
+    /// structural hardlines should use `hardline()`.
     pub fn trailing_hardline() -> Self {
         Self::with_state(pretty_expressive::text(""), false, true, false)
     }
@@ -102,6 +134,10 @@ impl<'src> RcDoc<'src> {
             return self;
         }
 
+        // A deferred newline belongs between the two documents at this append
+        // boundary. Any pending newline on the right remains deferred so a
+        // later `nest` can wrap the document body without capturing its
+        // terminal break.
         let document = if self.trailing_hardline {
             self.doc & pretty_expressive::hard_nl()
         } else {
@@ -116,6 +152,10 @@ impl<'src> RcDoc<'src> {
     }
 
     pub fn group(self) -> Self {
+        // Upstream `group` is `doc | flatten(doc)`, and `flatten` currently
+        // discards `Full`. A deferred hardline is also invisible to `flatten`.
+        // In either case, retaining only the unflattened layout is necessary
+        // to keep line comments semantically terminal.
         if self.contains_full || self.trailing_hardline {
             self
         } else {
@@ -129,9 +169,15 @@ impl<'src> RcDoc<'src> {
     }
 
     pub fn nest(self, offset: isize) -> Self {
+        // The public Cedar configuration historically used a signed width,
+        // while `pretty-expressive` accepts only `usize`. The formatter entry
+        // point rejects negative values; `fail` is a defensive fallback for
+        // any future internal caller.
         let Ok(offset) = usize::try_from(offset) else {
             return Self::new(pretty_expressive::fail(), false);
         };
+        // Do not materialize `trailing_hardline` here. It must escape this nest
+        // so the next token uses its own indentation level.
         Self::with_state(
             pretty_expressive::nest(offset, self.doc),
             self.contains_full,
@@ -141,6 +187,8 @@ impl<'src> RcDoc<'src> {
     }
 
     pub fn full(self) -> Self {
+        // Preserve a separate marker because an enclosing upstream `group`
+        // would otherwise erase this constraint while flattening.
         Self::with_state(
             pretty_expressive::full(self.doc),
             true,
@@ -164,11 +212,16 @@ impl<'src> RcDoc<'src> {
     }
 
     pub fn render(&self, line_width: usize) -> pretty_expressive::Result<String> {
+        // A document ending in a comment still needs its deferred newline even
+        // when nothing is appended after it.
         let document = if self.trailing_hardline {
             self.doc.clone() & pretty_expressive::hard_nl()
         } else {
             self.doc.clone()
         };
+        // Use `validate` instead of `Doc`'s `Display` implementation so an
+        // unprintable constrained document is returned as an error, not a
+        // panic.
         document
             .validate(line_width)
             .map(|layout| layout.to_string())
@@ -212,6 +265,8 @@ mod tests {
 
     #[test]
     fn trailing_hardline_escapes_inner_nesting() {
+        // The comment body is nested by two, but its terminal newline must
+        // return to the outer two-space indentation before rendering `,`.
         let inner = RcDoc::text("value")
             .append(RcDoc::space())
             .append(RcDoc::text("// comment").full())

--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -57,6 +57,9 @@ pub fn get_trailing_comment_doc_from_str<'src>(
     next_doc: RcDoc<'src>,
 ) -> RcDoc<'src> {
     if !trailing_comment.is_empty() {
+        // `full` forbids later tokens on the comment line. The deferred
+        // hardline then ends the comment at the caller's indentation level,
+        // rather than at any temporary nest surrounding the commented token.
         RcDoc::space()
             .append(RcDoc::text(trailing_comment))
             .full()

--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -16,11 +16,10 @@
 
 use std::borrow::Borrow;
 
-use itertools::Itertools;
-use pretty::RcDoc;
-
 use crate::token::regex_constants;
+use itertools::Itertools;
 
+use super::pretty::RcDoc;
 use super::token::{Comment, WrappedToken};
 
 // Add brackets
@@ -44,12 +43,10 @@ pub fn get_leading_comment_doc_from_str<'src>(leading_comment: &[&'src str]) -> 
     }
 }
 
-/// Convert multiline text into an `RcDoc`. Both `RcDoc::as_string` and
-/// `RcDoc::text` allow newlines in the text (although the official
-/// documentation says they don't), but the resulting text will maintain its
-/// original indentation instead of the new "pretty" indentation.
+/// Convert multiline text into an `RcDoc`, preserving the original indentation
+/// of each line instead of applying the surrounding formatter indentation.
 fn create_multiline_doc<'src>(text: &[&'src str]) -> RcDoc<'src> {
-    RcDoc::intersperse(text.iter().map(|c| RcDoc::text(*c)), RcDoc::hardline())
+    RcDoc::intersperse(text.iter().map(|c| RcDoc::text(*c)), &RcDoc::hardline())
 }
 
 /// Convert a trailing comment to an `RcDoc`, adding a trailing newline.
@@ -62,7 +59,8 @@ pub fn get_trailing_comment_doc_from_str<'src>(
     if !trailing_comment.is_empty() {
         RcDoc::space()
             .append(RcDoc::text(trailing_comment))
-            .append(RcDoc::hardline())
+            .full()
+            .append(RcDoc::trailing_hardline())
     } else {
         next_doc
     }

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@blank_lines.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@blank_lines.cedar.snap
@@ -10,7 +10,8 @@ input_file: cedar-policy-formatter/tests/blank_lines.cedar
 permit (
   principal == User::"alice",
   action,
-  resource in Folder::"Name
+  resource in
+    Folder::"Name
 
 	
 with a newline"
@@ -37,7 +38,9 @@ permit (
   resource is Photo in Album::"vacation"
 )
 when
-{ (User::"alice" is User) && (User::"alice" in Group::"
+{
+  (User::"alice" is User) &&
+  (User::"alice" in Group::"
 
 
 
@@ -46,4 +49,5 @@ when
 
 
 
-friends") };
+friends")
+};


### PR DESCRIPTION
## Description of changes

## Why `pretty-expressive`?

  `pretty-expressive` is a better fit for Cedar because formatting policies involves semantic constraints, not just
  choosing whether a group fits on one line. Its `full` primitive can express that no code may follow a `//` comment on
  the same line, while `reset` preserves the original indentation of multiline strings and entity identifiers. Its cost-
  based layout selection and arbitrary alternatives also provide a foundation for improving difficult cases such as long
  attribute chains and keeping method names attached to their argument lists.

  The migration uses a small compatibility layer so Cedar’s existing document builders and formatting style remain
  largely unchanged. That layer also guards comment constraints during grouping and preserves the old printer’s newline-
  indentation behavior. As a result, Cedar gains a more expressive layout engine without coupling comment attachment to
  rendering or requiring an immediate formatter rewrite.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
