### PR TITLE
Move invalid action application errors from an error to a warning

### DIFF
--- a/cedar-policy-core/src/validator.rs
+++ b/cedar-policy-core/src/validator.rs
@@ -123,13 +123,14 @@ impl Validator {
             .unzip();
         let template_and_static_policy_errs = validate_policy_results.0.into_iter().flatten();
         let template_and_static_policy_warnings = validate_policy_results.1.into_iter().flatten();
-        let link_errs = policies
+        let (link_errs, link_warnings): (Vec<_>, Vec<_>) = policies
             .policies()
             .filter_map(|p| self.validate_slots(p, mode))
-            .flatten();
+            .unzip();
         ValidationResult::new(
-            template_and_static_policy_errs.chain(link_errs),
+            template_and_static_policy_errs.chain(link_errs.into_iter().flatten()),
             template_and_static_policy_warnings
+                .chain(link_warnings.into_iter().flatten())
                 .chain(confusable_string_checks(policies.all_templates())),
         )
     }
@@ -150,13 +151,14 @@ impl Validator {
             .unzip();
         let template_and_static_policy_errs = validate_policy_results.0.into_iter().flatten();
         let template_and_static_policy_warnings = validate_policy_results.1.into_iter().flatten();
-        let link_errs = policies
+        let (link_errs, link_warnings): (Vec<_>, Vec<_>) = policies
             .policies()
             .filter_map(|p| self.validate_slots(p, mode))
-            .flatten();
+            .unzip();
         ValidationResult::new(
-            template_and_static_policy_errs.chain(link_errs),
+            template_and_static_policy_errs.chain(link_errs.into_iter().flatten()),
             template_and_static_policy_warnings
+                .chain(link_warnings.into_iter().flatten())
                 .chain(confusable_string_checks(policies.all_templates())),
         )
     }
@@ -172,28 +174,32 @@ impl Validator {
         impl Iterator<Item = ValidationError> + 'a,
         impl Iterator<Item = ValidationWarning> + 'a,
     ) {
-        let validation_errors = if mode.is_partial() {
+        let (validation_errors, action_application_warning) = if mode.is_partial() {
             // We skip `validate_entity_types`, `validate_action_ids`, and
             // `validate_action_application` passes for partial schema
             // validation because there may be arbitrary extra entity types and
             // actions, so we can never claim that one doesn't exist.
-            None
+            (None, None)
         } else {
-            Some(
-                Validator::validate_entity_types(&self.schema, p)
-                    .chain(Validator::validate_enum_entity(&self.schema, p))
-                    .chain(Validator::validate_action_ids(&self.schema, p))
-                    // We could usefully update this pass to apply to partial
-                    // schema if it only failed when there is a known action
-                    // applied to known principal/resource entity types that are
-                    // not in its `appliesTo`.
-                    .chain(self.validate_template_action_application(p).err()),
+            (
+                Some(
+                    Validator::validate_entity_types(&self.schema, p)
+                        .chain(Validator::validate_enum_entity(&self.schema, p))
+                        .chain(Validator::validate_action_ids(&self.schema, p)),
+                ),
+                // We could usefully update this pass to apply to partial
+                // schema if it only warned when there is a known action
+                // applied to known principal/resource entity types that are
+                // not in its `appliesTo`.
+                self.validate_template_action_application(p).err(),
             )
-        }
-        .into_iter()
-        .flatten();
+        };
+        let validation_errors = validation_errors.into_iter().flatten();
         let (errors, warnings) = self.typecheck_policy(p, mode);
-        (validation_errors.chain(errors), warnings)
+        (
+            validation_errors.chain(errors),
+            action_application_warning.into_iter().chain(warnings),
+        )
     }
 
     /// Check that all entity types are defined in the schema, and each entity
@@ -215,7 +221,10 @@ impl Validator {
         &'a self,
         p: &'a Policy,
         mode: ValidationMode,
-    ) -> Option<impl Iterator<Item = ValidationError> + 'a> {
+    ) -> Option<(
+        impl Iterator<Item = ValidationError> + 'a,
+        Option<ValidationWarning>,
+    )> {
         // Ignore static policies since they are already handled by `validate_policy`
         if p.is_static() {
             return None;
@@ -229,10 +238,10 @@ impl Validator {
         // For template-linked policies `Policy::principal_constraint()` and
         // `Policy::resource_constraint()` return a copy of the constraint with
         // the slot filled by the appropriate value.
-        Some(
-            self.validate_entity_types_in_slots(p.id(), p.env())
-                .chain(self.validate_linked_action_application(p).err()),
-        )
+        Some((
+            self.validate_entity_types_in_slots(p.id(), p.env()),
+            self.validate_linked_action_application(p).err(),
+        ))
     }
 
     /// Construct a Typechecker instance and use it to detect any type errors in
@@ -472,14 +481,15 @@ mod test {
         .expect("Linking failed!");
         let result = validator.validate(&set, ValidationMode::default());
         assert!(!result.validation_passed());
-        assert_eq!(result.validation_errors().count(), 2);
+        assert_eq!(result.validation_errors().count(), 1);
         let undefined_err = ValidationError::unrecognized_entity_type(
             None,
             PolicyID::from_string("link2"),
             "some_namespace::Undefined".to_string(),
             Some("some_namespace::User".to_string()),
         );
-        let invalid_action_err = ValidationError::invalid_action_application(
+        // no action can apply to the linked resource type, which is a warning
+        let invalid_action_warning = ValidationWarning::invalid_action_application(
             loc.clone(),
             PolicyID::from_string("link2"),
             false,
@@ -492,13 +502,14 @@ mod test {
             .unwrap();
         assert_eq!(actual_undef_error, &undefined_err);
 
-        let actual_action_error = result
-            .validation_errors()
-            .find(|e| matches!(e, ValidationError::InvalidActionApplication(_)))
+        let actual_action_warning = result
+            .validation_warnings()
+            .find(|w| matches!(w, ValidationWarning::InvalidActionApplication(_)))
             .unwrap();
-        assert_eq!(actual_action_error, &invalid_action_err);
+        assert_eq!(actual_action_warning, &invalid_action_warning);
 
-        // this is also an invalid link (not a valid resource type for any action in the schema)
+        // this is also an invalid link (not a valid resource type for any action
+        // in the schema), but that only warrants a warning
         let mut values = HashMap::new();
         values.insert(
             ast::SlotId::resource(),
@@ -516,15 +527,17 @@ mod test {
         .expect("Linking failed!");
         let result = validator.validate(&set, ValidationMode::default());
         assert!(!result.validation_passed());
-        // `result` contains the two prior error messages plus one new one
-        assert_eq!(result.validation_errors().count(), 3);
-        let invalid_action_err = ValidationError::invalid_action_application(
+        // `result` contains the one prior error message plus one new warning
+        assert_eq!(result.validation_errors().count(), 1);
+        let invalid_action_warning = ValidationWarning::invalid_action_application(
             loc,
             PolicyID::from_string("link3"),
             false,
             false,
         );
-        assert!(result.validation_errors().contains(&invalid_action_err));
+        assert!(result
+            .validation_warnings()
+            .contains(&invalid_action_warning));
 
         Ok(())
     }
@@ -664,7 +677,11 @@ mod enumerated_entity_types {
         let validator = Validator::new(schema);
         let result = validator.validate(&policy_set, crate::validator::ValidationMode::Strict);
 
-        assert_eq!(result.validation_errors().collect_vec().len(), 1);
+        assert!(result.validation_errors().collect_vec().is_empty());
+        assert_matches!(
+            result.validation_warnings().collect_vec().as_slice(),
+            [ValidationWarning::InvalidActionApplication(_)]
+        );
     }
 
     #[test]

--- a/cedar-policy-core/src/validator/diagnostics.rs
+++ b/cedar-policy-core/src/validator/diagnostics.rs
@@ -101,12 +101,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnrecognizedActionId(#[from] validation_errors::UnrecognizedActionId),
-    /// There is no action satisfying the action scope constraint that can be
-    /// applied to a principal and resources that both satisfy their respective
-    /// scope conditions.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    InvalidActionApplication(#[from] validation_errors::InvalidActionApplication),
     /// The typechecker expected to see a subtype of one of the types in
     /// `expected`, but saw `actual`.
     #[error(transparent)]
@@ -201,21 +195,6 @@ impl ValidationError {
             policy_id,
             actual_action_id,
             hint,
-        }
-        .into()
-    }
-
-    pub(crate) fn invalid_action_application(
-        source_loc: Option<Loc>,
-        policy_id: PolicyID,
-        would_in_fix_principal: bool,
-        would_in_fix_resource: bool,
-    ) -> Self {
-        validation_errors::InvalidActionApplication {
-            source_loc,
-            policy_id,
-            would_in_fix_principal,
-            would_in_fix_resource,
         }
         .into()
     }
@@ -453,6 +432,12 @@ pub enum ValidationWarning {
     #[diagnostic(transparent)]
     #[error(transparent)]
     ImpossiblePolicy(#[from] validation_warnings::ImpossiblePolicy),
+    /// There is no action satisfying the action scope constraint that can be
+    /// applied to a principal and resources that both satisfy their respective
+    /// scope conditions, so the policy can never apply to any request.
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    InvalidActionApplication(#[from] validation_warnings::InvalidActionApplication),
 }
 
 impl ValidationWarning {
@@ -527,6 +512,21 @@ impl ValidationWarning {
         validation_warnings::ImpossiblePolicy {
             source_loc,
             policy_id,
+        }
+        .into()
+    }
+
+    pub(crate) fn invalid_action_application(
+        source_loc: Option<Loc>,
+        policy_id: PolicyID,
+        would_in_fix_principal: bool,
+        would_in_fix_resource: bool,
+    ) -> Self {
+        validation_warnings::InvalidActionApplication {
+            source_loc,
+            policy_id,
+            would_in_fix_principal,
+            would_in_fix_resource,
         }
         .into()
     }

--- a/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
@@ -137,39 +137,6 @@ pub fn unrecognized_action_id_help(
     }
 }
 
-/// Structure containing details about an invalid action application error.
-#[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
-#[error("for policy `{policy_id}`, unable to find an applicable action given the policy scope constraints")]
-pub struct InvalidActionApplication {
-    /// Source location
-    pub source_loc: Option<Loc>,
-    /// Policy ID where the error occurred
-    pub policy_id: PolicyID,
-    /// `true` if changing `==` to `in` would fix the principal clause
-    pub would_in_fix_principal: bool,
-    /// `true` if changing `==` to `in` would fix the resource clause
-    pub would_in_fix_resource: bool,
-}
-
-impl Diagnostic for InvalidActionApplication {
-    impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        match (self.would_in_fix_principal, self.would_in_fix_resource) {
-            (true, false) => Some(Box::new(
-                "try replacing `==` with `in` in the principal clause",
-            )),
-            (false, true) => Some(Box::new(
-                "try replacing `==` with `in` in the resource clause",
-            )),
-            (true, true) => Some(Box::new(
-                "try replacing `==` with `in` in the principal clause and the resource clause",
-            )),
-            (false, false) => None,
-        }
-    }
-}
-
 /// Structure containing details about an unexpected type error.
 #[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 #[error("for policy `{policy_id}`, unexpected type: expected {} but saw {}",

--- a/cedar-policy-core/src/validator/diagnostics/validation_warnings.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_warnings.rs
@@ -135,3 +135,38 @@ impl Diagnostic for ImpossiblePolicy {
     impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
+
+/// Warning for policies where no action in the schema can be applied to a
+/// principal and resource that both satisfy the policy scope
+#[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
+#[error("for policy `{policy_id}`, unable to find an applicable action given the policy scope constraints")]
+pub struct InvalidActionApplication {
+    /// Source location
+    pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
+    pub policy_id: PolicyID,
+    /// `true` if changing `==` to `in` would fix the principal clause
+    pub would_in_fix_principal: bool,
+    /// `true` if changing `==` to `in` would fix the resource clause
+    pub would_in_fix_resource: bool,
+}
+
+impl Diagnostic for InvalidActionApplication {
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
+    impl_diagnostic_warning!();
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        match (self.would_in_fix_principal, self.would_in_fix_resource) {
+            (true, false) => Some(Box::new(
+                "try replacing `==` with `in` in the principal clause",
+            )),
+            (false, true) => Some(Box::new(
+                "try replacing `==` with `in` in the resource clause",
+            )),
+            (true, true) => Some(Box::new(
+                "try replacing `==` with `in` in the principal clause and the resource clause",
+            )),
+            (false, false) => None,
+        }
+    }
+}

--- a/cedar-policy-core/src/validator/rbac.rs
+++ b/cedar-policy-core/src/validator/rbac.rs
@@ -1185,7 +1185,7 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_validate_policy_errors(
+    fn assert_validate_policy_fails(
         validator: &Validator,
         policy: &Template,
         expected: &[ValidationError],
@@ -1350,13 +1350,13 @@ mod test {
         let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
-        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_fails(&validator, &policy, &[]);
         assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal is biz in faz::"a", action, resource);"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_errors(
+        assert_validate_policy_fails(
             &validator,
             &policy,
             &[
@@ -1379,7 +1379,7 @@ mod test {
         let src = r#"permit(principal is bar in baz::"buz", action, resource);"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_fails(&validator, &policy, &[]);
         assert_validate_policy_flags_invalid_action_application(&validator, &policy);
     }
 
@@ -1410,19 +1410,19 @@ mod test {
         let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
-        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_fails(&validator, &policy, &[]);
         assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is baz in bar::"buz");"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_fails(&validator, &policy, &[]);
         assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is biz in faz::"a");"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_errors(
+        assert_validate_policy_fails(
             &validator,
             &policy,
             &[

--- a/cedar-policy-core/src/validator/rbac.rs
+++ b/cedar-policy-core/src/validator/rbac.rs
@@ -31,7 +31,7 @@ use std::{collections::HashSet, sync::Arc};
 use crate::validator::{
     expr_iterator::{policy_entity_type_names, policy_entity_uids},
     validation_errors::unrecognized_action_id_help,
-    ValidationError,
+    ValidationError, ValidationWarning,
 };
 
 use super::{schema::*, Validator};
@@ -226,7 +226,7 @@ impl Validator {
     pub(crate) fn validate_linked_action_application<'a>(
         &self,
         p: &'a Policy,
-    ) -> Result<(), ValidationError> {
+    ) -> Result<(), ValidationWarning> {
         self.validate_action_application(
             p.loc(),
             p.id(),
@@ -239,7 +239,7 @@ impl Validator {
     pub(crate) fn validate_template_action_application<'a>(
         &self,
         t: &'a Template,
-    ) -> Result<(), ValidationError> {
+    ) -> Result<(), ValidationWarning> {
         self.validate_action_application(
             t.loc(),
             t.id(),
@@ -260,7 +260,7 @@ impl Validator {
         principal_constraint: &PrincipalConstraint,
         action_constraint: &ActionConstraint,
         resource_constraint: &ResourceConstraint,
-    ) -> Result<(), ValidationError> {
+    ) -> Result<(), ValidationWarning> {
         let mut apply_specs = self.get_apply_specs_for_action(action_constraint);
         let resources_for_scope: HashSet<&ast::EntityType> = self
             .get_resources_satisfying_constraint(resource_constraint)
@@ -282,7 +282,7 @@ impl Validator {
                 self.check_if_in_fixes_principal(principal_constraint, action_constraint);
             let would_in_fix_resource =
                 self.check_if_in_fixes_resource(resource_constraint, action_constraint);
-            Err(ValidationError::invalid_action_application(
+            Err(ValidationWarning::invalid_action_application(
                 source_loc.cloned(),
                 policy_id.clone(),
                 would_in_fix_principal,
@@ -1185,7 +1185,7 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_validate_policy_fails(
+    fn assert_validate_policy_errors(
         validator: &Validator,
         policy: &Template,
         expected: &[ValidationError],
@@ -1211,6 +1211,29 @@ mod test {
                 policy.loc().cloned(),
                 policy.id().clone()
             )],
+            "Unexpected validation warnings."
+        );
+    }
+
+    #[track_caller]
+    fn assert_validate_policy_flags_invalid_action_application(
+        validator: &Validator,
+        policy: &Template,
+    ) {
+        assert_eq!(
+            validator
+                .validate_policy(policy, ValidationMode::default())
+                .1
+                .collect::<Vec<ValidationWarning>>(),
+            vec![
+                ValidationWarning::invalid_action_application(
+                    policy.loc().cloned(),
+                    policy.id().clone(),
+                    false,
+                    false,
+                ),
+                ValidationWarning::impossible_policy(policy.loc().cloned(), policy.id().clone()),
+            ],
             "Unexpected validation warnings."
         );
     }
@@ -1327,22 +1350,13 @@ mod test {
         let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
-        assert_validate_policy_fails(
-            &validator,
-            &policy,
-            &[ValidationError::invalid_action_application(
-                Some(Loc::new(0..43, Arc::from(src))),
-                PolicyID::from_string("policy0"),
-                false,
-                false,
-            )],
-        );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal is biz in faz::"a", action, resource);"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_fails(
+        assert_validate_policy_errors(
             &validator,
             &policy,
             &[
@@ -1358,30 +1372,15 @@ mod test {
                     "biz".into(),
                     Some("baz".into()),
                 ),
-                ValidationError::invalid_action_application(
-                    Some(Loc::new(0..55, Arc::from(src))),
-                    PolicyID::from_string("policy0"),
-                    false,
-                    false,
-                ),
             ],
         );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal is bar in baz::"buz", action, resource);"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_fails(
-            &validator,
-            &policy,
-            &[ValidationError::invalid_action_application(
-                Some(Loc::new(0..57, Arc::from(src))),
-                PolicyID::from_string("policy0"),
-                false,
-                false,
-            )],
-        );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
     }
 
     #[test]
@@ -1411,37 +1410,19 @@ mod test {
         let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
-        assert_validate_policy_fails(
-            &validator,
-            &policy,
-            &[ValidationError::invalid_action_application(
-                Some(Loc::new(0..43, Arc::from(src))),
-                PolicyID::from_string("policy0"),
-                false,
-                false,
-            )],
-        );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is baz in bar::"buz");"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_fails(
-            &validator,
-            &policy,
-            &[ValidationError::invalid_action_application(
-                Some(Loc::new(0..57, Arc::from(src))),
-                PolicyID::from_string("policy0"),
-                false,
-                false,
-            )],
-        );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_errors(&validator, &policy, &[]);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is biz in faz::"a");"#;
         let policy = parse_policy_or_template(None, src).unwrap();
 
-        assert_validate_policy_fails(
+        assert_validate_policy_errors(
             &validator,
             &policy,
             &[
@@ -1457,15 +1438,9 @@ mod test {
                     "biz".into(),
                     Some("baz".into()),
                 ),
-                ValidationError::invalid_action_application(
-                    Some(Loc::new(0..55, Arc::from(src))),
-                    PolicyID::from_string("policy0"),
-                    false,
-                    false,
-                ),
             ],
         );
-        assert_validate_policy_flags_impossible_policy(&validator, &policy);
+        assert_validate_policy_flags_invalid_action_application(&validator, &policy);
     }
 
     #[test]
@@ -1640,7 +1615,7 @@ mod test {
 
         let validator = Validator::new(schema);
         let (template, _) = Template::link_static_policy(policy);
-        assert_validate_policy_flags_impossible_policy(&validator, &template);
+        assert_validate_policy_flags_invalid_action_application(&validator, &template);
     }
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,9 +17,9 @@ Cedar Language Version: TBD
 ### Changed
 
 - Invalid action application errors ("Unable to find an applicable action given the policy scope constraints")
-  are now reported as a validation warning instead of errors. These errors do not indicate that a run-time
+  are now reported as validation warnings instead of errors. These do not indicate that a run-time
   error may exist in the policy. They are similar to the impossible policy warning, indicating that a policy
-  cannot apply to any request. This change makes it possible to remove entires from an `appliesTo` list
+  cannot apply to any request. This change makes it possible to remove entries from an `appliesTo` list
   without introducing validation errors. Callers that want to keep rejecting these policies should check
   `ValidationResult::validation_warnings` for `ValidationWarning::InvalidActionApplication`.
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,6 +14,16 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 Cedar Language Version: TBD
 
+### Changed
+
+- Invalid action application errors ("Unable to find an applicable action given the policy scope constraints")
+  are now reported as a validation warning instead of errors. These errors do not indicate that a run-time
+  error may exist in the policy. They are similar to the impossible policy warning, indicating that a policy
+  cannot apply to any request. This change makes it possible to remove entires from an `appliesTo` list
+  without introducing validation errors. Callers that want to keep rejecting these policies should check
+  `ValidationResult::validation_warnings` for `ValidationWarning::InvalidActionApplication`.
+
+
 ### Fixed
 - Fixed `Policy::try_into_pst()` and `Template::try_into_pst()` to preserve policy IDs for text- and JSON-backed values, restoring `PolicySet::try_into_pst()` / `PolicySet::from_pst()` round trips.
 - In the experimental `protobufs` feature, the `Schema::decode` function now accepts schemas that reference `Action` entity types not defined in the schema. This was previously  rejected (#2491).

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -412,6 +412,10 @@ pub enum ValidationError {
     /// There is no action satisfying the action scope constraint that can be
     /// applied to a principal and resources that both satisfy their respective
     /// scope conditions.
+    ///
+    /// This error type is no longer ever returned; it is now reported as
+    /// [`ValidationWarning::InvalidActionApplication`] instead. It remains here
+    /// for backwards-compatibility.
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionApplication(#[from] validation_errors::InvalidActionApplication),
@@ -519,9 +523,6 @@ impl From<cedar_policy_core::validator::ValidationError> for ValidationError {
             cedar_policy_core::validator::ValidationError::UnrecognizedActionId(e) => {
                 Self::UnrecognizedActionId(e.into())
             }
-            cedar_policy_core::validator::ValidationError::InvalidActionApplication(e) => {
-                Self::InvalidActionApplication(e.into())
-            }
             cedar_policy_core::validator::ValidationError::UnexpectedType(e) => {
                 Self::UnexpectedType(e.into())
             }
@@ -612,6 +613,12 @@ pub enum ValidationWarning {
     #[diagnostic(transparent)]
     #[error(transparent)]
     ImpossiblePolicy(#[from] validation_warnings::ImpossiblePolicy),
+    /// There is no action satisfying the action scope constraint that can be
+    /// applied to a principal and resources that both satisfy their respective
+    /// scope conditions, so the policy can never apply to any request.
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    InvalidActionApplication(#[from] validation_warnings::InvalidActionApplication),
 }
 
 impl ValidationWarning {
@@ -624,6 +631,7 @@ impl ValidationWarning {
             Self::MixedScriptIdentifier(w) => w.policy_id(),
             Self::ConfusableIdentifier(w) => w.policy_id(),
             Self::ImpossiblePolicy(w) => w.policy_id(),
+            Self::InvalidActionApplication(w) => w.policy_id(),
         }
     }
 }
@@ -649,6 +657,9 @@ impl From<cedar_policy_core::validator::ValidationWarning> for ValidationWarning
             }
             cedar_policy_core::validator::ValidationWarning::ImpossiblePolicy(w) => {
                 Self::ImpossiblePolicy(w.into())
+            }
+            cedar_policy_core::validator::ValidationWarning::InvalidActionApplication(w) => {
+                Self::InvalidActionApplication(w.into())
             }
         }
     }

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -34,11 +34,14 @@ use crate::ValidationError;
 // documentation should be written.
 macro_rules! wrap_core_error {
     ($s:ident) => {
+        wrap_core_error!($s, validation_errors);
+    };
+    ($s:ident, $m:ident) => {
         #[derive(Debug, Clone, Error, Diagnostic)]
         #[error(transparent)]
         #[diagnostic(transparent)]
         #[doc=concat!("Structure containing details about a [`ValidationError::", stringify!($s), "`].")]
-        pub struct $s(cedar_policy_core::validator::validation_errors::$s);
+        pub struct $s(cedar_policy_core::validator::$m::$s);
 
         impl $s {
             /// Access the `[PolicyId]` for the policy where this error was found.
@@ -48,8 +51,8 @@ macro_rules! wrap_core_error {
         }
 
         #[doc(hidden)]
-        impl From<cedar_policy_core::validator::validation_errors::$s> for $s {
-            fn from(e: cedar_policy_core::validator::validation_errors::$s) -> Self {
+        impl From<cedar_policy_core::validator::$m::$s> for $s {
+            fn from(e: cedar_policy_core::validator::$m::$s) -> Self {
                 Self(e)
             }
         }
@@ -58,7 +61,7 @@ macro_rules! wrap_core_error {
 
 wrap_core_error!(UnrecognizedEntityType);
 wrap_core_error!(UnrecognizedActionId);
-wrap_core_error!(InvalidActionApplication);
+wrap_core_error!(InvalidActionApplication, validation_warnings);
 wrap_core_error!(UnexpectedType);
 wrap_core_error!(IncompatibleTypes);
 wrap_core_error!(UnsafeAttributeAccess);

--- a/cedar-policy/src/api/err/validation_warnings.rs
+++ b/cedar-policy/src/api/err/validation_warnings.rs
@@ -62,3 +62,4 @@ wrap_core_warning!(BidiCharsInIdentifier);
 wrap_core_warning!(MixedScriptIdentifier);
 wrap_core_warning!(ConfusableIdentifier);
 wrap_core_warning!(ImpossiblePolicy);
+wrap_core_warning!(InvalidActionApplication);

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -238,6 +238,30 @@ mod test {
         })
     }
 
+    /// Assert that [`validate_json()`] returns [`ValidationAnswer::Success`]
+    /// with no errors, and return the enclosed warnings
+    #[track_caller]
+    fn assert_validates_with_warnings(json: serde_json::Value) -> Vec<ValidationError> {
+        let ans_val = validate_json(json).unwrap();
+        let result: Result<ValidationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(ValidationAnswer::Success { validation_errors, validation_warnings, other_warnings: _ }) => {
+            assert_eq!(validation_errors.len(), 0, "Unexpected validation errors: {validation_errors:?}");
+            validation_warnings
+        })
+    }
+
+    /// Assert that `warnings` reports that no action can apply to `policy_id`
+    #[track_caller]
+    fn assert_invalid_action_application_warning(warnings: &[ValidationError], policy_id: &str) {
+        let msg = format!("for policy `{policy_id}`, unable to find an applicable action given the policy scope constraints");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.policy_id == PolicyId::new(policy_id) && w.error.message == msg),
+            "expected the warning `{msg}`, but saw warnings: {warnings:?}"
+        );
+    }
+
     /// Assert that [`validate_json_str()`] returns a `serde_json::Error`
     /// error with a message that matches `msg`
     #[track_caller]
@@ -361,7 +385,7 @@ mod test {
     }
 
     #[test]
-    fn test_semantically_incorrect_policy_fails_with_errors() {
+    fn test_impossible_policy_warns() {
         let json = json!({
         "schema": { "": {
           "entityTypes": {
@@ -388,25 +412,10 @@ mod test {
           }
         }});
 
-        let errs = assert_validates_with_errors(json);
-        assert_length_matches(&errs, 2);
-        for err in errs {
-            if err.policy_id == PolicyId::new("policy0") {
-                assert_error_matches(
-                    &err.error,
-                    "for policy `policy0`, unable to find an applicable action given the policy scope constraints",
-                    None
-                );
-            } else if err.policy_id == PolicyId::new("policy1") {
-                assert_error_matches(
-                    &err.error,
-                    "for policy `policy1`, unable to find an applicable action given the policy scope constraints",
-                    None
-                );
-            } else {
-                panic!("unexpected validation error: {err:?}");
-            }
-        }
+        // no action can apply to these policies, which is a warning, not an error
+        let warnings = assert_validates_with_warnings(json);
+        assert_invalid_action_application_warning(&warnings, "policy0");
+        assert_invalid_action_application_warning(&warnings, "policy1");
     }
 
     #[test]
@@ -524,7 +533,7 @@ mod test {
     }
 
     #[test]
-    fn test_semantically_incorrect_policy_fails_with_errors_concatenated_policies() {
+    fn test_impossible_policy_warns_concatenated_policies() {
         let json = json!({
           "schema": { "": {
             "entityTypes": {
@@ -549,14 +558,9 @@ mod test {
           }
         });
 
-        let errs = assert_validates_with_errors(json);
-        assert_length_matches(&errs, 1);
-        assert_eq!(errs[0].policy_id, PolicyId::new("policy1"));
-        assert_error_matches(
-            &errs[0].error,
-            "for policy `policy1`, unable to find an applicable action given the policy scope constraints",
-            None
-        );
+        // no action can apply to `policy1`, which is a warning, not an error
+        let warnings = assert_validates_with_warnings(json);
+        assert_invalid_action_application_warning(&warnings, "policy1");
     }
 
     #[test]
@@ -663,34 +667,15 @@ mod test {
             }
         });
         let errs = assert_validates_with_errors(json);
-        assert_length_matches(&errs, 3);
-        for err in errs {
-            if err.policy_id == PolicyId::new("ID1") {
-                if err.error.message.contains("unrecognized action") {
-                    assert_error_matches(
-                        &err.error,
-                        "for policy `ID1`, unrecognized action `Action::\"foo\"`",
-                        Some("did you mean `Action::\"viewPhoto\"`?"),
-                    );
-                } else {
-                    assert_error_matches(
-                        &err.error,
-                        "for policy `ID1`, unable to find an applicable action given the policy scope constraints",
-                        None,
-                    );
-                }
-            } else if err.policy_id == PolicyId::new("ID2") {
-                assert_error_matches(
-                    &err.error,
-                    "for policy `ID2`, unable to find an applicable action given the policy scope constraints",
-                    None,
-                );
-            } else {
-                panic!("unexpected validation error: {err:?}");
-            }
-        }
+        assert_length_matches(&errs, 1);
+        assert_eq!(errs[0].policy_id, PolicyId::new("ID1"));
+        assert_error_matches(
+            &errs[0].error,
+            "for policy `ID1`, unrecognized action `Action::\"foo\"`",
+            Some("did you mean `Action::\"viewPhoto\"`?"),
+        );
 
-        // Validation fails due to bad link
+        // Validation warns (but does not fail) due to bad link
         let json = json!({
             "schema": "entity User, Photo; action viewPhoto appliesTo { principal: User, resource: Photo };",
             "policies": {
@@ -709,13 +694,7 @@ mod test {
               }]
             }
         });
-        let errs = assert_validates_with_errors(json);
-        assert_length_matches(&errs, 1);
-        assert_eq!(errs[0].policy_id, PolicyId::new("ID2"));
-        assert_error_matches(
-            &errs[0].error,
-            "for policy `ID2`, unable to find an applicable action given the policy scope constraints",
-            None
-        );
+        let warnings = assert_validates_with_warnings(json);
+        assert_invalid_action_application_warning(&warnings, "ID2");
     }
 }

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -6065,6 +6065,45 @@ mod function_argument_validation_help_tests {
     }
 }
 
+mod invalid_action_application_tests {
+    use crate::{PolicyId, PolicySet, ValidationMode, ValidationWarning, Validator};
+    use std::str::FromStr;
+
+    use super::Schema;
+
+    #[test]
+    fn removing_applies_to_warns_but_does_not_error() {
+        let policies = PolicySet::from_str(
+            r#"
+            permit(principal == User::"alice", action == Action::"view", resource);
+            permit(principal is User, action in [Action::"view"], resource is Photo);
+            permit(principal, action, resource);
+            "#,
+        )
+        .unwrap();
+
+        // no `appliesTo` the actions, simulating an edit to the schema that "deletes" the action by
+        // removing it's `appliesTo` while keeping the action to avoid unknown action errors.
+        let schema = Schema::from_str("entity User; entity Photo; action view;").unwrap();
+        let result = Validator::new(schema).validate(&policies, ValidationMode::Strict);
+        assert!(
+            result.validation_passed(),
+            "unexpected validation errors: {:?}",
+            result.validation_errors().collect::<Vec<_>>()
+        );
+        for policy_id in ["policy0", "policy1", "policy2"] {
+            assert!(
+                result.validation_warnings().any(|w| {
+                    w.policy_id() == &PolicyId::new(policy_id)
+                        && matches!(w, ValidationWarning::InvalidActionApplication(_))
+                }),
+                "expected an `InvalidActionApplication` warning for `{policy_id}`, but saw {:?}",
+                result.validation_warnings().collect::<Vec<_>>()
+            );
+        }
+    }
+}
+
 mod issue_604 {
     use crate::Policy;
     use cedar_policy_core::parser::parse_policy_or_template_to_est;


### PR DESCRIPTION
This change lets us support an additional kind of backwards compatible schema change. Previosly, removing an entry form an action `appliesTo` list (or removing the `appliesTo` block entirely) could introduce a validation error. This change can't introduce any new type errors (or other run time errors). It can only make it so that some existing polices no longer apply to any valid authorizatoin requests. This is an interesting finding, but it isn't an error. It's essentialy a special kind of "impossible policy" finding which is already reported as a warning. 

For backwards compatibility, this keep the existing error variant and adds a new warning variant for this finding. 

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
