### PR TITLE
fix id preservation in pst

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 Cedar Language Version: TBD
 
 ### Fixed
+- Fixed `Policy::try_into_pst()` and `Template::try_into_pst()` to preserve policy IDs for text- and JSON-backed values, restoring `PolicySet::try_into_pst()` / `PolicySet::from_pst()` round trips.
 - In the experimental `protobufs` feature, the `Schema::decode` function now accepts schemas that reference `Action` entity types not defined in the schema. This was previously  rejected (#2491).
 - For the experimental `tpe` feature, fixed `TpeResponse::policy_set` to return the residual policies, matching `TpeResponse::policies` as documented. Previously it returned the original policies (#2540).
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3514,17 +3514,31 @@ impl Template {
 
     /// Get the PST representation of this template.
     pub fn to_pst(&self) -> Result<pst::Template, pst::PstConstructionError> {
-        self.lossless
-            .pst(|| pst::Template::try_from(self.ast.clone()))
-            .map(|t| t.with_id(self.ast.id().clone().into()))
+        Self::pst_with_id(
+            self.ast.id().clone(),
+            self.lossless
+                .pst(|| pst::Template::try_from(self.ast.clone())),
+        )
     }
 
     /// Get an owned PST representation of this template.
     /// Can return an error if the template was built from a non-PST representation that
     /// is not a valid Cedar template.
     pub fn try_into_pst(self) -> Result<pst::Template, pst::PstConstructionError> {
-        self.lossless
-            .try_into_pst(|| pst::Template::try_from(self.ast))
+        let id = self.ast.id().clone();
+        Self::pst_with_id(
+            id,
+            self.lossless
+                .try_into_pst(|| pst::Template::try_from(self.ast)),
+        )
+    }
+
+    /// Replace the representation-specific ID with the authoritative AST ID.
+    fn pst_with_id(
+        id: ast::PolicyID,
+        template: Result<pst::Template, pst::PstConstructionError>,
+    ) -> Result<pst::Template, pst::PstConstructionError> {
+        template.map(|template| template.with_id(id.into()))
     }
 
     /// Attempt to parse a [`Template`] from source.
@@ -4270,16 +4284,30 @@ impl Policy {
 
     /// Get the PST representation of this policy.
     pub fn to_pst(&self) -> Result<pst::Policy, pst::PstConstructionError> {
-        self.lossless
-            .pst(|| pst::Policy::try_from(self.ast.clone()))
-            .map(|p| p.new_id(self.ast.id().clone().into()))
+        Self::pst_with_id(
+            self.ast.id().clone(),
+            self.lossless
+                .pst(|| pst::Policy::try_from(self.ast.clone())),
+        )
     }
 
     /// Get an owned PST representation of this policy. May return an error when the policy
     /// has been constructed from a different representation that is not a valid Cedar policy.
     pub fn try_into_pst(self) -> Result<pst::Policy, pst::PstConstructionError> {
-        self.lossless
-            .try_into_pst(|| pst::Policy::try_from(self.ast.clone()))
+        let id = self.ast.id().clone();
+        Self::pst_with_id(
+            id,
+            self.lossless
+                .try_into_pst(|| pst::Policy::try_from(self.ast)),
+        )
+    }
+
+    /// Replace the representation-specific ID with the authoritative AST ID.
+    fn pst_with_id(
+        id: ast::PolicyID,
+        policy: Result<pst::Policy, pst::PstConstructionError>,
+    ) -> Result<pst::Policy, pst::PstConstructionError> {
+        policy.map(|policy| policy.new_id(id.into()))
     }
 
     /// Get all the unknown entities from the policy

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -9681,7 +9681,7 @@ mod has_non_scope_constraint {
 mod pst_api {
     use super::super::super::*;
     use cool_asserts::assert_matches;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, HashMap, HashSet};
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -9802,24 +9802,55 @@ mod pst_api {
     }
 
     #[test]
-    fn template_to_pst_preserves_id_from_text() {
+    fn template_pst_conversions_preserve_id_from_text() {
         let src = "permit(principal == ?principal, action, resource);";
-        let t = Template::parse(Some(PolicyId::new("my_template")), src).unwrap();
-        let pst = t.to_pst().expect("should succeed");
-        assert_eq!(pst.id, pst::PolicyID("my_template".into()));
+        let id = PolicyId::new("my_template");
+        let to_pst = Template::parse(Some(id.clone()), src)
+            .unwrap()
+            .to_pst()
+            .unwrap();
+        let into_pst = Template::parse(Some(id), src)
+            .unwrap()
+            .try_into_pst()
+            .unwrap();
+        assert_eq!(to_pst.id, pst::PolicyID("my_template".into()));
+        assert_eq!(into_pst.id, pst::PolicyID("my_template".into()));
     }
 
     #[test]
-    fn policy_to_pst_preserves_id_from_text() {
+    fn policy_pst_conversions_preserve_id_from_text() {
         let src = "permit(principal, action, resource);";
-        // When text is parsed and parse given a policy id, we should preserve that id in the PST
-        let p = Policy::parse(Some(PolicyId::new("my_policy")), src).unwrap();
-        let pst = p.to_pst().expect("should succeed");
-        if let pst::Policy::Static(sp) = &pst {
-            assert_eq!(sp.body().id, pst::PolicyID("my_policy".into()));
-        } else {
-            panic!("expected static policy");
+        let id = PolicyId::new("my_policy");
+        let to_pst = Policy::parse(Some(id.clone()), src)
+            .unwrap()
+            .to_pst()
+            .unwrap();
+        let into_pst = Policy::parse(Some(id), src)
+            .unwrap()
+            .try_into_pst()
+            .unwrap();
+        for pst in [to_pst, into_pst] {
+            assert_matches!(pst, pst::Policy::Static(sp) => {
+                assert_eq!(sp.body().id, pst::PolicyID("my_policy".into()));
+            });
         }
+    }
+
+    #[test]
+    fn policy_set_try_into_pst_roundtrip_preserves_ids_from_text() {
+        let src = r#"
+            permit(principal, action, resource);
+            forbid(principal, action == Action::"delete", resource);
+        "#;
+        let pset = PolicySet::from_str(src).unwrap();
+        let ids = |ps: &PolicySet| {
+            ps.policies()
+                .map(|p| p.id().to_string())
+                .collect::<HashSet<_>>()
+        };
+        let expected = ids(&pset);
+        let recovered = PolicySet::from_pst(pset.try_into_pst().unwrap()).unwrap();
+        assert_eq!(ids(&recovered), expected);
     }
 
     #[test]
@@ -9990,18 +10021,21 @@ mod pst_api {
             "resource": { "op": "All" },
             "conditions": [{ "kind": "when", "body": { "==": { "left": { "Var": "context" }, "right": { "Record": {} } } } }]
         });
-        let p = Policy::from_json(None, json.clone()).unwrap();
+        let id = PolicyId::new("my_policy");
+        let p = Policy::from_json(Some(id.clone()), json.clone()).unwrap();
         let pst = p.to_pst().expect("to_pst should succeed");
         if let pst::Policy::Static(sp) = &pst {
+            assert_eq!(sp.body().id, pst::PolicyID("my_policy".into()));
             assert_eq!(sp.body().effect, pst::Effect::Forbid);
             assert_eq!(sp.body().clauses().len(), 1);
         } else {
             panic!("expected static");
         }
         // also test try_into_pst
-        let p2 = Policy::from_json(None, json).unwrap();
-        let pst2 = p2.try_into_pst().expect("try_into_pst should succeed");
-        assert_matches!(pst2, pst::Policy::Static(_));
+        let p2 = Policy::from_json(Some(id), json).unwrap();
+        assert_matches!(p2.try_into_pst().unwrap(), pst::Policy::Static(sp) => {
+            assert_eq!(sp.body().id, pst::PolicyID("my_policy".into()));
+        });
     }
 
     #[test]
@@ -10013,14 +10047,17 @@ mod pst_api {
             "resource": { "op": "All" },
             "conditions": [{ "kind": "unless", "body": { "Var": "context" } }]
         });
-        let t = Template::from_json(None, json.clone()).unwrap();
+        let id = PolicyId::new("my_template");
+        let t = Template::from_json(Some(id.clone()), json.clone()).unwrap();
         let pst = t.to_pst().expect("to_pst should succeed");
+        assert_eq!(pst.id, pst::PolicyID("my_template".into()));
         assert!(pst.principal.has_slot());
         assert_eq!(pst.clauses().len(), 1);
         assert_matches!(pst.clauses()[0], pst::Clause::Unless(_));
         // also test try_into_pst
-        let t2 = Template::from_json(None, json).unwrap();
+        let t2 = Template::from_json(Some(id), json).unwrap();
         let pst2 = t2.try_into_pst().expect("try_into_pst should succeed");
+        assert_eq!(pst2.id, pst::PolicyID("my_template".into()));
         assert!(pst2.principal.has_slot());
     }
 


### PR DESCRIPTION
Fixes how `id` of templates and policies are generated, it was inconsistent between `to_pst` and `try_into_pst`.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.

