### PR TITLE
Avoid computing flag for validation help messsage when no error exists

### DIFF
--- a/cedar-policy-core/src/validator.rs
+++ b/cedar-policy-core/src/validator.rs
@@ -187,7 +187,7 @@ impl Validator {
                     // schema if it only failed when there is a known action
                     // applied to known principal/resource entity types that are
                     // not in its `appliesTo`.
-                    .chain(self.validate_template_action_application(p)),
+                    .chain(self.validate_template_action_application(p).err()),
             )
         }
         .into_iter()
@@ -231,7 +231,7 @@ impl Validator {
         // the slot filled by the appropriate value.
         Some(
             self.validate_entity_types_in_slots(p.id(), p.env())
-                .chain(self.validate_linked_action_application(p)),
+                .chain(self.validate_linked_action_application(p).err()),
         )
     }
 

--- a/cedar-policy-core/src/validator/rbac.rs
+++ b/cedar-policy-core/src/validator/rbac.rs
@@ -226,7 +226,7 @@ impl Validator {
     pub(crate) fn validate_linked_action_application<'a>(
         &self,
         p: &'a Policy,
-    ) -> impl Iterator<Item = ValidationError> + 'a {
+    ) -> Result<(), ValidationError> {
         self.validate_action_application(
             p.loc(),
             p.id(),
@@ -239,7 +239,7 @@ impl Validator {
     pub(crate) fn validate_template_action_application<'a>(
         &self,
         t: &'a Template,
-    ) -> impl Iterator<Item = ValidationError> + 'a {
+    ) -> Result<(), ValidationError> {
         self.validate_action_application(
             t.loc(),
             t.id(),
@@ -260,7 +260,7 @@ impl Validator {
         principal_constraint: &PrincipalConstraint,
         action_constraint: &ActionConstraint,
         resource_constraint: &ResourceConstraint,
-    ) -> impl Iterator<Item = ValidationError> {
+    ) -> Result<(), ValidationError> {
         let mut apply_specs = self.get_apply_specs_for_action(action_constraint);
         let resources_for_scope: HashSet<&ast::EntityType> = self
             .get_resources_satisfying_constraint(resource_constraint)
@@ -269,27 +269,26 @@ impl Validator {
             .get_principals_satisfying_constraint(principal_constraint)
             .collect();
 
-        let would_in_fix_principal =
-            self.check_if_in_fixes_principal(principal_constraint, action_constraint);
-        let would_in_fix_resource =
-            self.check_if_in_fixes_resource(resource_constraint, action_constraint);
-
-        Some(ValidationError::invalid_action_application(
-            source_loc.cloned(),
-            policy_id.clone(),
-            would_in_fix_principal,
-            would_in_fix_resource,
-        ))
-        .filter(|_| {
-            !apply_specs.any(|spec| {
-                let action_principals = spec.applicable_principal_types().collect::<HashSet<_>>();
-                let action_resources = spec.applicable_resource_types().collect::<HashSet<_>>();
-                let matching_principal = !principals_for_scope.is_disjoint(&action_principals);
-                let matching_resource = !resources_for_scope.is_disjoint(&action_resources);
-                matching_principal && matching_resource
-            })
-        })
-        .into_iter()
+        if apply_specs.any(|spec| {
+            let action_principals = spec.applicable_principal_types().collect::<HashSet<_>>();
+            let action_resources = spec.applicable_resource_types().collect::<HashSet<_>>();
+            let matching_principal = !principals_for_scope.is_disjoint(&action_principals);
+            let matching_resource = !resources_for_scope.is_disjoint(&action_resources);
+            matching_principal && matching_resource
+        }) {
+            Ok(())
+        } else {
+            let would_in_fix_principal =
+                self.check_if_in_fixes_principal(principal_constraint, action_constraint);
+            let would_in_fix_resource =
+                self.check_if_in_fixes_resource(resource_constraint, action_constraint);
+            Err(ValidationError::invalid_action_application(
+                source_loc.cloned(),
+                policy_id.clone(),
+                would_in_fix_principal,
+                would_in_fix_resource,
+            ))
+        }
     }
 
     /// Gather all `ApplySpec` objects for all actions in the schema.
@@ -466,12 +465,11 @@ mod test {
         let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<ValidationError> =
-            validate.validate_template_action_application(&p).collect();
+        let notes = validate.validate_template_action_application(&p);
 
         expect_err(
             src,
-            &Report::new(notes.first().unwrap().clone()),
+            &Report::new(notes.unwrap_err()),
             &ExpectedErrorMessageBuilder::error(
                 r#"for policy `policy0`, unable to find an applicable action given the policy scope constraints"#,
             )
@@ -479,7 +477,6 @@ mod test {
             .exactly_one_underline(src)
             .build(),
         );
-        assert_eq!(notes.len(), 1, "{notes:?}");
     }
 
     #[test]
@@ -1246,19 +1243,17 @@ mod test {
         let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<ValidationError> =
-            validate.validate_template_action_application(&p).collect();
+        let notes = validate.validate_template_action_application(&p);
 
         expect_err(
             src,
-            &Report::new(notes.first().unwrap().clone()),
+            &Report::new(notes.unwrap_err()),
             &ExpectedErrorMessageBuilder::error(
                 r#"for policy `policy0`, unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),
         );
-        assert_eq!(notes.len(), 1, "{notes:?}");
     }
 
     #[test]
@@ -1270,19 +1265,17 @@ mod test {
         let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<ValidationError> =
-            validate.validate_template_action_application(&p).collect();
+        let notes = validate.validate_template_action_application(&p);
 
         expect_err(
             src,
-            &Report::new(notes.first().unwrap().clone()),
+            &Report::new(notes.unwrap_err()),
             &ExpectedErrorMessageBuilder::error(
                 r#"for policy `policy0`, unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),
         );
-        assert_eq!(notes.len(), 1, "{notes:?}");
     }
 
     #[test]
@@ -1294,19 +1287,17 @@ mod test {
         let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<ValidationError> =
-            validate.validate_template_action_application(&p).collect();
+        let notes = validate.validate_template_action_application(&p);
 
         expect_err(
             src,
-            &Report::new(notes.first().unwrap().clone()),
+            &Report::new(notes.unwrap_err()),
             &ExpectedErrorMessageBuilder::error(
                 r#"for policy `policy0`, unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),
         );
-        assert_eq!(notes.len(), 1, "{notes:?}");
     }
 
     #[test]


### PR DESCRIPTION
For `InvalidActionApplication` errors, we were computing a relativitly expensive flag used for the help messages for policies that didn't contain any errors. Optimize to only compute it after we know we need to report an error. This shouldn't be a huge optimization since the cost scaled with the size of the `appliesTo` lists (not the total number of actions or entities).


## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
