### PR TITLE
Updated schema validation for protobuf when no actions are defined

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1934,8 +1934,6 @@ mod test {
     use smol_str::ToSmolStr;
     use std::collections::{hash_map::DefaultHasher, HashSet};
 
-    use crate::expr_builder::ExprBuilder as _;
-
     use super::*;
 
     pub fn all_vars() -> impl Iterator<Item = Var> {

--- a/cedar-policy-core/src/validator/rbac.rs
+++ b/cedar-policy-core/src/validator/rbac.rs
@@ -886,6 +886,42 @@ mod test {
         assert_eq!(notes.len(), 1, "{notes:?}");
     }
 
+    /// A policy referencing an action under the bare `Action` type, when the
+    /// only declared action lives under a namespaced `NS::Action` type, must
+    /// report only the `UnrecognizedActionId` error. In particular the bare
+    /// `Action` type must not additionally be flagged as an
+    /// `UnrecognizedEntityType`: action-typed references in policies are
+    /// validated by `validate_action_ids`, not `validate_entity_types`.
+    #[test]
+    fn validate_action_id_wrong_namespace_reports_only_unrecognized_action() {
+        let descriptors = json_schema::Fragment::from_json_str(
+            r#"
+                {
+                    "NS": {
+                        "entityTypes": {},
+                        "actions": { "foo": {} }
+                    }
+                }"#,
+        )
+        .expect("Expected schema parse.");
+        let schema = descriptors.try_into().unwrap();
+
+        let src = r#"permit(principal, action == Action::"foo", resource);"#;
+        let policy = parse_policy_or_template(None, src).unwrap();
+        let validate = Validator::new(schema);
+        let notes: Vec<ValidationError> =
+            Validator::validate_entity_types_and_literals(validate.schema(), &policy).collect();
+
+        assert_eq!(notes.len(), 1, "{notes:?}");
+        assert!(
+            matches!(
+                notes.first().unwrap(),
+                ValidationError::UnrecognizedActionId(_)
+            ),
+            "expected only an UnrecognizedActionId error, got {notes:?}"
+        );
+    }
+
     #[test]
     fn validate_namespaced_entity_type_in_schema() {
         let descriptors = json_schema::Fragment::from_json_str(

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -2421,9 +2421,8 @@ pub(crate) mod test {
 
         // User has an attribute referencing Foo::Action, and an action of type
         // Foo::Action is declared.
-        let attr_type = AttributeType::required_attribute(Arc::new(Type::named_entity_reference(
-            action_type,
-        )));
+        let attr_type =
+            AttributeType::required_attribute(Arc::new(Type::named_entity_reference(action_type)));
         let context = Type::record_with_required_attributes([], OpenTag::ClosedAttributes);
         let schema = ValidatorSchema::new(
             [ValidatorEntityType::new_standard(
@@ -2434,7 +2433,14 @@ pub(crate) mod test {
                 None,
                 None,
             )],
-            [ValidatorActionId::new(action_uid, [], [], [], context, None)],
+            [ValidatorActionId::new(
+                action_uid,
+                [],
+                [],
+                [],
+                context,
+                None,
+            )],
         );
 
         assert_matches!(schema.try_validate(), Ok(_));

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1017,7 +1017,10 @@ impl ValidatorSchema {
         self.action_ids.contains_key(action_id)
     }
 
-    /// Return true when the `entity_type` corresponds to a valid entity type.
+    /// Return true when the `entity_type` corresponds to a valid entity type. Note that
+    /// unlike Schema validation which reports an error if the action entity
+    /// type is not inhabited i.e. no action is defined in the corresponding namespace,
+    /// this accepts any action type.
     pub(crate) fn is_known_entity_type(&self, entity_type: &EntityType) -> bool {
         entity_type.is_action() || self.entity_types.contains_key(entity_type)
     }
@@ -1196,6 +1199,11 @@ impl ValidatorSchema {
         // each action defined in a namespace (the action type lives in the same namespace).
         // If no action is defined, the Action type is uninhabited, in which case we reject
         // the schema as not well formed -- consistent with the Cedar schema parsers.
+        //
+        // Note: we cannot use `is_known_entity_type` here because it treats *any*
+        // action-typed name as known (action references in policies are validated
+        // separately, by `validate_action_ids`). Here we need the stricter notion
+        // that an action type is only inhabited when a matching action is declared.
         let action_entity_types: HashSet<&EntityType> = self
             .action_ids
             .keys()

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -2446,8 +2446,7 @@ pub(crate) mod test {
         assert_matches!(schema.try_validate(), Ok(_));
     }
 
-    /// Regression test for the `protobuf-decode-bytes-schema` fuzz failure
-    /// (nightly 2026-08-09): a schema like `namespace gz { entity sX tags Action; }` has an
+    /// A schema like `namespace gz { entity sX tags Action; }` has an
     /// uninhabited `Action` tag type with no declared action, so it must be rejected (see
     /// `check_references_wf`).
     #[test]

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1192,11 +1192,20 @@ impl ValidatorSchema {
 
     /// Check that all entity types referenced in attribute/tag/context types are declared
     fn check_references_wf(&self) -> std::result::Result<(), SchemaError> {
+        // Attributes and tags can reference Action entity types. We add an action type for
+        // each action defined in a namespace (the action type lives in the same namespace).
+        // If no action is defined, the Action type is uninhabited, in which case we reject
+        // the schema as not well formed -- consistent with the Cedar schema parsers.
+        let action_entity_types: HashSet<&EntityType> = self
+            .action_ids
+            .keys()
+            .map(|uid| uid.entity_type())
+            .collect();
         let mut undeclared = Vec::new();
         for ty in self.leaf_types().unique() {
             if let Type::Entity(EntityKind::Entity(lub)) = ty {
                 for e in lub.iter() {
-                    if !self.is_known_entity_type(e) {
+                    if !self.entity_types.contains_key(e) && !action_entity_types.contains(e) {
                         undeclared.push(e.clone());
                     }
                 }
@@ -2372,13 +2381,15 @@ pub(crate) mod test {
         );
     }
 
-    /// `check_references_wf` should accept entity attributes that reference Action entity types
+    /// An `Action` reference with no declared action is uninhabited, so `try_validate`
+    /// must reject it (see `check_references_wf`).
     #[test]
-    fn try_validate_accepts_action_entity_type_reference_in_attribute() {
+    fn try_validate_rejects_namespaced_action_attribute_without_action() {
         let user_type = EntityType::from_normalized_str("User").unwrap();
         let action_type = EntityType::from_normalized_str("Foo::Action").unwrap();
 
-        // User entity type has an attribute of type Entity that references Foo::Action
+        // User entity type has an attribute of type Entity that references Foo::Action,
+        // but no action of type Foo::Action is declared.
         let attr_type =
             AttributeType::required_attribute(Arc::new(Type::named_entity_reference(action_type)));
         let schema = ValidatorSchema::new(
@@ -2393,8 +2404,98 @@ pub(crate) mod test {
             [],
         );
 
-        // Should succeed — Action entity types are valid references
+        assert_matches!(
+            schema.try_validate(),
+            Err(SchemaError::UndeclaredEntityTypes(_))
+        );
+    }
+
+    /// Conversely, an `Action` reference is accepted when a matching action is declared
+    /// (the action adds its type to the namespace; see `check_references_wf`).
+    #[test]
+    fn try_validate_accepts_namespaced_action_attribute_with_action() {
+        let user_type = EntityType::from_normalized_str("User").unwrap();
+        let action_type = EntityType::from_normalized_str("Foo::Action").unwrap();
+        let action_uid =
+            EntityUID::from_components(action_type.clone(), crate::ast::Eid::new("a"), None);
+
+        // User has an attribute referencing Foo::Action, and an action of type
+        // Foo::Action is declared.
+        let attr_type = AttributeType::required_attribute(Arc::new(Type::named_entity_reference(
+            action_type,
+        )));
+        let context = Type::record_with_required_attributes([], OpenTag::ClosedAttributes);
+        let schema = ValidatorSchema::new(
+            [ValidatorEntityType::new_standard(
+                user_type,
+                [],
+                Attributes::with_attributes([("last_action".into(), attr_type)]),
+                OpenTag::ClosedAttributes,
+                None,
+                None,
+            )],
+            [ValidatorActionId::new(action_uid, [], [], [], context, None)],
+        );
+
         assert_matches!(schema.try_validate(), Ok(_));
+    }
+
+    /// Regression test for the `protobuf-decode-bytes-schema` fuzz failure
+    /// (nightly 2026-08-09): a schema like `namespace gz { entity sX tags Action; }` has an
+    /// uninhabited `Action` tag type with no declared action, so it must be rejected (see
+    /// `check_references_wf`).
+    #[test]
+    fn try_validate_rejects_bare_action_tag_without_action() {
+        let entity_type = EntityType::from_normalized_str("gz::sX").unwrap();
+        let action_type = EntityType::from_normalized_str("Action").unwrap();
+
+        // Entity has a tag of type Entity that references the bare `Action` type,
+        // but no action is declared anywhere in the schema.
+        let schema = ValidatorSchema::new(
+            [ValidatorEntityType::new_standard(
+                entity_type,
+                [],
+                Attributes::with_attributes([]),
+                OpenTag::ClosedAttributes,
+                Some(Type::named_entity_reference(action_type)),
+                None,
+            )],
+            [],
+        );
+
+        assert_matches!(
+            schema.try_validate(),
+            Err(SchemaError::UndeclaredEntityTypes(_))
+        );
+    }
+
+    /// An attribute referencing a bare `Action` type with no declared action is
+    /// uninhabited, so it must be rejected (see `check_references_wf`).
+    #[test]
+    fn try_validate_rejects_bare_action_attribute_without_action() {
+        let user_type = EntityType::from_normalized_str("User").unwrap();
+        let action_type = EntityType::from_normalized_str("Action").unwrap();
+
+        // User has an attribute referencing the bare `Action` type, but no action
+        // is declared anywhere in the schema.
+        let attr_type =
+            AttributeType::required_attribute(Arc::new(Type::named_entity_reference(action_type)));
+        let schema = ValidatorSchema::new(
+            [ValidatorEntityType::new_standard(
+                user_type,
+                [],
+                Attributes::with_attributes([("last_action".into(), attr_type)]),
+                OpenTag::ClosedAttributes,
+                None,
+                None,
+            )],
+            [],
+        );
+
+        assert_matches!(
+            schema.try_validate(),
+            Err(SchemaError::UndeclaredEntityTypes(_))
+        );
     }
 
     /// Regression test: enum entity types reachable only via transitive


### PR DESCRIPTION
## Description of changes
Updated schema validation in protobuf to report an error if the Action type is uninhabited i.e. if not actions are defined.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
