### PR TITLE
Compute datetime representation lazily to avoid extra heap allocations

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -421,15 +421,12 @@ pub trait ExtensionValue: Debug + Send + Sync + UnwindSafe + RefUnwindSafe {
     /// If it supports operator overloading
     fn supports_operator_overloading(&self) -> bool;
 
-    /// Return the canonical representation of this extension value, if it
-    /// differs from the one stored by the constructor. The canonical representation
-    /// is likely to differ from the constructed value by the formatting of its
-    /// arguments.
-    /// Used by TPE to normalize residuals.  The default (`None`) means "keep whatever the
-    /// constructor stored".
-    fn canonical_repr(&self) -> Option<(Name, Vec<RestrictedExpr>)> {
-        None
-    }
+    /// Return the canonical `(func, args)` representation of this extension
+    /// value, i.e. the one satisfying `eval(func(args)) == self`. It is likely
+    /// to differ from the representation stored by the constructor by the
+    /// formatting of its arguments.
+    /// Used by TPE to normalize residuals.
+    fn canonical_repr(&self) -> (Name, Vec<RestrictedExpr>);
 }
 
 impl<V: ExtensionValue> StaticallyTyped for V {
@@ -473,8 +470,6 @@ impl RepresentableExtensionValue {
     /// Create a [`RepresentableExtensionValue`] whose `(func, args)`
     /// representation is derived from [`ExtensionValue::canonical_repr`] on
     /// first access.
-    ///
-    /// Only valid for values whose `canonical_repr` returns `Some`.
     pub(crate) fn new_lazy(value: Arc<dyn InternalExtensionValue + Send + Sync>) -> Self {
         Self {
             repr: OnceLock::new(),
@@ -484,15 +479,7 @@ impl RepresentableExtensionValue {
 
     /// The `(func, args)` such that `eval(func(args)) == value`.
     fn repr(&self) -> &(Name, Vec<RestrictedExpr>) {
-        self.repr.get_or_init(|| {
-            #[expect(
-                clippy::expect_used,
-                reason = "`new_lazy` is only used for values whose `canonical_repr` is `Some`"
-            )]
-            self.value
-                .canonical_repr()
-                .expect("a lazily-represented extension value must have a canonical representation")
-        })
+        self.repr.get_or_init(|| self.value.canonical_repr())
     }
 
     /// The extension function whose call reproduces this value.

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -464,15 +464,15 @@ impl RepresentableExtensionValue {
         func: Name,
         args: Vec<RestrictedExpr>,
     ) -> Self {
-        let repr = OnceLock::new();
-        // `set` on a fresh `OnceLock` cannot fail.
-        let _ = repr.set((func, args));
-        Self { repr, value }
+        Self {
+            repr: OnceLock::from((func, args)),
+            value,
+        }
     }
 
     /// Create a [`RepresentableExtensionValue`] whose `(func, args)`
     /// representation is derived from [`ExtensionValue::canonical_repr`] on
-    /// first access rather than up front.
+    /// first access.
     ///
     /// Only valid for values whose `canonical_repr` returns `Some`.
     pub(crate) fn new_lazy(value: Arc<dyn InternalExtensionValue + Send + Sync>) -> Self {

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Debug;
 use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Cedar extension.
 ///
@@ -448,19 +448,61 @@ impl<V: ExtensionValue> StaticallyTyped for V {
 /// `datetime` is represented by an `offset` method call.
 /// Nevertheless, an invariant is that `eval(<func>(<args>)) == value`
 pub struct RepresentableExtensionValue {
-    pub(crate) func: Name,
-    pub(crate) args: Vec<RestrictedExpr>,
+    /// The `(func, args)` such that `eval(func(args)) == value`. When
+    /// constructed via [`RepresentableExtensionValue::new_lazy`] this is
+    /// initially empty and filled on first access from
+    /// [`ExtensionValue::canonical_repr`].
+    repr: OnceLock<(Name, Vec<RestrictedExpr>)>,
     pub(crate) value: Arc<dyn InternalExtensionValue>,
 }
 
 impl RepresentableExtensionValue {
-    /// Create a new [`RepresentableExtensionValue`]
+    /// Create a [`RepresentableExtensionValue`] with a known `(func, args)`
+    /// representation.
     pub fn new(
         value: Arc<dyn InternalExtensionValue + Send + Sync>,
         func: Name,
         args: Vec<RestrictedExpr>,
     ) -> Self {
-        Self { func, args, value }
+        let repr = OnceLock::new();
+        // `set` on a fresh `OnceLock` cannot fail.
+        let _ = repr.set((func, args));
+        Self { repr, value }
+    }
+
+    /// Create a [`RepresentableExtensionValue`] whose `(func, args)`
+    /// representation is derived from [`ExtensionValue::canonical_repr`] on
+    /// first access rather than up front.
+    ///
+    /// Only valid for values whose `canonical_repr` returns `Some`.
+    pub(crate) fn new_lazy(value: Arc<dyn InternalExtensionValue + Send + Sync>) -> Self {
+        Self {
+            repr: OnceLock::new(),
+            value,
+        }
+    }
+
+    /// The `(func, args)` such that `eval(func(args)) == value`.
+    fn repr(&self) -> &(Name, Vec<RestrictedExpr>) {
+        self.repr.get_or_init(|| {
+            #[expect(
+                clippy::expect_used,
+                reason = "`new_lazy` is only used for values whose `canonical_repr` is `Some`"
+            )]
+            self.value
+                .canonical_repr()
+                .expect("a lazily-represented extension value must have a canonical representation")
+        })
+    }
+
+    /// The extension function whose call reproduces this value.
+    pub(crate) fn func(&self) -> &Name {
+        &self.repr().0
+    }
+
+    /// The arguments to [`Self::func`] whose call reproduces this value.
+    pub(crate) fn args(&self) -> &[RestrictedExpr] {
+        &self.repr().1
     }
 
     /// Get the internal value
@@ -481,7 +523,14 @@ impl RepresentableExtensionValue {
 
 impl From<RepresentableExtensionValue> for RestrictedExpr {
     fn from(val: RepresentableExtensionValue) -> Self {
-        RestrictedExpr::call_extension_fn(val.func, val.args)
+        // Populate the cell, then take ownership of its contents.
+        val.repr();
+        #[expect(
+            clippy::expect_used,
+            reason = "`repr()` guarantees the cell is initialized"
+        )]
+        let (func, args) = val.repr.into_inner().expect("repr populated above");
+        RestrictedExpr::call_extension_fn(func, args)
     }
 }
 

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2232,9 +2232,9 @@ mod json_parsing_tests {
 
         assert_matches!(eparser.single_from_json_value(json), Ok(entity) => {
             assert_matches!(entity.get("time"), Some(PartialValue::Value(Value { value: ValueKind::ExtensionValue(v), .. })) => {
-                assert_eq!(v.func, "offset".parse().unwrap());
-                assert_eq!(v.args[0].to_string(), r#"datetime("1970-01-01")"#);
-                assert_eq!(v.args[1].to_string(), r#"duration("3600000ms")"#);
+                assert_eq!(*v.func(), "offset".parse().unwrap());
+                assert_eq!(v.args()[0].to_string(), r#"datetime("1970-01-01")"#);
+                assert_eq!(v.args()[1].to_string(), r#"duration("3600000ms")"#);
             });
         });
 
@@ -2252,9 +2252,9 @@ mod json_parsing_tests {
 
         assert_matches!(eparser.single_from_json_value(json), Ok(entity) => {
             assert_matches!(entity.get("time"), Some(PartialValue::Value(Value { value: ValueKind::ExtensionValue(v), .. })) => {
-                assert_eq!(v.func, "offset".parse().unwrap());
-                assert_eq!(v.args[0].to_string(), r#"datetime("1970-01-01")"#);
-                assert_eq!(v.args[1].to_string(), r#"duration("3600000ms")"#);
+                assert_eq!(*v.func(), "offset".parse().unwrap());
+                assert_eq!(v.args()[0].to_string(), r#"datetime("1970-01-01")"#);
+                assert_eq!(v.args()[1].to_string(), r#"duration("3600000ms")"#);
             });
         });
     }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -558,8 +558,8 @@ impl CedarValueJson {
                 ))
             }
             ValueKind::ExtensionValue(ev) => {
-                let ext_func = &ev.func;
-                match ev.args.as_slice() {
+                let ext_func = ev.func();
+                match ev.args() {
                     [] => Err(JsonSerializationError::call_0_args(ext_func.clone())),
                     [ref expr] => Ok(Self::ExtnEscape {
                         __extn: FnAndArgs::Single {

--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -354,12 +354,8 @@ impl From<DateTime> for RestrictedExpr {
 
 impl From<DateTime> for RepresentableExtensionValue {
     fn from(value: DateTime) -> Self {
-        let (func, args) = value.as_ext_func_call();
-        Self {
-            func,
-            args,
-            value: Arc::new(value),
-        }
+        // Representation is derived from `canonical_repr` on demand.
+        Self::new_lazy(Arc::new(value))
     }
 }
 
@@ -410,12 +406,8 @@ impl From<Duration> for RestrictedExpr {
 
 impl From<Duration> for RepresentableExtensionValue {
     fn from(value: Duration) -> Self {
-        let (func, args) = value.as_ext_func_call();
-        Self {
-            func,
-            args,
-            value: Arc::new(value),
-        }
+        // Representation is derived from `canonical_repr` on demand.
+        Self::new_lazy(Arc::new(value))
     }
 }
 

--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -284,9 +284,8 @@ impl ExtensionValue for DateTime {
     /// The canonical representation of a Cedar [`DateTime`] is the one returned by
     /// [`DateTime::as_ext_func_call`], i.e.
     /// `offset(datetime(<UNIX_EPOCH_STR>), duration("<Offset in MS>ms"))`
-    fn canonical_repr(&self) -> Option<(crate::ast::Name, Vec<crate::ast::RestrictedExpr>)> {
-        let (func, args) = (*self).as_ext_func_call();
-        Some((func, args))
+    fn canonical_repr(&self) -> (crate::ast::Name, Vec<crate::ast::RestrictedExpr>) {
+        (*self).as_ext_func_call()
     }
 }
 
@@ -391,9 +390,8 @@ impl ExtensionValue for Duration {
     }
     /// The canonical representation of a Cedar [`Duration`] is the one returned by
     /// duration("<MILLISECONDS>ms")
-    fn canonical_repr(&self) -> Option<(crate::ast::Name, Vec<RestrictedExpr>)> {
-        let (func, args) = (*self).as_ext_func_call();
-        Some((func, args))
+    fn canonical_repr(&self) -> (crate::ast::Name, Vec<RestrictedExpr>) {
+        (*self).as_ext_func_call()
     }
 }
 

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -182,11 +182,11 @@ impl ExtensionValue for Decimal {
     /// The canonical representation of a [`Decimal`] formats the argument string representing the
     /// decimal with [`NUM_DIGITS`] digits after `.`, even though the [`Decimal`] might have been constructed
     /// with a representation having fewer than [`NUM_DIGITS`].
-    fn canonical_repr(&self) -> Option<(Name, Vec<crate::ast::RestrictedExpr>)> {
-        Some((
+    fn canonical_repr(&self) -> (Name, Vec<crate::ast::RestrictedExpr>) {
+        (
             constants::DECIMAL_FROM_STR_NAME.clone(),
             vec![crate::ast::RestrictedExpr::val(self.to_string())],
-        ))
+        )
     }
 }
 

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -249,11 +249,11 @@ impl ExtensionValue for IPAddr {
 
     /// The canonical representation of an IP Address formats the IP address string
     /// argument of the `ip` extension.
-    fn canonical_repr(&self) -> Option<(Name, Vec<crate::ast::RestrictedExpr>)> {
-        Some((
+    fn canonical_repr(&self) -> (Name, Vec<crate::ast::RestrictedExpr>) {
+        (
             names::IP_FROM_STR_NAME.clone(),
             vec![crate::ast::RestrictedExpr::val(self.to_string())],
-        ))
+        )
     }
 }
 

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -517,9 +517,9 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
     match &value.value {
         ValueKind::Lit(_) => None,
         ValueKind::ExtensionValue(ev) => Some(Value {
-            value: ValueKind::ExtensionValue(Arc::new(
-                ast::RepresentableExtensionValue::new_lazy(ev.value.clone()),
-            )),
+            value: ValueKind::ExtensionValue(Arc::new(ast::RepresentableExtensionValue::new_lazy(
+                ev.value.clone(),
+            ))),
             loc: value.loc.clone(),
         }),
         ValueKind::Set(s) if s.fast.is_some() => {

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -503,10 +503,11 @@ impl Evaluator<'_> {
     }
 }
 
-/// If the value is an extension value whose type provides a [`canonical_repr`],
-/// rebuild the [`RepresentableExtensionValue`] so that the stored `func`/`args`
-/// match the canonical form.  This ensures TPE residuals are deterministic
-/// regardless of which constructor originally created the value.
+/// If the value is an extension value, rebuild the
+/// [`RepresentableExtensionValue`] so that the stored `func`/`args` match the
+/// canonical form given by [`ExtensionValue::canonical_repr`]. This ensures TPE
+/// residuals are deterministic regardless of which constructor originally
+/// created the value.
 fn normalize_ext_value(value: Value) -> Value {
     normalize_ext_value_inner(&value).unwrap_or(value)
 }
@@ -515,17 +516,12 @@ fn normalize_ext_value(value: Value) -> Value {
 fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
     match &value.value {
         ValueKind::Lit(_) => None,
-        ValueKind::ExtensionValue(ev) => {
-            let (func, args) = ev.value().canonical_repr()?;
-            Some(Value {
-                value: ValueKind::ExtensionValue(Arc::new(ast::RepresentableExtensionValue::new(
-                    ev.value.clone(),
-                    func,
-                    args,
-                ))),
-                loc: value.loc.clone(),
-            })
-        }
+        ValueKind::ExtensionValue(ev) => Some(Value {
+            value: ValueKind::ExtensionValue(Arc::new(
+                ast::RepresentableExtensionValue::new_lazy(ev.value.clone()),
+            )),
+            loc: value.loc.clone(),
+        }),
         ValueKind::Set(s) if s.fast.is_some() => {
             // due to invariant on set, this means all elements are literals, hence nothing to norm
             None


### PR DESCRIPTION
## Description of changes

Compute datetime representation lazily to avoid extra heap allocations on authorization path.

## Issue #, if available

https://github.com/cedar-policy/cedar/issues/2549

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
