### PR TITLE
Write symcc transitivty enforcement in terms of set union/product

### DIFF
--- a/cedar-policy-symcc/src/symccopt/enforcer.rs
+++ b/cedar-policy-symcc/src/symccopt/enforcer.rs
@@ -19,42 +19,41 @@
 
 use std::collections::BTreeSet;
 
+use itertools::Itertools;
+
 use crate::symcc::{self, term::Term};
 
 use super::{CompiledPolicy, CompiledPolicySet};
 
 pub fn enforce_compiled_policy(cp: &CompiledPolicy) -> BTreeSet<Term> {
-    let tr = cp.footprint.iter().flat_map(|term1| {
-        cp.footprint
-            .iter()
-            .map(|term2| symcc::enforcer::transitivity(term1, term2, &cp.symenv.entities))
-    });
+    let tr = cp
+        .footprint
+        .iter()
+        .cartesian_product(&cp.footprint)
+        .map(|(term1, term2)| symcc::enforcer::transitivity(term1, term2, &cp.symenv.entities));
     cp.acyclicity.iter().cloned().chain(tr).collect()
 }
 
 #[expect(dead_code, reason = "exists in the Lean")]
 pub fn enforce_compiled_policyset(cpset: &CompiledPolicySet) -> BTreeSet<Term> {
-    let tr = cpset.footprint.iter().flat_map(|term1| {
-        cpset
-            .footprint
-            .iter()
-            .map(|term2| symcc::enforcer::transitivity(term1, term2, &cpset.symenv.entities))
-    });
+    let tr = cpset
+        .footprint
+        .iter()
+        .cartesian_product(&cpset.footprint)
+        .map(|(term1, term2)| symcc::enforcer::transitivity(term1, term2, &cpset.symenv.entities));
     cpset.acyclicity.iter().cloned().chain(tr).collect()
 }
 
 pub fn enforce_pair_compiled_policy(cp1: &CompiledPolicy, cp2: &CompiledPolicy) -> BTreeSet<Term> {
     assert_eq!(&cp1.symenv, &cp2.symenv);
-    let footprint = cp1.footprint.iter().chain(cp2.footprint.iter()); // since `footprint` is just an iterator, it is cheap to clone
-    let tr = footprint.clone().flat_map(|term1| {
-        footprint
-            .clone()
-            .map(|term2| symcc::enforcer::transitivity(term1, term2, &cp1.symenv.entities))
-    });
-    cp1.acyclicity
+    let footprint: Vec<_> = cp1.footprint.union(&cp2.footprint).collect();
+    let tr = footprint
         .iter()
+        .cartesian_product(&footprint)
+        .map(|(term1, term2)| symcc::enforcer::transitivity(term1, term2, &cp1.symenv.entities));
+    cp1.acyclicity
+        .union(&cp2.acyclicity)
         .cloned()
-        .chain(cp2.acyclicity.iter().cloned())
         .chain(tr)
         .collect()
 }
@@ -64,17 +63,15 @@ pub fn enforce_pair_compiled_policyset(
     cpset2: &CompiledPolicySet,
 ) -> BTreeSet<Term> {
     assert_eq!(&cpset1.symenv, &cpset2.symenv);
-    let footprint = cpset1.footprint.iter().chain(cpset2.footprint.iter()); // since `footprint` is just an iterator, it is cheap to clone
-    let tr = footprint.clone().flat_map(|term1| {
-        footprint
-            .clone()
-            .map(|term2| symcc::enforcer::transitivity(term1, term2, &cpset1.symenv.entities))
-    });
+    let footprint: Vec<_> = cpset1.footprint.union(&cpset2.footprint).collect();
+    let tr = footprint
+        .iter()
+        .cartesian_product(&footprint)
+        .map(|(term1, term2)| symcc::enforcer::transitivity(term1, term2, &cpset1.symenv.entities));
     cpset1
         .acyclicity
-        .iter()
+        .union(&cpset2.acyclicity)
         .cloned()
-        .chain(cpset2.acyclicity.iter().cloned())
         .chain(tr)
         .collect()
 }


### PR DESCRIPTION
## Description of changes

See https://github.com/cedar-policy/cedar-spec/pull/1001

After this change the Rust and Lean implementations are actually more aligned than they were originally. Lean was using `++` which was actually a set union while Rust was chaining iterators. Rust still built a set at the end so the functions behaved the same, but the implementation is now more aligned. 

There is possibly a slight performance implication here: 

Where we previously had 

```rust
let footprint = cp1.footprint.iter().chain(cp2.footprint.iter());
```

we now have

```rust
let footprint: Vec<_> = cp1.footprint.union(&cp2.footprint).collect()
```

This trades an intermediate `Vec` allocation to avoid building duplicate transitivity terms when `cp1.footprint` and `cp2.footprint` intersect. The duplicate transitivity terms were dropped when building a set later, so this doesn't impact what's sent to the solver. The lean model (now, and prior to the linked cedar-spec PR) is more similar to current `union` code. I expect that this is better in the common case of comparing two similar polices, e.g., after an edit or refactoring, where footprints will be largely the same.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
