### PR TITLE
Add missing `some_of` in non-opt symcc compiler

### DIFF
--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -305,8 +305,8 @@ pub fn compile_has_attr(t: Term, a: &Attr, es: &SymEntities) -> Result<Term> {
     match attrs.type_of() {
         TermType::Record { rty } => match rty.get(a) {
             Some(ty) if ty.is_option_type() => Ok(some_of(is_some(record_get(attrs, a)))),
-            Some(_) => Ok(true.into()),
-            None => Ok(false.into()),
+            Some(_) => Ok(some_of(true.into())),
+            None => Ok(some_of(false.into())),
         },
         _ => Err(CompileError::TypeError),
     }


### PR DESCRIPTION
## Description of changes

The non-optimized symbolic compiler did not apply `some_of` on terms returned by `compile_has_attr` where the Lean model and the optimized compiler do. As far as I can tell, there is no observable difference in behavior here, I think because the result is always passed to `factory::if_some` which is written to return `Option<T>` given either an `T` or `Option<T>` kind of term in its second argument.

See Lean model here:

https://github.com/cedar-policy/cedar-spec/blob/a3f2accb100fa49ac1347c1c436fa57eb32bd464/cedar-lean/Cedar/SymCC/Compiler.lean#L139-L140

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
