### PR TITLE
avoid reconstructing `ActionSchemaEntries` for each action

### DIFF
--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -259,9 +259,8 @@ impl SymEntityData {
     pub(super) fn of_action_type<'a>(
         act_ty: &EntityType,
         act_tys: impl IntoIterator<Item = &'a EntityType>,
-        schema: &ValidatorSchema,
+        actions: &ActionSchemaEntries,
     ) -> Self {
-        let sch = ActionSchemaEntries::of_schema(schema);
         let attrs_udf = Udf(Arc::new(function::Udf {
             arg: entity(act_ty.clone()),
             out: TermType::Record {
@@ -292,7 +291,8 @@ impl SymEntityData {
                 arg: entity(act_ty.clone()),
                 out: TermType::set_of(entity(anc_ty.clone())),
                 table: Arc::new(
-                    sch.iter()
+                    actions
+                        .iter()
                         .filter_map(|(uid, entry)| {
                             Some((
                                 term_of_type(act_ty.clone(), uid.clone())?,
@@ -307,7 +307,7 @@ impl SymEntityData {
                 },
             }))
         };
-        let acts = sch
+        let acts = actions
             .keys()
             .filter(|uid| uid.type_name() == act_ty)
             .map(|uid| SmolStr::new(uid.id()))
@@ -361,10 +361,11 @@ impl SymEntities {
             .iter()
             .map(|act| core_entity_type_into_entity_type(act.uid().entity_type()))
             .collect();
+        let action_schema = ActionSchemaEntries::of_schema(schema);
         let a_data = act_tys.iter().map(|&act_ty| {
             Ok((
                 act_ty.clone(),
-                SymEntityData::of_action_type(act_ty, act_tys.clone(), schema),
+                SymEntityData::of_action_type(act_ty, act_tys.iter().copied(), &action_schema),
             ))
         });
         Ok(SymEntities(
@@ -521,7 +522,7 @@ impl EntitySchemaEntry {
 }
 
 // From `Validation/Types.lean`
-struct ActionSchemaEntry {
+pub(crate) struct ActionSchemaEntry {
     ancestors: BTreeSet<EntityUID>,
     // present in the Lean, but not used in SymCC
     // applies_to_principal: BTreeSet<EntityType>,
@@ -531,7 +532,7 @@ struct ActionSchemaEntry {
     // context: Attributes,
 }
 
-struct ActionSchemaEntries(BTreeMap<EntityUID, ActionSchemaEntry>);
+pub(crate) struct ActionSchemaEntries(BTreeMap<EntityUID, ActionSchemaEntry>);
 
 impl Deref for ActionSchemaEntries {
     type Target = BTreeMap<EntityUID, ActionSchemaEntry>;
@@ -542,7 +543,7 @@ impl Deref for ActionSchemaEntries {
 }
 
 impl ActionSchemaEntries {
-    fn of_schema(schema: &ValidatorSchema) -> Self {
+    pub(crate) fn of_schema(schema: &ValidatorSchema) -> Self {
         Self(
             #[expect(
                 clippy::expect_used,

--- a/cedar-policy-symcc/src/symcc/symbolizer.rs
+++ b/cedar-policy-symcc/src/symcc/symbolizer.rs
@@ -21,7 +21,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use crate::symcc::env::{EntitySchemaEntry, SymEntityData};
+use crate::symcc::env::{ActionSchemaEntries, EntitySchemaEntry, SymEntityData};
 use crate::symcc::function::{self, UnaryFunction};
 use crate::type_abbrevs::core_entity_type_into_entity_type;
 use cedar_policy::entities_errors::EntitiesError;
@@ -396,10 +396,11 @@ impl SymEntities {
             .iter()
             .map(|act| core_entity_type_into_entity_type(act.uid().entity_type()))
             .collect::<BTreeSet<_>>();
+        let action_schema = ActionSchemaEntries::of_schema(schema);
         let actions = act_tys.iter().map(|&act_ty| {
             Ok((
                 act_ty.clone(),
-                SymEntityData::of_action_type(act_ty, act_tys.clone(), schema),
+                SymEntityData::of_action_type(act_ty, act_tys.iter().copied(), &action_schema),
             ))
         });
 


### PR DESCRIPTION
## Description of changes

`ActionSchemaEntries::of_schema` exists to convert a `Schema` into a structure that's closer to what Lean uses. It builds a `BTreeMap` of all actions in the schema which can be reused across multiple downstream calls. 

The function doesn't exist directly in the Lean, so no model changes required. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
