### PR TITLE
adding missing cautions of public re-exports

### DIFF
--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -20,6 +20,10 @@ use miette::Diagnostic;
 use thiserror::Error;
 
 /// Errors in serializing, deserializing, and processing of Entities
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Diagnostic, Error)]
 pub enum EntitiesError {
     /// Error occurring in serialization of entities
@@ -63,11 +67,15 @@ impl From<transitive_closure::TcError<EntityUID>> for EntitiesError {
     }
 }
 
+/// Errors occurring while computing or enforcing transitive closure on the
+/// entity hierarchy.
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error(transparent)]
 #[diagnostic(transparent)]
-/// Errors occurring while computing or enforcing transitive closure on the
-/// entity hierarchy.
 pub struct TransitiveClosureError {
     err: Box<transitive_closure::TcError<EntityUID>>,
 }
@@ -85,9 +93,13 @@ impl From<transitive_closure::TcError<EntityUID>> for TransitiveClosureError {
     }
 }
 
+/// Error type for entity sets containing duplicate entity uids
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, PartialEq, Eq, Error, Diagnostic)]
 #[error("duplicate entity entry `{}`", .euid)]
-/// Error type for entity sets containing duplicate entity uids
 pub struct Duplicate {
     /// The [`EntityUID`] that was duplicated
     pub(crate) euid: EntityUID,

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -247,10 +247,14 @@ impl JsonDeserializationError {
     }
 }
 
+/// General error for type mismatches
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("{ctx}, {err}")]
 #[diagnostic(forward(err))]
-/// General error for type mismatches
 pub struct TypeMismatch {
     /// Context of this error, which will be something other than `EntityAttribute`.
     /// (Type mismatches in entity attributes are reported as
@@ -260,9 +264,13 @@ pub struct TypeMismatch {
     err: TypeMismatchError,
 }
 
+/// Error type for a record missing a required attr
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("{}, expected the record to have an attribute `{}`, but it does not", .ctx, .record_attr)]
-/// Error type for a record missing a required attr
 pub struct MissingRequiredRecordAttr {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,
@@ -270,9 +278,13 @@ pub struct MissingRequiredRecordAttr {
     record_attr: SmolStr,
 }
 
+/// Error type for record attributes that should not exist
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Diagnostic, Error)]
 #[error("{}, record attribute `{}` should not exist according to the schema", .ctx, .record_attr)]
-/// Error type for record attributes that should not exist
 pub struct UnexpectedRecordAttr {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,
@@ -280,9 +292,13 @@ pub struct UnexpectedRecordAttr {
     record_attr: SmolStr,
 }
 
+/// Error type for records having duplicate keys
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("{}, duplicate key `{}` in record", .ctx, .key)]
-/// Error type for records having duplicate keys
 pub struct DuplicateKey {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,
@@ -290,10 +306,14 @@ pub struct DuplicateKey {
     key: SmolStr,
 }
 
+/// Error type for missing extension constructors
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("{}, missing extension constructor for {}", .ctx, .return_type)]
 #[diagnostic(help("expected a value of type {} because of the schema", .return_type))]
-/// Error type for missing extension constructors
 pub struct MissingImpliedConstructor {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,
@@ -313,10 +333,14 @@ pub struct IncorrectNumOfArguments {
     func_name: SmolStr,
 }
 
+/// Error type for action  parents not having type `Action`
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("action `{}` has a non-action parent `{}`", .uid, .parent)]
 #[diagnostic(help("parents of actions need to have type `Action` themselves, perhaps namespaced"))]
-/// Error type for action  parents not having type `Action`
 pub struct ActionParentIsNotAction {
     /// Action entity that had the invalid parent
     uid: EntityUID,
@@ -324,6 +348,11 @@ pub struct ActionParentIsNotAction {
     parent: EntityUID,
 }
 
+/// Error type for incorrect escaping
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("failed to parse escape `{kind}`: {value}, errors: {errs}")]
 #[diagnostic(
@@ -333,7 +362,6 @@ pub struct ActionParentIsNotAction {
     }),
     forward(errs)
 )]
-/// Error type for incorrect escaping
 pub struct ParseEscape {
     /// Escape kind
     kind: EscapeKind,
@@ -356,10 +384,14 @@ pub struct ExpectedLiteralEntityRef {
     got: Box<Either<serde_json::Value, Expr>>,
 }
 
+/// Error type for getting any expression other than en extesion value
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("{}, expected an extension value, but got `{}`", .ctx, display_json_value(.got.as_ref()))]
 #[diagnostic(help(r#"extension values can be made with `{{ "fn": "SomeFn", "id": "SomeId" }}`"#))]
-/// Error type for getting any expression other than en extesion value
 pub struct ExpectedExtnValue {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,


### PR DESCRIPTION
Adding 'CAUTION: this type is publicly exported` on relevant types in cedar-policy-core. 
I also moved the comments above the derive macros where I had to make changes.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
