### PR TITLE
add a doc comment for #2538

### DIFF
--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -583,6 +583,9 @@ impl TpeResponse<'_> {
     /// Returns an iterator of non-trivial (meaning more than just `true`
     /// or `false`, or an error) residuals as [`Policy`]s.
     ///
+    /// This function is meant to allow inspecting non-trivial residuals. To get the complete set
+    /// of residual policies that will be used for reauthorization, use [`TpeResponse::policies`]
+    /// or [`TpeResponse::policy_set`].
     /// To find policies that reached a concrete value, use, e.g., [`TpeResponse::true_permits`].
     ///
     /// Each returned [`Policy`] inherits its [`PolicyId`] and


### PR DESCRIPTION
Adds another doc comment to `residual_policies`. 

The current doc is precise about what gets returned. This additional comment can help users that don't immediately map the concept of "only non-trivial policies excluding trivially true, false or error" to the fact that this is not the complete set of policies that would be used for re-authorization.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
