### PR TITLE
fix #2539 - return residuals in tpe's policy_set

### DIFF
--- a/cedar-policy-core/src/tpe/response.rs
+++ b/cedar-policy-core/src/tpe/response.rs
@@ -334,8 +334,167 @@ impl<'a> Response<'a> {
                 clippy::unwrap_used,
                 reason = "`PolicySet::add` only fails on duplicate ids, but all residual policies will have unique ids"
             )]
-            ps.add(p.policy.as_ref().clone()).unwrap()
+            ps.add(p.clone().into()).unwrap()
         }
         ps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashSet};
+    use std::sync::Arc;
+
+    use crate::ast::{
+        ActionConstraint, EntityUID, Policy, PolicySet, PrincipalConstraint, ResourceConstraint,
+    };
+    use crate::extensions::Extensions;
+    use crate::parser::parse_policyset;
+    use crate::tpe::entities::{PartialEntities, PartialEntity};
+    use crate::tpe::is_authorized;
+    use crate::tpe::request::{PartialEntityUID, PartialRequest};
+    use crate::validator::ValidatorSchema;
+
+    fn schema() -> ValidatorSchema {
+        ValidatorSchema::from_cedarschema_str(
+            r#"
+            namespace Auth {
+              entity Group {};
+              entity Role {};
+              entity User in [Group] {};
+              action "AssumeRole" appliesTo {
+                principal: [Auth::User],
+                resource: Auth::Role,
+              };
+            }
+            "#,
+            Extensions::all_available(),
+        )
+        .unwrap()
+        .0
+    }
+
+    fn policies() -> PolicySet {
+        parse_policyset(
+            r#"
+            @id("permit")
+            permit(principal == Auth::User::"1", action == Auth::Action::"AssumeRole", resource);
+            @id("forbid")
+            forbid(principal, action == Auth::Action::"AssumeRole", resource == Auth::Role::"2");
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn request() -> PartialRequest {
+        PartialRequest::new(
+            r#"Auth::User::"1""#.parse::<EntityUID>().unwrap().into(),
+            r#"Auth::Action::"AssumeRole""#.parse().unwrap(),
+            // Unknown resource of type `Auth::Role`.
+            PartialEntityUID {
+                ty: "Auth::Role".parse().unwrap(),
+                eid: None,
+            },
+            Some(Arc::new(BTreeMap::new())),
+            &schema(),
+        )
+        .unwrap()
+    }
+
+    fn entities() -> PartialEntities {
+        let schema = schema();
+        PartialEntities::from_entities(
+            [PartialEntity::new(
+                r#"Auth::User::"1""#.parse().unwrap(),
+                Some(BTreeMap::new()),
+                Some(HashSet::new()),
+                None,
+                &schema,
+            )
+            .unwrap()]
+            .into_iter(),
+            &schema,
+        )
+        .unwrap()
+    }
+
+    #[track_caller]
+    fn assert_scopes_unconstrained(policy: &Policy) {
+        let t = policy.template();
+        assert_eq!(
+            t.principal_constraint(),
+            &PrincipalConstraint::any(),
+            "residual policy `{}` should have an unconstrained principal scope",
+            policy.id()
+        );
+        assert_eq!(
+            t.action_constraint(),
+            &ActionConstraint::any(),
+            "residual policy `{}` should have an unconstrained action scope",
+            policy.id()
+        );
+        assert_eq!(
+            t.resource_constraint(),
+            &ResourceConstraint::any(),
+            "residual policy `{}` should have an unconstrained resource scope",
+            policy.id()
+        );
+    }
+
+    #[test]
+    fn policy_set_returns_residuals_not_originals() {
+        let policies = policies();
+        let schema = schema();
+        let request = request();
+        let entities = entities();
+
+        let res = is_authorized(&policies, &request, &entities, &schema).unwrap();
+        // With a concrete principal and an unknown resource, we can't decide.
+        assert_eq!(res.decision(), None);
+
+        let policy_set = res.policy_set();
+        assert_eq!(policy_set.policies().count(), 2);
+
+        for p in policy_set.policies() {
+            assert_scopes_unconstrained(p);
+        }
+    }
+
+    #[test]
+    fn policy_set_matches_policies() {
+        let policies = policies();
+        let schema = schema();
+        let request = request();
+        let entities = entities();
+
+        let res = is_authorized(&policies, &request, &entities, &schema).unwrap();
+
+        let policy_set = res.policy_set();
+
+        let mut expected = PolicySet::new();
+        for p in res.policies() {
+            expected.add(p.clone().into()).unwrap();
+        }
+
+        assert_eq!(policy_set.policies().count(), expected.policies().count());
+        for expected_policy in expected.policies() {
+            let actual = policy_set
+                .get(expected_policy.id())
+                .unwrap_or_else(|| panic!("missing policy `{}`", expected_policy.id()));
+            assert_eq!(actual.effect(), expected_policy.effect());
+            assert_eq!(
+                actual.template().principal_constraint(),
+                expected_policy.template().principal_constraint()
+            );
+            assert_eq!(
+                actual.template().action_constraint(),
+                expected_policy.template().action_constraint()
+            );
+            assert_eq!(
+                actual.template().resource_constraint(),
+                expected_policy.template().resource_constraint()
+            );
+            assert_eq!(actual.condition(), expected_policy.condition());
+        }
     }
 }

--- a/cedar-policy-core/src/tpe/response.rs
+++ b/cedar-policy-core/src/tpe/response.rs
@@ -342,17 +342,18 @@ impl<'a> Response<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashSet};
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use crate::ast::{
-        ActionConstraint, EntityUID, Policy, PolicySet, PrincipalConstraint, ResourceConstraint,
+        ActionConstraint, Policy, PolicySet, PrincipalConstraint, ResourceConstraint,
     };
     use crate::extensions::Extensions;
-    use crate::parser::parse_policyset;
-    use crate::tpe::entities::{PartialEntities, PartialEntity};
+    use crate::parser::{parse_euid, parse_policyset};
+    use crate::tpe::entities::PartialEntities;
     use crate::tpe::is_authorized;
-    use crate::tpe::request::{PartialEntityUID, PartialRequest};
+    use crate::tpe::request::PartialRequest;
+    use crate::tpe::test_utils::parse_partial_euid;
     use crate::validator::ValidatorSchema;
 
     fn schema() -> ValidatorSchema {
@@ -388,13 +389,9 @@ mod tests {
 
     fn request() -> PartialRequest {
         PartialRequest::new(
-            r#"Auth::User::"1""#.parse::<EntityUID>().unwrap().into(),
-            r#"Auth::Action::"AssumeRole""#.parse().unwrap(),
-            // Unknown resource of type `Auth::Role`.
-            PartialEntityUID {
-                ty: "Auth::Role".parse().unwrap(),
-                eid: None,
-            },
+            parse_partial_euid(r#"Auth::User::"1""#),
+            parse_euid(r#"Auth::Action::"AssumeRole""#).unwrap(),
+            parse_partial_euid("Auth::Role"),
             Some(Arc::new(BTreeMap::new())),
             &schema(),
         )
@@ -402,22 +399,22 @@ mod tests {
     }
 
     fn entities() -> PartialEntities {
-        let schema = schema();
-        PartialEntities::from_entities(
-            [PartialEntity::new(
-                r#"Auth::User::"1""#.parse().unwrap(),
-                Some(BTreeMap::new()),
-                Some(HashSet::new()),
-                None,
-                &schema,
-            )
-            .unwrap()]
-            .into_iter(),
-            &schema,
+        PartialEntities::from_json_value(
+            serde_json::json!([
+                {
+                    "uid": { "type": "Auth::User", "id": "1" },
+                    "attrs": {},
+                    "parents": []
+                }
+            ]),
+            &schema(),
         )
         .unwrap()
     }
 
+    /// Assert that the scope is (principal, action, resource).
+    /// Can be used as a proxy to check a policy with constrained scope is evaluated to
+    /// a residual, which in the current implementation doesn't have scope constraints.
     #[track_caller]
     fn assert_scopes_unconstrained(policy: &Policy) {
         let t = policy.template();

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,7 @@ Cedar Language Version: TBD
 
 ### Fixed
 - In the experimental `protobufs` feature, the `Schema::decode` function now accepts schemas that reference `Action` entity types not defined in the schema. This was previously  rejected (#2491).
+- For the experimental `tpe` feature, fixed `TpeResponse::policy_set` to return the residual policies, matching `TpeResponse::policies` as documented. Previously it returned the original policies (#2540).
 
 ## [4.12.0] - 2026-07-28
 

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -1558,7 +1558,20 @@ unless
             )
             .unwrap();
             let policies = policy_set();
-            let partial_entities = PartialEntities::from_concrete(entities(), &schema).unwrap();
+            let partial_entities = PartialEntities::from_json_value(
+                serde_json::json!([
+                    {
+                        "uid": { "type": "Subscriber", "id": "Alice" },
+                        "attrs": {
+                            "subscription": { "tier": "standard" },
+                            "profile": { "isKid": false }
+                        },
+                        "parents": []
+                    }
+                ]),
+                &schema,
+            )
+            .unwrap();
 
             let response = policies
                 .tpe(&request, &partial_entities, &schema)
@@ -1570,10 +1583,8 @@ unless
             // `policy_set` includes all residuals (true/false/error + non-trivial).
             assert_eq!(residual_set.num_of_policies(), policies.num_of_policies());
 
-            // Every policy in the set must have unconstrained scopes: the
-            // original scopes (e.g. `principal is Subscriber`,
-            // `action == Action::"watch"`, `resource is Movie`) must have been
-            // folded into the residual condition rather than left in the scope.
+            // Every policy in the set must have unconstrained scopes (given the current
+            // partial evaluation's implementation)
             for p in residual_set.policies() {
                 assert_matches!(p.action_constraint(), ActionConstraint::Any);
                 assert_matches!(p.principal_constraint(), PrincipalConstraint::Any);

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -1526,6 +1526,74 @@ unless
             });
         }
 
+        // Api test: `TpeResponse::policy_set` agrees with `TpeResponse::policies`, as
+        // documented. It returns residuals.
+        #[test]
+        fn policy_set_returns_residuals() {
+            let schema = schema();
+            let request = PartialRequest::new(
+                PartialEntityUid::from_concrete(r#"Subscriber::"Alice""#.parse().unwrap()),
+                r#"Action::"watch""#.parse().unwrap(),
+                // Unknown resource of type `Movie`.
+                PartialEntityUid::new("Movie".parse().unwrap(), None),
+                Some(
+                    Context::from_pairs([(
+                        "now".into(),
+                        RestrictedExpression::new_record([
+                            (
+                                "datetime".into(),
+                                RestrictedExpression::from_str(r#"datetime("2025-07-22")"#)
+                                    .unwrap(),
+                            ),
+                            (
+                                "localTimeOffset".into(),
+                                RestrictedExpression::from_str(r#"duration("0h")"#).unwrap(),
+                            ),
+                        ])
+                        .unwrap(),
+                    )])
+                    .unwrap(),
+                ),
+                &schema,
+            )
+            .unwrap();
+            let policies = policy_set();
+            let partial_entities = PartialEntities::from_concrete(entities(), &schema).unwrap();
+
+            let response = policies
+                .tpe(&request, &partial_entities, &schema)
+                .expect("tpe should succeed");
+            assert_eq!(response.decision(), None);
+
+            let residual_set = response.policy_set();
+
+            // `policy_set` includes all residuals (true/false/error + non-trivial).
+            assert_eq!(residual_set.num_of_policies(), policies.num_of_policies());
+
+            // Every policy in the set must have unconstrained scopes: the
+            // original scopes (e.g. `principal is Subscriber`,
+            // `action == Action::"watch"`, `resource is Movie`) must have been
+            // folded into the residual condition rather than left in the scope.
+            for p in residual_set.policies() {
+                assert_matches!(p.action_constraint(), ActionConstraint::Any);
+                assert_matches!(p.principal_constraint(), PrincipalConstraint::Any);
+                assert_matches!(p.resource_constraint(), ResourceConstraint::Any);
+            }
+
+            // `policy_set` returns exactly the same policies as `policies`.
+            let mut from_policies: Vec<(String, String)> = response
+                .policies()
+                .map(|p| (p.id().to_string(), p.to_cedar().unwrap()))
+                .collect();
+            from_policies.sort();
+            let mut from_set: Vec<(String, String)> = residual_set
+                .policies()
+                .map(|p| (p.id().to_string(), p.to_cedar().unwrap()))
+                .collect();
+            from_set.sort();
+            assert_eq!(from_set, from_policies);
+        }
+
         #[test]
         fn query_resource() {
             let schema = schema();


### PR DESCRIPTION
Now `TPEResponse::policy_set` returns the residuals, as documented.

Both added tests will catch the regression.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
