### PR TITLE
Upgrade tsify version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,6 @@ updates:
     allow:
       - dependency-type: "all"
     ignore:
-      # Due to a build error when updating from tsify 0.4.5, we are skipping the
-      # next release (0.5.5). Issue #1744 tracks an eventual upgrade to this
-      # version or a later version.
-      - dependency-name: "tsify"
-        versions: ["0.5.5"]
       # Due to an issue with cross-compilation in lalrpop 0.23.0, we are ignoring this version.
       # Issue #2209 tracks an eventual upgrade to a later version.
       - dependency-name: "lalrpop"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-utils"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
 dependencies = [
  "js-sys",
  "serde",
@@ -2496,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3139,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "tsify"
-version = "0.4.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+checksum = "ea3af6b48c5c5624f7eb3c2f578d1335fadac433321980cae0063e8eb0acaa44"
 dependencies = [
  "gloo-utils",
  "serde",
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "tsify-macros"
-version = "0.4.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -34,8 +34,7 @@ dashmap = { version = "6.2.1", optional = true}
 
 # Dependencies needed only for WASM integration
 serde-wasm-bindgen = { version = "0.6", optional = true }
-# Intentionally not updated to 0.5.5, see issue #1744
-tsify = { version = "0.4.5", optional = true }
+tsify = { version = "0.5.8", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 
 [dev-dependencies]

--- a/cedar-language-server/src/policy/types.rs
+++ b/cedar-language-server/src/policy/types.rs
@@ -57,7 +57,6 @@ pub(crate) mod context;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyLanguageFeatures {
     pub allow_templates: bool,
     pub allow_multiple_policies: bool,

--- a/cedar-language-server/src/schema.rs
+++ b/cedar-language-server/src/schema.rs
@@ -38,7 +38,6 @@ extern crate tsify;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaType {
     CedarSchema,
     Json,
@@ -46,7 +45,6 @@ pub enum SchemaType {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SchemaInfo {
     pub schema_type: SchemaType,
     pub text: String,

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -35,8 +35,7 @@ linked_hash_set = "0.1.6"
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
-# Intentionally not updated to 0.5.5, see issue #1744
-tsify = { version = "0.4.5", optional = true }
+tsify = { version = "0.5.8", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 
 # datetime extension requires chrono

--- a/cedar-policy-core/src/ast/annotation.rs
+++ b/cedar-policy-core/src/ast/annotation.rs
@@ -105,7 +105,6 @@ impl From<BTreeMap<AnyId, Annotation>> for Annotations {
 #[educe(Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Annotation {
     /// Annotation value
     pub val: SmolStr,

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1867,7 +1867,6 @@ impl<T> Expr<T> {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Var {
     /// the Principal of the given request
     Principal,

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -120,7 +120,6 @@ impl FromNormalizedStr for Id {
 /// An `Id` that is not equal to `__cedar`, as specified by RFC 52
 #[derive(Serialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct UnreservedId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] pub(crate) Id);
 
 impl From<UnreservedId> for Id {
@@ -295,7 +294,6 @@ impl<'a> arbitrary::Arbitrary<'a> for UnreservedId {
 // For now, internally, `AnyId`s are just owned `SmolString`s.
 #[derive(Serialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AnyId(SmolStr);
 
 impl AnyId {

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1948,7 +1948,6 @@ impl arbitrary::Arbitrary<'_> for PolicyID {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Effect {
     /// this is a Permit policy
     Permit,

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -696,7 +696,6 @@ impl Response {
 /// Decision returned from the `Authorizer`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub enum Decision {
     /// The `Authorizer` determined that the request should be allowed

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -42,7 +42,6 @@ extern crate tsify;
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityJson {
     /// UID of the entity, specified in any form accepted by `EntityUidJson`
     uid: EntityUidJson,

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -74,7 +74,6 @@ enum RawCedarValueJson {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum CedarValueJson {
     /// The `__expr` escape has been removed, but is still reserved in order to throw meaningful errors.
     ExprEscape {
@@ -273,7 +272,6 @@ impl JsonRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct TypeAndId {
     /// Entity typename
     #[cfg_attr(feature = "wasm", tsify(type = "string"))]
@@ -319,7 +317,6 @@ impl TryFrom<TypeAndId> for EntityUID {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(untagged)]
 pub enum FnAndArgs {
     /// Single-argument function
@@ -971,7 +968,6 @@ impl DeserializationContext for NoStaticContext {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum EntityUidJson<Context = NoStaticContext> {
     /// This was removed in 3.0 and is only here for generating nice error messages.
     ExplicitExprEscape {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -53,8 +53,8 @@ extern crate tsify;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(feature = "wasm", serde(rename = "PolicyJson"))]
+#[cfg_attr(feature = "wasm", tsify(rename = "PolicyJson"))]
 pub struct Policy {
     /// `Effect` of the policy or template
     pub(crate) effect: ast::Effect,
@@ -78,7 +78,6 @@ pub struct Policy {
 #[serde(tag = "kind", content = "body")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Clause {
     /// A `when` clause
     When(Expr),

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -40,7 +40,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Expr {
     /// Any Cedar expression other than an extension function call.
     ExprNoExt(ExprNoExt),
@@ -115,7 +114,6 @@ impl<'de> Deserialize<'de> for Expr {
 /// Represent an element of a pattern literal
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PatternElem {
     /// The wildcard asterisk
     Wildcard,
@@ -160,7 +158,6 @@ impl From<crate::ast::Pattern> for Vec<PatternElem> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi,))]
 pub enum HasAttrRepr {
     /// Simple has test with a single attribute :
     /// { "has": { "left": ..., "attr": <string>}}
@@ -186,7 +183,6 @@ pub enum HasAttrRepr {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ExprNoExt {
     /// Literal value (including anything that's legal to express in the
     /// attribute-value JSON format)
@@ -414,7 +410,6 @@ pub enum ExprNoExt {
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ExtFuncCall {
     /// maps the name of the function to a JSON list/array of the arguments.
     /// Note that for method calls, the method receiver is the first argument.

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -37,7 +37,6 @@ extern crate tsify;
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PrincipalConstraint {
     /// No constraint (e.g., `principal,`)
     #[serde(alias = "all")]
@@ -58,7 +57,6 @@ pub enum PrincipalConstraint {
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ActionConstraint {
     /// No constraint (i.e., `action,`)
     #[serde(alias = "all")]
@@ -80,7 +78,6 @@ pub enum ActionConstraint {
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ResourceConstraint {
     /// No constraint (e.g., `resource,`)
     #[serde(alias = "all")]
@@ -100,7 +97,6 @@ pub enum ResourceConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum EqConstraint {
     /// `==` a literal entity
     Entity {
@@ -120,7 +116,6 @@ pub enum EqConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PrincipalOrResourceInConstraint {
     /// `in` a literal entity
     Entity {
@@ -140,7 +135,6 @@ pub enum PrincipalOrResourceInConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PrincipalOrResourceIsConstraint {
     #[cfg_attr(feature = "wasm", tsify(type = "string"))]
     entity_type: SmolStr,
@@ -170,7 +164,6 @@ impl PrincipalOrResourceIsConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ActionInConstraint {
     /// Single entity
     Single {

--- a/cedar-policy-core/src/validator/json_schema.rs
+++ b/cedar-policy-core/src/validator/json_schema.rs
@@ -98,8 +98,8 @@ pub struct CommonType<N> {
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(feature = "wasm", serde(rename = "SchemaJson"))]
+#[cfg_attr(feature = "wasm", tsify(rename = "SchemaJson"))]
 pub struct Fragment<N>(
     #[serde(deserialize_with = "deserialize_schema_fragment")]
     #[cfg_attr(
@@ -304,7 +304,6 @@ impl Fragment<InternalName> {
 #[derive(Educe, Debug, Clone, Serialize)]
 #[educe(PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct CommonTypeId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] UnreservedId);
 
 impl From<CommonTypeId> for UnreservedId {
@@ -421,7 +420,6 @@ pub struct ReservedCommonTypeBasenameError {
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct NamespaceDefinition<N> {
     #[serde(default)]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
@@ -592,7 +590,6 @@ impl NamespaceDefinition<InternalName> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum EntityTypeKind<N> {
     /// The standard entity type specified by [`StandardEntityType`]
     Standard(StandardEntityType<N>),
@@ -733,7 +730,6 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for EntityType<N
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct StandardEntityType<N> {
     /// Entities of this [`StandardEntityType`] are allowed to be members of entities of
     /// these types.
@@ -850,7 +846,6 @@ impl EntityType<ConditionalName> {
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AttributesOrContext<N>(
     // We use the usual `Type` deserialization, but it will ultimately need to
     // be a `Record` or common-type reference which resolves to a `Record`.
@@ -935,7 +930,6 @@ impl AttributesOrContext<ConditionalName> {
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionType<N> {
     /// Vestigial attributes left in place to avoid any possibly breaking change
     /// to schema parsing. Providing anything other than `None` will result in an error.
@@ -1042,7 +1036,6 @@ impl ActionType<ConditionalName> {
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ApplySpec<N> {
     /// Resource types that are valid for the action
     pub resource_types: Vec<N>,
@@ -1110,7 +1103,6 @@ impl ApplySpec<ConditionalName> {
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionEntityUID<N> {
     /// Represents the [`crate::ast::Eid`] of the action
     pub id: SmolStr,
@@ -1348,7 +1340,6 @@ impl From<EntityUID> for ActionEntityUID<Name> {
 // captures the name of the unrecognized tag.
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Type<N> {
     /// One of the standard types exposed to users.
     ///
@@ -2081,7 +2072,6 @@ impl<N> From<TypeVariant<N>> for Type<N> {
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct RecordType<N> {
     /// Attribute names and types for the record
     pub attributes: BTreeMap<SmolStr, TypeOfAttribute<N>>,
@@ -2158,7 +2148,6 @@ impl RecordType<ConditionalName> {
 #[serde(tag = "type")]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum TypeVariant<N> {
     /// String
     String,

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -28,8 +28,7 @@ linked-hash-map = { version = "0.5.6", features = ["serde_impl"] }
 linked_hash_set = "0.1.6"
 
 # wasm dependencies
-# Intentionally not updated to 0.5.5, see issue #1744
-tsify = { version = "0.4.5", optional = true }
+tsify = { version = "0.5.8", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 semver = "1.0.28"
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1467,7 +1467,6 @@ impl From<authorizer::Response> for Response {
 /// Used to select how a policy will be validated.
 #[derive(Default, Eq, PartialEq, Copy, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum ValidationMode {

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -357,7 +357,6 @@ impl From<ast::EntityUID> for EntityUid {
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord, Serialize, Deserialize, RefCast)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] ast::PolicyID);
 
 #[doc(hidden)] // because this converts to a private/internal type
@@ -418,7 +417,6 @@ impl From<PolicyId> for pst::PolicyID {
 #[repr(transparent)]
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash, RefCast, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SlotId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] ast::SlotId);
 
 #[doc(hidden)] // because this converts to a private/internal type

--- a/cedar-policy/src/ffi/check_parse.rs
+++ b/cedar-policy/src/ffi/check_parse.rs
@@ -25,13 +25,28 @@
 use super::{utils::DetailedError, Context, Entities, EntityUid, PolicySet, Schema};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{Ts, Tsify as _};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
 /// Check whether a policy set successfully parses.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "checkParsePolicySet"))]
+///
+/// # Errors
+///
+/// Throws if `policies` does not match the `PolicySet` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "checkParsePolicySet")]
+pub fn check_parse_policy_set_wasm(
+    policies: Ts<PolicySet>,
+) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(check_parse_policy_set(policies.to_rust()?).into_ts()?)
+}
+
+/// Check whether a policy set successfully parses.
 pub fn check_parse_policy_set(policies: PolicySet) -> CheckParseAnswer {
     policies.parse().into()
 }
@@ -64,7 +79,18 @@ pub fn check_parse_policy_set_json_str(json: &str) -> Result<String, serde_json:
 }
 
 /// Check whether a schema successfully parses.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "checkParseSchema"))]
+///
+/// # Errors
+///
+/// Throws if `schema` does not match the `Schema` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "checkParseSchema")]
+pub fn check_parse_schema_wasm(schema: Ts<Schema>) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(check_parse_schema(schema.to_rust()?).into_ts()?)
+}
+
+/// Check whether a schema successfully parses.
 pub fn check_parse_schema(schema: Schema) -> CheckParseAnswer {
     schema.parse().into()
 }
@@ -160,7 +186,20 @@ pub fn check_parse_scope_variables_json(
 }
 
 /// Check whether a set of entities successfully parses.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "checkParseEntities"))]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `EntitiesParsingCall` type, or if the
+/// answer cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "checkParseEntities")]
+pub fn check_parse_entities_wasm(
+    call: Ts<EntitiesParsingCall>,
+) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(check_parse_entities(call.to_rust()?).into_ts()?)
+}
+
+/// Check whether a set of entities successfully parses.
 pub fn check_parse_entities(call: EntitiesParsingCall) -> CheckParseAnswer {
     let schema = match call.schema.map(|s| s.parse().map(|res| res.0)).transpose() {
         Ok(schema) => schema,
@@ -202,7 +241,20 @@ pub fn check_parse_entities_json_str(json: &str) -> Result<String, serde_json::E
 }
 
 /// Check whether a context successfully parses.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "checkParseContext"))]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `ContextParsingCall` type, or if the
+/// answer cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "checkParseContext")]
+pub fn check_parse_context_wasm(
+    call: Ts<ContextParsingCall>,
+) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(check_parse_context(call.to_rust()?).into_ts()?)
+}
+
+/// Check whether a context successfully parses.
 pub fn check_parse_context(call: ContextParsingCall) -> CheckParseAnswer {
     let action = match call.action.map(|a| a.parse(Some("action"))).transpose() {
         Ok(action) => action,
@@ -269,7 +321,6 @@ pub fn check_parse_context_json_str(json: &str) -> Result<String, serde_json::Er
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum CheckParseAnswer {
     /// Successfully parsed
     Success,
@@ -305,7 +356,6 @@ impl<T> From<Result<T, Vec<miette::Report>>> for CheckParseAnswer {
 /// Struct containing the input data for [`check_parse_entities()`]
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct EntitiesParsingCall {
@@ -332,7 +382,6 @@ pub struct ScopeVariablesParsingCall {
 /// Struct containing the input data for [`check_parse_context()`]
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ContextParsingCall {

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -24,14 +24,29 @@ use crate::api::{PolicySet, StringifiedPolicySet};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{Ts, Tsify as _};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
 /// Takes a `PolicySet` represented as string and return the policies
 /// and templates split into vecs and sorted by id.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
+///
+/// # Errors
+///
+/// Throws if the answer cannot be serialized to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "policySetTextToParts")]
+pub fn policy_set_text_to_parts_wasm(
+    policyset_str: &str,
+) -> Result<Ts<PolicySetTextToPartsAnswer>, JsError> {
+    Ok(policy_set_text_to_parts(policyset_str).into_ts()?)
+}
+
+/// Takes a `PolicySet` represented as string and return the policies
+/// and templates split into vecs and sorted by id.
 pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {
     let parsed_ps: Result<PolicySet, _> = PolicySet::from_str(policyset_str);
     match parsed_ps {
@@ -63,7 +78,18 @@ pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnsw
 }
 
 /// Return the Cedar (textual) representation of a policy.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policyToText"))]
+///
+/// # Errors
+///
+/// Throws if `policy` does not match the `Policy` type, or if the answer cannot
+/// be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "policyToText")]
+pub fn policy_to_text_wasm(policy: Ts<Policy>) -> Result<Ts<PolicyToTextAnswer>, JsError> {
+    Ok(policy_to_text(policy.to_rust()?).into_ts()?)
+}
+
+/// Return the Cedar (textual) representation of a policy.
 pub fn policy_to_text(policy: Policy) -> PolicyToTextAnswer {
     match policy.parse(None) {
         Ok(policy) => PolicyToTextAnswer::Success {
@@ -76,7 +102,18 @@ pub fn policy_to_text(policy: Policy) -> PolicyToTextAnswer {
 }
 
 /// Return the Cedar (textual) representation of a template.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "templateToText"))]
+///
+/// # Errors
+///
+/// Throws if `template` does not match the `Template` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "templateToText")]
+pub fn template_to_text_wasm(template: Ts<Template>) -> Result<Ts<PolicyToTextAnswer>, JsError> {
+    Ok(template_to_text(template.to_rust()?).into_ts()?)
+}
+
+/// Return the Cedar (textual) representation of a template.
 pub fn template_to_text(template: Template) -> PolicyToTextAnswer {
     match template.parse(None) {
         Ok(template) => PolicyToTextAnswer::Success {
@@ -89,7 +126,18 @@ pub fn template_to_text(template: Template) -> PolicyToTextAnswer {
 }
 
 /// Return the JSON representation of a policy.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policyToJson"))]
+///
+/// # Errors
+///
+/// Throws if `policy` does not match the `Policy` type, or if the answer cannot
+/// be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "policyToJson")]
+pub fn policy_to_json_wasm(policy: Ts<Policy>) -> Result<Ts<PolicyToJsonAnswer>, JsError> {
+    Ok(policy_to_json(policy.to_rust()?).into_ts()?)
+}
+
+/// Return the JSON representation of a policy.
 pub fn policy_to_json(policy: Policy) -> PolicyToJsonAnswer {
     match policy.parse(None) {
         Ok(policy) => match policy.to_json() {
@@ -105,7 +153,18 @@ pub fn policy_to_json(policy: Policy) -> PolicyToJsonAnswer {
 }
 
 /// Return the JSON representation of a template.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "templateToJson"))]
+///
+/// # Errors
+///
+/// Throws if `template` does not match the `Template` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "templateToJson")]
+pub fn template_to_json_wasm(template: Ts<Template>) -> Result<Ts<PolicyToJsonAnswer>, JsError> {
+    Ok(template_to_json(template.to_rust()?).into_ts()?)
+}
+
+/// Return the JSON representation of a template.
 pub fn template_to_json(template: Template) -> PolicyToJsonAnswer {
     match template.parse(None) {
         Ok(template) => match template.to_json() {
@@ -121,7 +180,18 @@ pub fn template_to_json(template: Template) -> PolicyToJsonAnswer {
 }
 
 /// Return the Cedar (textual) representation of a schema.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "schemaToText"))]
+///
+/// # Errors
+///
+/// Throws if `schema` does not match the `Schema` type, or if the answer cannot
+/// be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "schemaToText")]
+pub fn schema_to_text_wasm(schema: Ts<Schema>) -> Result<Ts<SchemaToTextAnswer>, JsError> {
+    Ok(schema_to_text(schema.to_rust()?).into_ts()?)
+}
+
+/// Return the Cedar (textual) representation of a schema.
 pub fn schema_to_text(schema: Schema) -> SchemaToTextAnswer {
     match schema.parse_schema_fragment() {
         Ok((schema_frag, warnings)) => {
@@ -151,7 +221,18 @@ pub fn schema_to_text(schema: Schema) -> SchemaToTextAnswer {
 }
 
 /// Return the JSON representation of a schema.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "schemaToJson"))]
+///
+/// # Errors
+///
+/// Throws if `schema` does not match the `Schema` type, or if the answer cannot
+/// be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "schemaToJson")]
+pub fn schema_to_json_wasm(schema: Ts<Schema>) -> Result<Ts<SchemaToJsonAnswer>, JsError> {
+    Ok(schema_to_json(schema.to_rust()?).into_ts()?)
+}
+
+/// Return the JSON representation of a schema.
 pub fn schema_to_json(schema: Schema) -> SchemaToJsonAnswer {
     match schema.parse_schema_fragment() {
         Ok((schema_frag, warnings)) => match schema_frag.to_json_value() {
@@ -184,10 +265,24 @@ pub fn schema_to_json(schema: Schema) -> SchemaToJsonAnswer {
 /// Entity or `CommonType` classifications using the schema's type definitions.
 /// This is primarily meant to be used when working with schemas programmatically,
 /// for example when creating a schema building UI.
-#[cfg_attr(
-    feature = "wasm",
-    wasm_bindgen(js_name = "schemaToJsonWithResolvedTypes")
-)]
+///
+/// # Errors
+///
+/// Throws if the answer cannot be serialized to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "schemaToJsonWithResolvedTypes")]
+pub fn schema_to_json_with_resolved_types_wasm(
+    schema_str: &str,
+) -> Result<Ts<SchemaToJsonWithResolvedTypesAnswer>, JsError> {
+    Ok(schema_to_json_with_resolved_types(schema_str).into_ts()?)
+}
+
+/// Convert a Cedar schema string to JSON format with resolved types.
+///
+/// This function resolves ambiguous "`EntityOrCommon`" types to their specific
+/// Entity or `CommonType` classifications using the schema's type definitions.
+/// This is primarily meant to be used when working with schemas programmatically,
+/// for example when creating a schema building UI.
 pub fn schema_to_json_with_resolved_types(schema_str: &str) -> SchemaToJsonWithResolvedTypesAnswer {
     match crate::api::schema_str_to_json_with_resolved_types(schema_str) {
         Ok((json_value, warnings)) => SchemaToJsonWithResolvedTypesAnswer::Success {
@@ -208,7 +303,6 @@ pub fn schema_to_json_with_resolved_types(schema_str: &str) -> SchemaToJsonWithR
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PolicyToTextAnswer {
     /// Represents a successful call
     Success {
@@ -228,7 +322,6 @@ pub enum PolicyToTextAnswer {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PolicySetTextToPartsAnswer {
     /// Represents a successful call
     Success {
@@ -249,7 +342,6 @@ pub enum PolicySetTextToPartsAnswer {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PolicyToJsonAnswer {
     /// Represents a successful call
     Success {
@@ -269,7 +361,6 @@ pub enum PolicyToJsonAnswer {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaToTextAnswer {
     /// Represents a successful call
     Success {
@@ -290,7 +381,6 @@ pub enum SchemaToTextAnswer {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaToJsonAnswer {
     /// Represents a successful call
     Success {
@@ -312,7 +402,6 @@ pub enum SchemaToJsonAnswer {
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaToJsonWithResolvedTypesAnswer {
     /// Represents a successful call
     Success {

--- a/cedar-policy/src/ffi/format.rs
+++ b/cedar-policy/src/ffi/format.rs
@@ -26,13 +26,26 @@ use super::utils::DetailedError;
 use cedar_policy_formatter::{policies_str_to_pretty, Config};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{Ts, Tsify as _};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
 /// Apply the Cedar policy formatter to a policy set in the Cedar policy format
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "formatPolicies"))]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `FormattingCall` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "formatPolicies")]
+pub fn format_wasm(call: Ts<FormattingCall>) -> Result<Ts<FormattingAnswer>, JsError> {
+    Ok(format(call.to_rust()?).into_ts()?)
+}
+
+/// Apply the Cedar policy formatter to a policy set in the Cedar policy format
 #[expect(
     clippy::needless_pass_by_value,
     reason = "FFI function which conventionally takes owned arguments"
@@ -79,7 +92,6 @@ pub fn format_json_str(json: &str) -> Result<String, serde_json::Error> {
 /// Struct containing the input data for formatting
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct FormattingCall {
@@ -103,7 +115,6 @@ const fn default_indent_width() -> isize {
 /// Result struct for formatting
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 pub enum FormattingAnswer {

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -33,7 +33,9 @@ use serde_with::serde_as;
 use std::collections::HashMap;
 use std::collections::HashSet;
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{Ts, Tsify as _};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
@@ -54,7 +56,18 @@ thread_local!(
 );
 
 /// Basic interface, using [`AuthorizationCall`] and [`AuthorizationAnswer`] types
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "isAuthorized"))]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `AuthorizationCall` type, or if the
+/// answer cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "isAuthorized")]
+pub fn is_authorized_wasm(call: Ts<AuthorizationCall>) -> Result<Ts<AuthorizationAnswer>, JsError> {
+    Ok(is_authorized(call.to_rust()?).into_ts()?)
+}
+
+/// Basic interface, using [`AuthorizationCall`] and [`AuthorizationAnswer`] types
 pub fn is_authorized(call: AuthorizationCall) -> AuthorizationAnswer {
     match call.parse() {
         WithWarnings {
@@ -106,8 +119,22 @@ pub fn is_authorized_json_str(json: &str) -> Result<String, serde_json::Error> {
 ///
 /// # Errors
 ///
+/// Throws if `policies` does not match the `PolicySet` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "preparsePolicySet")]
+pub fn preparse_policy_set_wasm(
+    pset_id: String,
+    policies: Ts<PolicySet>,
+) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(preparse_policy_set(pset_id, policies.to_rust()?).into_ts()?)
+}
+
+/// Preparse and cache a policy set in thread-local storage
+///
+/// # Errors
+///
 /// Will return `Err` if the input cannot be parsed. Side-effect free on error.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "preparsePolicySet"))]
 pub fn preparse_policy_set(pset_id: String, policies: PolicySet) -> CheckParseAnswer {
     use super::check_parse::CheckParseAnswer;
 
@@ -129,8 +156,22 @@ pub fn preparse_policy_set(pset_id: String, policies: PolicySet) -> CheckParseAn
 ///
 /// # Errors
 ///
+/// Throws if `schema` does not match the `Schema` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "preparseSchema")]
+pub fn preparse_schema_wasm(
+    schema_name: String,
+    schema: Ts<Schema>,
+) -> Result<Ts<CheckParseAnswer>, JsError> {
+    Ok(preparse_schema(schema_name, schema.to_rust()?).into_ts()?)
+}
+
+/// Preparse and cache a schema in thread-local storage
+///
+/// # Errors
+///
 /// Will return `Err` if the input cannot be parsed. Side-effect free on error.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "preparseSchema"))]
 pub fn preparse_schema(schema_name: String, schema: Schema) -> CheckParseAnswer {
     use super::check_parse::CheckParseAnswer;
 
@@ -151,8 +192,23 @@ pub fn preparse_schema(schema_name: String, schema: Schema) -> CheckParseAnswer 
 /// Basic interface for partial evaluation, using [`AuthorizationCall`] and
 /// [`PartialAuthorizationAnswer`] types
 #[doc = include_str!("../../experimental_warning.md")]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `PartialAuthorizationCall` type, or if
+/// the answer cannot be serialized back to JavaScript.
+#[cfg(all(feature = "wasm", feature = "partial-eval"))]
+#[wasm_bindgen(js_name = "isAuthorizedPartial")]
+pub fn is_authorized_partial_wasm(
+    call: Ts<PartialAuthorizationCall>,
+) -> Result<Ts<PartialAuthorizationAnswer>, JsError> {
+    Ok(is_authorized_partial(call.to_rust()?).into_ts()?)
+}
+
+/// Basic interface for partial evaluation, using [`AuthorizationCall`] and
+/// [`PartialAuthorizationAnswer`] types
+#[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "isAuthorizedPartial"))]
 pub fn is_authorized_partial(call: PartialAuthorizationCall) -> PartialAuthorizationAnswer {
     match call.parse() {
         WithWarnings {
@@ -217,7 +273,6 @@ pub fn is_authorized_partial_json_str(json: &str) -> Result<String, serde_json::
 /// Interface version of a `Response` that uses the interface version of `Diagnostics`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Response {
@@ -231,7 +286,6 @@ pub struct Response {
 /// in the `DetailedError` format
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct Diagnostics {
@@ -299,7 +353,6 @@ impl Diagnostics {
 /// Error (or warning) which occurred in a particular policy during authorization
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct AuthorizationError {
@@ -352,7 +405,6 @@ impl From<cedar_policy_core::authorizer::AuthorizationError> for AuthorizationEr
 #[cfg(feature = "partial-eval")]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ResidualResponse {
@@ -461,7 +513,6 @@ impl TryFrom<crate::PartialResponse> for ResidualResponse {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub enum AuthorizationAnswer {
     /// Represents a failure to parse or call the authorizer entirely
@@ -492,7 +543,6 @@ pub enum AuthorizationAnswer {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub enum PartialAuthorizationAnswer {
     /// Represents a failure to parse or call the authorizer entirely
@@ -521,7 +571,6 @@ pub enum PartialAuthorizationAnswer {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct AuthorizationCall {
@@ -555,7 +604,6 @@ pub struct AuthorizationCall {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct StatefulAuthorizationCall {
@@ -590,7 +638,6 @@ pub struct StatefulAuthorizationCall {
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct PartialAuthorizationCall {
@@ -622,9 +669,25 @@ pub struct PartialAuthorizationCall {
 
 /// Stateful authorization using preparsed schemas and policy sets.
 ///
+/// This function works like `isAuthorized` but retrieves schemas and policy sets
+/// from thread-local cache instead of parsing them on each call.
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `StatefulAuthorizationCall` type, or if
+/// the answer cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "statefulIsAuthorized")]
+pub fn stateful_is_authorized_wasm(
+    call: Ts<StatefulAuthorizationCall>,
+) -> Result<Ts<AuthorizationAnswer>, JsError> {
+    Ok(stateful_is_authorized(call.to_rust()?).into_ts()?)
+}
+
+/// Stateful authorization using preparsed schemas and policy sets.
+///
 /// This function works like [`is_authorized`] but retrieves schemas and policy sets
 /// from thread-local cache instead of parsing them on each call.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "statefulIsAuthorized"))]
 pub fn stateful_is_authorized(call: StatefulAuthorizationCall) -> AuthorizationAnswer {
     match call.parse() {
         WithWarnings {

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -191,12 +191,12 @@ pub fn preparse_schema(schema_name: String, schema: Schema) -> CheckParseAnswer 
 
 /// Basic interface for partial evaluation, using [`AuthorizationCall`] and
 /// [`PartialAuthorizationAnswer`] types
-#[doc = include_str!("../../experimental_warning.md")]
 ///
 /// # Errors
 ///
 /// Throws if `call` does not match the `PartialAuthorizationCall` type, or if
 /// the answer cannot be serialized back to JavaScript.
+#[doc = include_str!("../../experimental_warning.md")]
 #[cfg(all(feature = "wasm", feature = "partial-eval"))]
 #[wasm_bindgen(js_name = "isAuthorizedPartial")]
 pub fn is_authorized_partial_wasm(

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -37,7 +37,6 @@ extern crate tsify;
 /// Structure of the JSON output representing one `miette` error
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Deserialize, Serialize, Default)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct DetailedError {
@@ -81,7 +80,6 @@ impl FromStr for DetailedError {
 /// If `miette::Severity` adds `derive(Hash)` in the future, we can remove this
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Deserialize, Serialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub enum Severity {
     /// Advice (the lowest severity)
@@ -105,7 +103,6 @@ impl From<miette::Severity> for Severity {
 /// Structure of the JSON output representing a `miette` source label (range)
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Deserialize, Serialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct SourceLabel {
@@ -119,7 +116,6 @@ pub struct SourceLabel {
 /// A range of source code representing the location of an error or warning.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Deserialize, Serialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct SourceLocation {
@@ -182,7 +178,6 @@ impl From<miette::Report> for DetailedError {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityUid(
     #[cfg_attr(feature = "wasm", tsify(type = "EntityUidJson"))] JsonValueWithNoDuplicateKeys,
 );
@@ -223,7 +218,6 @@ impl From<serde_json::Value> for EntityUid {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Context(
     #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
     JsonValueWithNoDuplicateKeys,
@@ -273,7 +267,6 @@ impl From<serde_json::Value> for Context {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Entities(
     #[cfg_attr(feature = "wasm", tsify(type = "Array<EntityJson>"))] JsonValueWithNoDuplicateKeys,
 );
@@ -311,7 +304,6 @@ impl From<serde_json::Value> for Entities {
 /// Represents a static policy in either the Cedar or JSON policy format
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(untagged)]
 #[serde(
     expecting = "expected a static policy in the Cedar or JSON policy format (with no duplicate keys)"
@@ -383,7 +375,6 @@ impl From<&crate::Policy> for Policy {
 /// Represents a policy template in either the Cedar or JSON policy format.
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(untagged)]
 #[serde(
     expecting = "expected a policy template in the Cedar or JSON policy format (with no duplicate keys)"
@@ -473,7 +464,6 @@ impl From<&crate::Template> for Template {
 /// Represents a set of static policies
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(untagged)]
 #[serde(
     expecting = "expected a static policy set represented by a string, JSON array, or JSON object (with no duplicate keys)"
@@ -549,7 +539,6 @@ impl From<&crate::PolicySet> for StaticPolicySet {
 /// Represents a template-linked policy
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct TemplateLink {
@@ -583,7 +572,6 @@ impl TemplateLink {
 /// Represents a policy set, including static policies, templates, and template links
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct PolicySet {
@@ -647,7 +635,6 @@ impl PolicySet {
 /// Represents a schema in either the Cedar or JSON schema format
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(untagged)]
 #[serde(
     expecting = "expected a schema in the Cedar or JSON policy format (with no duplicate keys)"

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -26,7 +26,9 @@ use super::utils::{DetailedError, PolicySet, Schema, WithWarnings};
 use crate::{PolicyId, ValidationMode, Validator};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
+use tsify::{Ts, Tsify as _};
+#[cfg(feature = "wasm")]
+use wasm_bindgen::{prelude::wasm_bindgen, JsError};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
@@ -35,7 +37,21 @@ extern crate tsify;
 ///
 /// This is the basic validator interface, using [`ValidationCall`] and
 /// [`ValidationAnswer`] types
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "validate"))]
+///
+/// # Errors
+///
+/// Throws if `call` does not match the `ValidationCall` type, or if the answer
+/// cannot be serialized back to JavaScript.
+#[cfg(feature = "wasm")]
+#[wasm_bindgen(js_name = "validate")]
+pub fn validate_wasm(call: Ts<ValidationCall>) -> Result<Ts<ValidationAnswer>, JsError> {
+    Ok(validate(call.to_rust()?).into_ts()?)
+}
+
+/// Parse a policy set and optionally validate it against a provided schema
+///
+/// This is the basic validator interface, using [`ValidationCall`] and
+/// [`ValidationAnswer`] types
 pub fn validate(call: ValidationCall) -> ValidationAnswer {
     match call.get_components() {
         WithWarnings {
@@ -102,7 +118,6 @@ pub fn validate_json_str(json: &str) -> Result<String, serde_json::Error> {
 /// Struct containing the input data for validation
 #[derive(Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ValidationCall {
@@ -153,7 +168,6 @@ impl ValidationCall {
 /// Configuration for the validation call
 #[derive(Serialize, Deserialize, Debug, Default)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ValidationSettings {
@@ -164,7 +178,6 @@ pub struct ValidationSettings {
 /// Error (or warning) for a specified policy after validation
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct ValidationError {
@@ -180,7 +193,6 @@ pub struct ValidationError {
 /// Result struct for validation
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 pub enum ValidationAnswer {

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Upgraded tsify dependency and migrated wasm bindings to use the new `Ts<T>` wrapper pattern, fixing memory leak. (#2534)
+
 ## 4.12.0
 
 ## 4.11.1

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -20,8 +20,7 @@ serde_json = "1.0"
 # wasm support
 wasm-bindgen = { version = "0.2.106" }
 console_error_panic_hook = { version = "0.1.6", optional = true }
-# Intentionally not updated to 0.5.5, see issue #1744
-tsify = "0.4.5"
+tsify = "0.5.8"
 
 [features]
 default = ["console_error_panic_hook"]

--- a/cedar-wasm/src/utils.rs
+++ b/cedar-wasm/src/utils.rs
@@ -1,12 +1,12 @@
 use cedar_policy::ffi::{Policy, Schema, Template};
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsError;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 /// struct that defines the result of getting valid request environments
 pub enum GetValidRequestEnvsResult {
     /// represents a successful call to [`get_valid_request_envs_template()`]
@@ -25,7 +25,21 @@ pub enum GetValidRequestEnvsResult {
 }
 
 /// Get valid request environment
+///
+/// # Errors
+///
+/// Throws if `t` does not match the `Template` type or `s` does not
+/// match the `Schema` type, or if the result cannot be serialized back to
+/// JavaScript.
 #[wasm_bindgen(js_name = "getValidRequestEnvsTemplate")]
+pub fn get_valid_request_envs_template_wasm(
+    t: Ts<Template>,
+    s: Ts<Schema>,
+) -> Result<Ts<GetValidRequestEnvsResult>, JsError> {
+    Ok(get_valid_request_envs_template(t.to_rust()?, s.to_rust()?).into_ts()?)
+}
+
+/// Get valid request environment
 pub fn get_valid_request_envs_template(t: Template, s: Schema) -> GetValidRequestEnvsResult {
     match t.get_valid_request_envs(s) {
         Ok((principals, actions, resources)) => GetValidRequestEnvsResult::Success {
@@ -40,7 +54,21 @@ pub fn get_valid_request_envs_template(t: Template, s: Schema) -> GetValidReques
 }
 
 /// Get valid request environment
+///
+/// # Errors
+///
+/// Throws if `t` does not match the `Policy` type or `s` does not
+/// match the `Schema` type, or if the result cannot be serialized back to
+/// JavaScript.
 #[wasm_bindgen(js_name = "getValidRequestEnvsPolicy")]
+pub fn get_valid_request_envs_policy_wasm(
+    t: Ts<Policy>,
+    s: Ts<Schema>,
+) -> Result<Ts<GetValidRequestEnvsResult>, JsError> {
+    Ok(get_valid_request_envs_policy(t.to_rust()?, s.to_rust()?).into_ts()?)
+}
+
+/// Get valid request environment
 pub fn get_valid_request_envs_policy(t: Policy, s: Schema) -> GetValidRequestEnvsResult {
     match t.get_valid_request_envs(s) {
         Ok((principals, actions, resources)) => GetValidRequestEnvsResult::Success {


### PR DESCRIPTION
## Description of changes
tsify [released a fix for the renaming issue we encountered back in November](https://github.com/madonoharu/tsify/pull/98) enabling us to upgrade to the latest version using the new `rename` container attribute.

However, the `into_wasm_abi`/`from_wasm_abi`
container attributes which we heavily use are now deprecated because [they can cause memory leaks](https://github.com/madonoharu/tsify#why-are-the-wasm_abi-attributes-deprecated). The recommended alternative is to use the `Ts` wrapper type. To avoid changing the signature of the existing public Rust functions I made new wasm variants. (e.g., `pub fn is_authorized_wasm(call: Ts<AuthorizationCall>) -> Result<Ts<AuthorizationAnswer>, JsError>`).

To check backwards compatibility of the Rust API, I used cargo expand to diff the code for cedar-policy before and after this change. When every feature except tsify, wasm, and wasm-bindgen were enabled there is no difference.
When all features are enabled there are two main differences that are not backwards compatible:
1. There are no longer derived implementations of `OptionFromWasmAbi`, `FromWasmAbi`, `OptionIntoWasmAbi`, `IntoWasmAbi` and `WasmDescribe` for types previously annotated with `#[tsify(into_wasm_abi, from_wasm_abi)]`.
2. The signature of bindgen-generated functions are different
Main:
```rust
            pub unsafe extern "C-unwind" fn __wasm_bindgen_generated_checkParseEntities(
                arg0_1: <<EntitiesParsingCall as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim1,
                arg0_2: <<EntitiesParsingCall as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim2,
                arg0_3: <<EntitiesParsingCall as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim3,
                arg0_4: <<EntitiesParsingCall as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim4,
            ) -> wasm_bindgen::convert::WasmRet<
                <CheckParseAnswer as wasm_bindgen::convert::ReturnWasmAbi>::Abi,
            > {  }
}
```

This change:
```rust
        pub unsafe extern "C-unwind" fn __wasm_bindgen_generated_checkParseEntities(
                arg0_1: <<Ts<
                    EntitiesParsingCall,
                > as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim1,
                arg0_2: <<Ts<
                    EntitiesParsingCall,
                > as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim2,
                arg0_3: <<Ts<
                    EntitiesParsingCall,
                > as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim3,
                arg0_4: <<Ts<
                    EntitiesParsingCall,
                > as wasm_bindgen::convert::FromWasmAbi>::Abi as wasm_bindgen::convert::WasmAbi>::Prim4,
            ) -> wasm_bindgen::convert::WasmRet<
                <Result<
                    Ts<CheckParseAnswer>,
                    JsError,
                > as wasm_bindgen::convert::ReturnWasmAbi>::Abi,
            > {  }
```

To check the  backwards compatibility of the TypeScript API, I built the WASM bindings using the "build-wasm.sh" script on this change and main. I manually inspected the diffs. The type definitions and signatures appear to be the same. This is consistent with the tsify documentation which says that the generated TypeScript is unchanged when changing to the `Ts` wrappers.

## Issue #, if available
Resolves: #1744

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
