### PR TITLE
Reduce paren usage in expr printer

### DIFF
--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1661,7 +1661,7 @@ fn test_tpe() {
         contains("UNKNOWN")
             .and(contains("permit(principal, action, resource) when { resource.isPublic };"))
             .and(contains("permit(principal, action, resource) when { false };"))
-            .and(contains(r#"permit(principal, action, resource) when { (context.hasMFA) && ((resource.owner) == User::"Alice") };"#))
+            .and(contains(r#"permit(principal, action, resource) when { context.hasMFA && (resource.owner == User::"Alice") };"#))
     };
 
     cargo::cargo_bin_cmd!("cedar")
@@ -1779,7 +1779,7 @@ when {{ resource.isPublic }};"#
         .assert()
         .stdout(
             predicate::str::contains("UNKNOWN").and(predicate::str::contains(
-                r#"permit(principal, action, resource) when { (principal == User::"Alice") && (resource.isPublic) };"#
+                r#"permit(principal, action, resource) when { (principal == User::"Alice") && resource.isPublic };"#
             )),
         )
         .code(4);

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1698,27 +1698,52 @@ impl BoundedDisplay for ExprNoExt {
                 maybe_with_parens(f, right, n)
             }
             ExprNoExt::And { left, right } => {
-                maybe_with_parens(f, left, n)?;
+                // Left-associative, so we can omit parens on left operand if it's another `&&`
+                if matches!(left.as_ref(), Expr::ExprNoExt(ExprNoExt::And { .. })) {
+                    BoundedDisplay::fmt(left.as_ref(), f, n)
+                } else {
+                    maybe_with_parens(f, left, n)
+                }?;
                 write!(f, " && ")?;
                 maybe_with_parens(f, right, n)
             }
             ExprNoExt::Or { left, right } => {
-                maybe_with_parens(f, left, n)?;
+                // Left-associative, so we can omit parens on left operand if it's another `||`
+                if matches!(left.as_ref(), Expr::ExprNoExt(ExprNoExt::Or { .. })) {
+                    BoundedDisplay::fmt(left.as_ref(), f, n)
+                } else {
+                    maybe_with_parens(f, left, n)
+                }?;
                 write!(f, " || ")?;
                 maybe_with_parens(f, right, n)
             }
             ExprNoExt::Add { left, right } => {
-                maybe_with_parens(f, left, n)?;
+                // Left-associative, so we can omit parens on left operand if it's another `+`
+                if matches!(left.as_ref(), Expr::ExprNoExt(ExprNoExt::Add { .. })) {
+                    BoundedDisplay::fmt(left.as_ref(), f, n)
+                } else {
+                    maybe_with_parens(f, left, n)
+                }?;
                 write!(f, " + ")?;
                 maybe_with_parens(f, right, n)
             }
             ExprNoExt::Sub { left, right } => {
-                maybe_with_parens(f, left, n)?;
+                // Left-associative, so we can omit parens on left operand if it's another `-`
+                if matches!(left.as_ref(), Expr::ExprNoExt(ExprNoExt::Sub { .. })) {
+                    BoundedDisplay::fmt(left.as_ref(), f, n)
+                } else {
+                    maybe_with_parens(f, left, n)
+                }?;
                 write!(f, " - ")?;
                 maybe_with_parens(f, right, n)
             }
             ExprNoExt::Mul { left, right } => {
-                maybe_with_parens(f, left, n)?;
+                // Left-associative, so we can omit parens on left operand if it's another `*`
+                if matches!(left.as_ref(), Expr::ExprNoExt(ExprNoExt::Mul { .. })) {
+                    BoundedDisplay::fmt(left.as_ref(), f, n)
+                } else {
+                    maybe_with_parens(f, left, n)
+                }?;
                 write!(f, " * ")?;
                 maybe_with_parens(f, right, n)
             }
@@ -1810,12 +1835,13 @@ impl BoundedDisplay for ExprNoExt {
                 then_expr,
                 else_expr,
             } => {
+                // All three operands are `Expr` in the grammar, so they never need parens
                 write!(f, "if ")?;
-                maybe_with_parens(f, cond_expr, n)?;
+                BoundedDisplay::fmt(cond_expr.as_ref(), f, n)?;
                 write!(f, " then ")?;
-                maybe_with_parens(f, then_expr, n)?;
+                BoundedDisplay::fmt(then_expr.as_ref(), f, n)?;
                 write!(f, " else ")?;
-                maybe_with_parens(f, else_expr, n)
+                BoundedDisplay::fmt(else_expr.as_ref(), f, n)
             }
             ExprNoExt::Set(v) => {
                 match n {
@@ -1933,7 +1959,17 @@ fn maybe_with_parens(
         Expr::ExprNoExt(ExprNoExt::Record(_)) |
         Expr::ExprNoExt(ExprNoExt::Value(_)) |
         Expr::ExprNoExt(ExprNoExt::Var(_)) |
-        Expr::ExprNoExt(ExprNoExt::Slot(_)) => BoundedDisplay::fmt(expr, f, n),
+        Expr::ExprNoExt(ExprNoExt::Slot(_)) |
+        // Everything below prints at the grammar's `Member := Primary MemAccess*`
+        // which has the tightest associativity.
+        Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Contains { .. }) |
+        Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) |
+        Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) |
+        Expr::ExprNoExt(ExprNoExt::IsEmpty { .. }) |
+        Expr::ExprNoExt(ExprNoExt::GetTag { .. }) |
+        Expr::ExprNoExt(ExprNoExt::HasTag { .. }) |
+        Expr::ExtFuncCall { .. } => BoundedDisplay::fmt(expr, f, n),
 
         // we want parens here because things like parse((!x).y)
         // would be printed into !x.y which has a different meaning
@@ -1953,18 +1989,10 @@ fn maybe_with_parens(
         Expr::ExprNoExt(ExprNoExt::Add { .. }) |
         Expr::ExprNoExt(ExprNoExt::Sub { .. }) |
         Expr::ExprNoExt(ExprNoExt::Mul { .. }) |
-        Expr::ExprNoExt(ExprNoExt::Contains { .. }) |
-        Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) |
-        Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) |
-        Expr::ExprNoExt(ExprNoExt::IsEmpty { .. }) |
-        Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) |
         Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) |
-        Expr::ExprNoExt(ExprNoExt::GetTag { .. }) |
-        Expr::ExprNoExt(ExprNoExt::HasTag { .. }) |
         Expr::ExprNoExt(ExprNoExt::Like { .. }) |
         Expr::ExprNoExt(ExprNoExt::Is { .. }) |
-        Expr::ExprNoExt(ExprNoExt::If { .. }) |
-        Expr::ExtFuncCall { .. } => {
+        Expr::ExprNoExt(ExprNoExt::If { .. }) => {
             write!(f, "(")?;
             BoundedDisplay::fmt(expr, f, n)?;
             write!(f, ")")?;
@@ -2115,7 +2143,7 @@ mod test {
             .into_expr::<Builder>();
         assert_eq!(
             format!("{expr}"),
-            r#"if (context has "if") then false else true"#
+            r#"if context has "if" then false else true"#
         );
 
         let expr = parse_expr(r#"context has "has""#)
@@ -2128,7 +2156,7 @@ mod test {
             .into_expr::<Builder>();
         assert_eq!(
             format!("{expr}"),
-            r#"if (context has "foo-baz") then false else true"#
+            r#"if context has "foo-baz" then false else true"#
         );
     }
 
@@ -2558,5 +2586,97 @@ mod test {
             )]),
         });
         assert_eq!(expr.height(), 2);
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::panic, reason = "unit test code")]
+mod paren_omission {
+    use super::*;
+    use crate::parser::text_to_cst;
+    use insta::assert_snapshot;
+
+    #[track_caller]
+    fn render(text: &str) -> String {
+        let cst =
+            text_to_cst::parse_expr(text).unwrap_or_else(|e| panic!("cannot parse {text:?}: {e}"));
+        let est =
+            Expr::try_from(&cst).unwrap_or_else(|e| panic!("cannot build EST for {text:?}: {e}"));
+        let printed = est.to_string();
+        let cst = text_to_cst::parse_expr(&printed)
+            .unwrap_or_else(|e| panic!("printed form {printed:?} does not parse: {e}"));
+        let reparsed = Expr::try_from(&cst)
+            .unwrap_or_else(|e| panic!("printed form {printed:?} is not a valid EST: {e}"));
+        assert_eq!(
+            reparsed, est,
+            "printed form {printed:?} reparsed to a different EST"
+        );
+        printed
+    }
+
+    #[test]
+    fn member_level_operands() {
+        assert_snapshot!(render("(((context.a).b).c).d"), @"context.a.b.c.d");
+        assert_snapshot!(render("(context.a.contains(1)).bar"), @"context.a.contains(1).bar");
+        assert_snapshot!(render(r#"(ip("1.2.3.4")).foo"#), @r#"ip("1.2.3.4").foo"#);
+        assert_snapshot!(render(r#"(context.a["b c"]).d"#), @r#"context.a["b c"].d"#);
+        assert_snapshot!(render("(context.a.b) == (context.c.d)"), @"context.a.b == context.c.d");
+        assert_snapshot!(
+            render("principal is X::Y in (context.a.b)"),
+            @"principal is X::Y in context.a.b"
+        );
+        assert_snapshot!(render("!(context.a.b)"), @"!context.a.b");
+    }
+
+    #[test]
+    fn if_operands() {
+        assert_snapshot!(render("if (context.a == 1) then (2) else (3)"), @"if context.a == 1 then 2 else 3");
+        assert_snapshot!(
+            render("if context.a then (if context.b then 1 else 2) else (if context.c then 3 else 4)"),
+            @"if context.a then if context.b then 1 else 2 else if context.c then 3 else 4"
+        );
+        assert_snapshot!(
+            render("if (if (if true then true else true) then true else true) then 1 else 2"),
+            @"if if if true then true else true then true else true then 1 else 2"
+        );
+    }
+
+    #[test]
+    fn chained_operators() {
+        assert_snapshot!(
+            render("(context.a && context.b) && context.c"),
+            @"context.a && context.b && context.c"
+        );
+        assert_snapshot!(
+            render("(context.a || context.b) || context.c"),
+            @"context.a || context.b || context.c"
+        );
+        assert_snapshot!(render("(1 + 2) + 3"), @"1 + 2 + 3");
+        assert_snapshot!(render("(1 - 2) - 3"), @"1 - 2 - 3");
+        assert_snapshot!(render("(2 * 3) * 4"), @"2 * 3 * 4");
+        assert_snapshot!(render("(1 - 2) + 3"), @"(1 - 2) + 3");
+        assert_snapshot!(
+            render("(context.a && context.b) || context.c"),
+            @"(context.a && context.b) || context.c"
+        );
+    }
+
+    #[test]
+    fn right_operands_keep_parens() {
+        assert_snapshot!(render("1 + (2 + 3)"), @"1 + (2 + 3)");
+        assert_snapshot!(render("1 - (2 - 3)"), @"1 - (2 - 3)");
+        assert_snapshot!(
+            render("context.a && (context.b && context.c)"),
+            @"context.a && (context.b && context.c)"
+        );
+    }
+
+    #[test]
+    fn looser_operands_keep_parens() {
+        assert_snapshot!(render("(!principal).y"), @"(!principal).y");
+        assert_snapshot!(render("(-principal).y"), @"(-(principal)).y");
+        assert_snapshot!(render("(1 == 2) == true"), @"(1 == 2) == true");
+        assert_snapshot!(render("(if true then 1 else 2) + 3"), @"(if true then 1 else 2) + 3");
+        assert_snapshot!(render("(true || false) && true"), @"(true || false) && true");
     }
 }

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -1881,7 +1881,7 @@ mod tests {
             );
             assert_eq!(
                 complex.to_string(),
-                "if ((principal.age) > 18) then (principal.name) else \"unknown\""
+                "if principal.age > 18 then principal.name else \"unknown\""
             );
 
             // isEmpty

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -776,7 +776,7 @@ mod tests {
         // "<non-error-free> && false" cannot be fully simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.num + 1 == 100 && 41 == 42"),
-            @r#"(((User::"foo".num) + 1) == 100) && false"#
+            @r#"((User::"foo".num + 1) == 100) && false"#
         );
         // "<residual> && <nonbool>" => "<residual> && <error>"
         assert_snapshot!(
@@ -784,17 +784,17 @@ mod tests {
                 builder().get_attr(builder().var(Var::Principal), "foo".into()),
                 builder().val(42),
             )),
-            @r#"(User::"foo".foo) && (error())"#
+            @r#"User::"foo".foo && error()"#
         );
         // The "<residual> && <residual>" case cannot be simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.foo && principal.num == 100"),
-            @r#"(User::"foo".foo) && ((User::"foo".num) == 100)"#
+            @r#"User::"foo".foo && (User::"foo".num == 100)"#
         );
         // "<residual> && <error>" cannot be simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.foo && (9223372036854775807 * 2 == 0)"),
-            @r#"(User::"foo".foo) && (error())"#
+            @r#"User::"foo".foo && error()"#
         );
         // "<error> && <any>" => "<error>"
         assert_snapshot!(
@@ -848,7 +848,7 @@ mod tests {
         // "<non-error-free> || true" cannot be fully simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.num + 1 == 100 || 42 == 42"),
-            @r#"(((User::"foo".num) + 1) == 100) || true"#
+            @r#"((User::"foo".num + 1) == 100) || true"#
         );
         // "<residual> || <nonbool>" => "<residual> || <error>"
         assert_snapshot!(
@@ -856,17 +856,17 @@ mod tests {
                 builder().get_attr(builder().var(Var::Principal), "foo".into()),
                 builder().val(42),
             )),
-            @r#"(User::"foo".foo) || (error())"#
+            @r#"User::"foo".foo || error()"#
         );
         // The "<residual> || <residual>" case cannot be simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.foo || principal.num == 100"),
-            @r#"(User::"foo".foo) || ((User::"foo".num) == 100)"#
+            @r#"User::"foo".foo || (User::"foo".num == 100)"#
         );
         // "<residual> || <error>" cannot be simplified
         assert_snapshot!(
             interpret_typed_str_to_str("principal.foo || (9223372036854775807 * 2 == 0)"),
-            @r#"(User::"foo".foo) || (error())"#
+            @r#"User::"foo".foo || error()"#
         );
         // "<error> || <any>" => "<error>"
         assert_snapshot!(
@@ -893,7 +893,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"if (resource == User::"alice") then Document::"A" else Document::"B""#),
-            @r#"if (resource == User::"alice") then Document::"B" else Document::"B""#
+            @r#"if resource == User::"alice" then Document::"B" else Document::"B""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(&r#"if (9223372036854775807 * 2) == 0 then resource else Document::"A""#),
@@ -955,11 +955,11 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str("principal.baz is E"),
-            @"(principal.baz) is E"
+            @"principal.baz is E"
         );
         assert_snapshot!(
             interpret_typed_str_to_str("principal.baz is Document"),
-            @"(principal.baz) is Document"
+            @"principal.baz is Document"
         );
         assert_snapshot!(
             interpret_typed_str_to_str("User::\"alice\" is User"),
@@ -1005,11 +1005,11 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.s like "*""#),
-            @r#"(principal.s) like "*""#
+            @r#"principal.s like "*""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.s like "b*""#),
-            @r#"(principal.s) like "b*""#
+            @r#"principal.s like "b*""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then "a" else "b") like "b*""#),
@@ -1058,11 +1058,11 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"!(principal.b)"#),
-            @"!(principal.b)"
+            @"!principal.b"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"!!(principal.b)"#),
-            @"!(!(principal.b))"
+            @"!(!principal.b)"
         );
     }
 
@@ -1104,7 +1104,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.s.isEmpty()"#),
-            @"(resource.s).isEmpty()"
+            @"resource.s.isEmpty()"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(if (9223372036854775807 * 2 == 0) then [1] else [2]).isEmpty()"#),
@@ -1217,11 +1217,11 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.e.e.e.s"#),
-            @r#"((E::"x".e).e).s"#
+            @r#"E::"x".e.e.s"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.e.s"#),
-            @"(resource.e).s"
+            @"resource.e.s"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"loop".e"#),
@@ -1349,15 +1349,15 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal has s && principal.s == context.x"#),
-            @"(principal has s) && ((principal.s) == (context.x))"
+            @"(principal has s) && (principal.s == context.x)"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"0" has s && E::"0".s == context.x"#),
-            @r#""foo" == (context.x)"#
+            @r#""foo" == context.x"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(resource.b && E::"0" has s) && E::"0".s == context.x"#),
-            @r#"(resource.b) && ("foo" == (context.x))"#
+            @r#"resource.b && ("foo" == context.x)"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"1" has s && E::"1".s == context.x"#),
@@ -1366,15 +1366,15 @@ mod tests {
         // Residual `resource.b` means we can't eliminate `error` expression even though it's unreachable
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(resource.b && E::"1" has s) && E::"1".s == context.x"#),
-            @"((resource.b) && false) && (error())"
+            @"resource.b && false && error()"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"2" has s && E::"2".s == context.x"#),
-            @r#"(E::"2" has s) && ((E::"2".s) == (context.x))"#
+            @r#"(E::"2" has s) && (E::"2".s == context.x)"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"3" has s && E::"3".s == context.x"#),
-            @r#"(E::"3" has s) && ((E::"3".s) == (context.x))"#
+            @r#"(E::"3" has s) && (E::"3".s == context.x)"#
         );
     }
 
@@ -1513,7 +1513,7 @@ mod tests {
         // cases to preserve semantics, should often be possible.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"{e: if principal == User::"alice" then 9223372036854775807*2 else 0, l: 0}.l"#),
-            @r#"{e: if (principal == User::"alice") then (error()) else 0, l: 0}.l"#
+            @r#"{e: if principal == User::"alice" then error() else 0, l: 0}.l"#
         );
         // But it should be possible in other cases
         assert_snapshot!(
@@ -1599,7 +1599,7 @@ mod tests {
         // Mixing a known and an unknown attribute leaves a partial residual.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.metadata.m0.data + resource.metadata.m1.data"#),
-            @r#"42 + (M1::"m1".data)"#
+            @r#"42 + M1::"m1".data"#
         );
     }
 
@@ -1793,7 +1793,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"resource_child" in context.e"#),
-            @r#"E::"resource_child" in (context.e)"#
+            @r#"E::"resource_child" in context.e"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"resource_child" in [context.e]"#),
@@ -1801,7 +1801,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"context.e in E::"resource""#),
-            @r#"(context.e) in E::"resource""#
+            @r#"context.e in E::"resource""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"undefined" in resource"#),
@@ -1988,15 +1988,15 @@ mod tests {
         // Unknown cases
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.hasTag("s") && principal.getTag("s") == "bar" "#),
-            @r#"(principal.hasTag("s")) && ((principal.getTag("s")) == "bar")"#
+            @r#"principal.hasTag("s") && (principal.getTag("s") == "bar")"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"none_tags".hasTag("s") && User::"none_tags".getTag("s") == "bar" "#),
-            @r#"(User::"none_tags".hasTag("s")) && ((User::"none_tags".getTag("s")) == "bar")"#
+            @r#"User::"none_tags".hasTag("s") && (User::"none_tags".getTag("s") == "bar")"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"undefined".hasTag("s") && User::"undefined".getTag("s") == "bar" "#),
-            @r#"(User::"undefined".hasTag("s")) && ((User::"undefined".getTag("s")) == "bar")"#
+            @r#"User::"undefined".hasTag("s") && (User::"undefined".getTag("s") == "bar")"#
         );
 
         // `E` entities can't have tags, but `hasTag` is still well-typed. These could all reduce to
@@ -2021,7 +2021,7 @@ mod tests {
         // Residual on the left prevents eliminating `error()` expression even through it's unreachable
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"none_tags".hasTag("tag") && User::"none_tags".getTag("tag") == "foo" && User::"some_tags".hasTag("bogus") && User::"some_tags".getTag("bogus") == "bar" "#),
-            @r#"(((User::"none_tags".hasTag("tag")) && ((User::"none_tags".getTag("tag")) == "foo")) && false) && (error())"#
+            @r#"User::"none_tags".hasTag("tag") && (User::"none_tags".getTag("tag") == "foo") && false && error()"#
         );
     }
 
@@ -2037,11 +2037,11 @@ mod tests {
 
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.hasTag(context.tag) && principal.getTag(context.tag) == "bar" "#),
-            @r#"(principal.hasTag(context.tag)) && ((principal.getTag(context.tag)) == "bar")"#
+            @r#"principal.hasTag(context.tag) && (principal.getTag(context.tag) == "bar")"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"some_tags".hasTag(context.tag) && User::"some_tags".getTag(context.tag) == "bar" "#),
-            @r#"(User::"some_tags".hasTag(context.tag)) && ((User::"some_tags".getTag(context.tag)) == "bar")"#
+            @r#"User::"some_tags".hasTag(context.tag) && (User::"some_tags".getTag(context.tag) == "bar")"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"empty_tags".hasTag(context.tag) && E::"empty_tags".getTag(context.tag) == "bar" "#),
@@ -2086,7 +2086,7 @@ mod tests {
 
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"rec".hasTag("k") && User::"other".hasTag("k") && User::"rec".getTag("k") == User::"other".getTag("k")"#),
-            @r#"(User::"other".hasTag("k")) && ({inner: {n: 1}, s: "bar"} == (User::"other".getTag("k")))"#
+            @r#"User::"other".hasTag("k") && ({inner: {n: 1}, s: "bar"} == User::"other".getTag("k"))"#
         );
     }
 
@@ -2137,11 +2137,11 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"ent".hasTag("unk") && User::"ent".getTag("unk").data == 42"#),
-            @r#"(E::"unk".data) == 42"#
+            @r#"E::"unk".data == 42"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal.hasTag("k") && principal.getTag("k").data == 42"#),
-            @r#"(principal.hasTag("k")) && (((principal.getTag("k")).data) == 42)"#
+            @r#"principal.hasTag("k") && (principal.getTag("k").data == 42)"#
         );
     }
 
@@ -2190,7 +2190,7 @@ mod tests {
         // originated from.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"datetime("6640-02-11")"#),
-            @r#"(datetime("1970-01-01")).offset(duration("147374467200000ms"))"#
+            @r#"datetime("1970-01-01").offset(duration("147374467200000ms"))"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"decimal("0.0")"#),
@@ -2247,7 +2247,7 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.dt"#),
-            @r#"(datetime("1970-01-01")).offset(duration("1790812800000ms"))"#
+            @r#"datetime("1970-01-01").offset(duration("1790812800000ms"))"#
         );
     }
 
@@ -2290,7 +2290,7 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.rec"#),
-            @r#"{dt: (datetime("1970-01-01")).offset(duration("1790812800000ms"))}"#
+            @r#"{dt: datetime("1970-01-01").offset(duration("1790812800000ms"))}"#
         );
     }
 
@@ -2333,7 +2333,7 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.s"#),
-            @r#"[(datetime("1970-01-01")).offset(duration("86400000ms")), (datetime("1970-01-01")).offset(duration("1790812800000ms"))]"#
+            @r#"[datetime("1970-01-01").offset(duration("86400000ms")), datetime("1970-01-01").offset(duration("1790812800000ms"))]"#
         );
     }
 
@@ -2378,7 +2378,7 @@ mod tests {
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
             interpret_typed_str_to_str(r#"resource.rec"#),
-            @r#"{a: 1, dt: (datetime("1970-01-01")).offset(duration("1790812800000ms")), z: 2}"#
+            @r#"{a: 1, dt: datetime("1970-01-01").offset(duration("1790812800000ms")), z: 2}"#
         );
     }
 }

--- a/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
@@ -266,7 +266,7 @@ fn non_idempotent() {
 
     assert_matches!(typechecker.typecheck_by_single_request_env(&template, &req_env), PolicyCheck::Success(transformed) => {
         // after typechecking, the policy is transformed into this:
-        assert_eq!(transformed.to_string(), r#"true && ((action in [Action::"action"]) && ((resource is a) && (((true && (if (if (if true then true else true) then (if true then true else true) else (if true then true else true)) then (a::"".hasTag(if true then "" else "")) else (a::"".hasTag(if true then "" else "")))) && (if (a::"".hasTag(if true then "" else "")) then (if (if true then true else true) then (if true then true else true) else (if true then true else true)) else (principal in a::""))) && (a::"".hasTag("")))))"#);
+        assert_eq!(transformed.to_string(), r#"true && ((action in [Action::"action"]) && ((resource is a) && (true && (if if if true then true else true then if true then true else true else if true then true else true then a::"".hasTag(if true then "" else "") else a::"".hasTag(if true then "" else "")) && (if a::"".hasTag(if true then "" else "") then if if true then true else true then if true then true else true else if true then true else true else principal in a::"") && a::"".hasTag(""))))"#);
         // in particular, note that it still contains the `principal in a::""` term
         assert!(transformed.to_string().contains(r#"principal in a::"""#));
 
@@ -279,7 +279,7 @@ fn non_idempotent() {
         );
         assert_matches!(typechecker.typecheck_by_single_request_env(&transformed.template(), &req_env), PolicyCheck::Success(retransformed) => {
             // after re-typechecking, the policy is transformed into this:
-            assert_eq!(retransformed.to_string(), r#"true && (true && (true && (true && ((action in [Action::"action"]) && ((resource is a) && (((true && (if (if (if true then true else true) then (if true then true else true) else (if true then true else true)) then (a::"".hasTag(if true then "" else "")) else (a::"".hasTag(if true then "" else "")))) && (if (a::"".hasTag(if true then "" else "")) then (if (if true then true else true) then (if true then true else true) else (if true then true else true)) else (if (if true then true else true) then (if true then true else true) else (if true then true else true)))) && (a::"".hasTag(""))))))))"#);
+            assert_eq!(retransformed.to_string(), r#"true && (true && (true && (true && ((action in [Action::"action"]) && ((resource is a) && (true && (if if if true then true else true then if true then true else true else if true then true else true then a::"".hasTag(if true then "" else "") else a::"".hasTag(if true then "" else "")) && (if a::"".hasTag(if true then "" else "") then if if true then true else true then if true then true else true else if true then true else true else if if true then true else true then if true then true else true else if true then true else true) && a::"".hasTag("")))))))"#);
             // in particular, note that it no longer contains the `principal in a::""` term
             assert!(!retransformed.to_string().contains(r#"principal in a::"""#));
         });

--- a/cedar-policy-symcc/src/symcc/term.rs
+++ b/cedar-policy-symcc/src/symcc/term.rs
@@ -358,25 +358,25 @@ mod test {
         let term = Term::from(Ext::parse_datetime("2001-07-07").unwrap());
         insta::with_settings!({ description => format!("{term:?}") }, {
             // TODO: not pretty
-            insta::assert_snapshot!(term.to_string(), @r#"(datetime("1970-01-01")).offset(duration("994464000000ms"))"#);
+            insta::assert_snapshot!(term.to_string(), @r#"datetime("1970-01-01").offset(duration("994464000000ms"))"#);
         });
 
         let term = Term::from(Ext::parse_datetime("2010-12-31T11:59:59Z").unwrap());
         insta::with_settings!({ description => format!("{term:?}") }, {
             // TODO: not pretty
-            insta::assert_snapshot!(term.to_string(), @r#"(datetime("1970-01-01")).offset(duration("1293796799000ms"))"#);
+            insta::assert_snapshot!(term.to_string(), @r#"datetime("1970-01-01").offset(duration("1293796799000ms"))"#);
         });
 
         let term = Term::from(Ext::parse_datetime("2010-12-31T11:59:59.777Z").unwrap());
         insta::with_settings!({ description => format!("{term:?}") }, {
             // TODO: not pretty
-            insta::assert_snapshot!(term.to_string(), @r#"(datetime("1970-01-01")).offset(duration("1293796799777ms"))"#);
+            insta::assert_snapshot!(term.to_string(), @r#"datetime("1970-01-01").offset(duration("1293796799777ms"))"#);
         });
 
         let term = Term::from(Ext::parse_datetime("2010-12-31T11:59:59.777+1134").unwrap());
         insta::with_settings!({ description => format!("{term:?}") }, {
             // TODO: not pretty
-            insta::assert_snapshot!(term.to_string(), @r#"(datetime("1970-01-01")).offset(duration("1293755159777ms"))"#);
+            insta::assert_snapshot!(term.to_string(), @r#"datetime("1970-01-01").offset(duration("1293755159777ms"))"#);
         });
 
         let term = Term::Some(Arc::new(factory::set_of(

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -6411,7 +6411,7 @@ mod issue_611 {
         let src = r#"{"effect":"permit","principal":{"op":"All"},"action":{"op":"All"},"resource":{"op":"All"},"conditions":[{"kind":"when","body":{"==":{"left":{".":{"left":{"Var":"principal"},"attr":"x"}},"right":{"Value":-9223372036854775808}}}}]}"#;
         let v: serde_json::Value = serde_json::from_str(src).unwrap();
         let p = Policy::from_json(None, v).unwrap();
-        insta::assert_snapshot!(p, @"permit(principal, action, resource) when { (principal.x) == (-9223372036854775808) };");
+        insta::assert_snapshot!(p, @"permit(principal, action, resource) when { principal.x == (-9223372036854775808) };");
     }
 
     #[test]
@@ -6419,7 +6419,7 @@ mod issue_611 {
         let src = r#"{"effect":"permit","principal":{"op":"All"},"action":{"op":"All"},"resource":{"op":"All"},"conditions":[{"kind":"when","body":{"==":{"left":{".":{"left":{"Var":"principal"},"attr":"x"}},"right":{"Value":9223372036854775807}}}}]}"#;
         let v: serde_json::Value = serde_json::from_str(src).unwrap();
         let p = Policy::from_json(None, v).unwrap();
-        insta::assert_snapshot!(p, @"permit(principal, action, resource) when { (principal.x) == 9223372036854775807 };");
+        insta::assert_snapshot!(p, @"permit(principal, action, resource) when { principal.x == 9223372036854775807 };");
     }
 
     #[test]
@@ -8356,7 +8356,7 @@ mod policy_manipulation_functions_tests {
         // Since there's no extended has in AST, the result of the substitution has the desugared has
         assert_entity_sub(
             r#"permit(principal, action, resource) when { User::"Alice" has attr.andNested };"#,
-            r#"permit(principal, action, resource) when { (User::"Bob" has attr) && ((User::"Bob".attr) has andNested) };"#,
+            r#"permit(principal, action, resource) when { (User::"Bob" has attr) && (User::"Bob".attr has andNested) };"#,
             mapping.clone(),
         );
         // But staying in the EST doesn't result in desugaring


### PR DESCRIPTION
Avoid printing parenthesis where associativity is obvious. 

* left-chains of the same operation do not need parenthesis
* `if then else` doesn't need parenthesis the expression
*  method-call/attribute-access do not need parenthesis

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
