### PR TITLE
Extend TPE to support attribute level partial information

### DIFF
--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -96,6 +96,7 @@ pub fn is_authorized_batched(
     let initial_evaluator = Evaluator {
         request: &request,
         entities: &entities,
+        schema,
         extensions: Extensions::all_available(),
     };
     let mut residuals: Vec<ResidualPolicy> = policy_residual_map(&request, ps, schema)?
@@ -150,6 +151,7 @@ pub fn is_authorized_batched(
         let evaluator = Evaluator {
             request: &request,
             entities: &entities,
+            schema,
             extensions: Extensions::all_available(),
         };
 

--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -31,6 +31,7 @@ use crate::tpe::err::PartialRequestError;
 use crate::tpe::policy_residual_map;
 use crate::tpe::request::{PartialEntityUID, PartialRequest};
 use crate::tpe::response::{decision_from_residuals, ResidualPolicy, Response};
+use crate::tpe::value::PartialRecord;
 use crate::validator::ValidatorSchema;
 use crate::{ast::PolicySet, extensions::Extensions};
 
@@ -69,7 +70,10 @@ fn concrete_request_to_partial(
 
     // Convert context
     let context = match &request.context {
-        Some(crate::ast::Context::Value(attrs)) => Some(attrs.clone()),
+        Some(crate::ast::Context::Value(attrs)) => Some(
+            PartialRecord::concrete_context_for_action(attrs, &action, schema)
+                .ok_or(PartialRequestError {})?,
+        ),
         Some(crate::ast::Context::RestrictedResidual(_)) => {
             return Err(PartialRequestError {}.into())
         }
@@ -125,26 +129,16 @@ pub fn is_authorized_batched(
                 to_load.insert(uid);
             }
         }
-        // Subtle: missing entities are equivalent empty entities in both normal and partial evaluation.
         let loaded_entities = loader.load_entities(&to_load);
-
-        // check that all requested entities were loaded and return error otherwise
-
         for (id, e_option) in loaded_entities {
-            match e_option {
-                Some(e) => {
-                    entities.add_entities(
-                        iter::once((id, PartialEntity::try_from(e)?)),
-                        schema,
-                        TCComputation::AssumeAlreadyComputed,
-                    )?;
-                }
-                None => {
-                    entities.add_entity_trusted(
-                        id.clone(),
-                        PartialEntity::try_from(Entity::with_uid(id))?,
-                    )?;
-                }
+            // If the entity isn't loaded we can't insert an empty entity as that would assume that
+            // the entity exists, allowing partial eval to unsoundly reduce `has` and `hasTag` to `true`
+            if let Some(e) = e_option {
+                entities.add_entities(
+                    iter::once((id, PartialEntity::from_entity(e, schema)?)),
+                    schema,
+                    TCComputation::AssumeAlreadyComputed,
+                )?;
             }
         }
 

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -89,6 +89,7 @@ pub fn is_authorized<'a>(
     let evaluator = Evaluator {
         request,
         entities,
+        schema,
         extensions: Extensions::all_available(),
     };
     let residuals = policy_residual_map(request, ps, schema)?

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -22,6 +22,7 @@ pub mod evaluator;
 pub mod request;
 pub mod residual;
 pub mod response;
+pub mod value;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
@@ -112,20 +113,19 @@ mod tests {
 
     use crate::ast::{Annotation, AnyId, BinaryOp, Literal, PolicyID, Value, ValueKind, Var};
     use crate::tpe::residual::{Residual, ResidualKind};
+    use crate::tpe::value::AttrState;
     use crate::validator::ValidatorSchema;
     use crate::{
         ast::{EntityUID, PolicySet},
         extensions::Extensions,
         parser::parse_policyset,
     };
-    use std::{
-        collections::{BTreeMap, HashSet},
-        sync::Arc,
-    };
+    use std::collections::HashSet;
 
     use crate::tpe::{
         entities::{PartialEntities, PartialEntity},
         request::{PartialEntityUID, PartialRequest},
+        value::PartialRecord,
     };
 
     use super::is_authorized;
@@ -279,10 +279,7 @@ action Delete appliesTo {
                 ty: "Document".parse().unwrap(),
                 eid: None,
             },
-            Some(Arc::new(BTreeMap::from_iter(std::iter::once((
-                "hasMFA".into(),
-                true.into(),
-            ))))),
+            Some(std::iter::once(("hasMFA".into(), AttrState::Value(Value::from(true)))).collect()),
             &rfc_schema(),
         )
         .unwrap()
@@ -293,7 +290,7 @@ action Delete appliesTo {
         PartialEntities::from_entities(
             [PartialEntity::new(
                 r#"User::"Alice""#.parse().unwrap(),
-                Some(BTreeMap::new()),
+                Some(PartialRecord::new()),
                 Some(HashSet::new()),
                 None,
                 &schema,
@@ -361,7 +358,6 @@ action Delete appliesTo {
 #[cfg(test)]
 mod tinytodo {
     use std::collections::HashSet;
-    use std::{collections::BTreeMap, sync::Arc};
 
     use crate::ast::{BinaryOp, EntityUID};
     use crate::tpe::residual::{Residual, ResidualKind};
@@ -373,6 +369,7 @@ mod tinytodo {
     use crate::tpe::{
         entities::PartialEntities,
         request::{PartialEntityUID, PartialRequest},
+        value::PartialRecord,
     };
 
     use super::is_authorized;
@@ -483,7 +480,7 @@ when { principal in resource.editors };
                 ty: "List".parse().unwrap(),
                 eid: None,
             },
-            Some(Arc::new(BTreeMap::new())),
+            Some(PartialRecord::new()),
             &schema(),
         )
         .unwrap()

--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -16,38 +16,34 @@
 
 //! This module contains partial entities.
 
-use crate::ast::{Entity, PartialValueToValueError};
-use crate::entities::conformance::err::EntitySchemaConformanceError;
+use crate::ast::{Entity, PartialValue, RestrictedExpr};
+use crate::entities::conformance::err::UndeclaredAction;
+use crate::entities::conformance::err::{AttrOrTag, EntitySchemaConformanceError};
+use crate::entities::conformance::typecheck_value_against_schematype;
+use crate::entities::conformance::TypecheckError;
+use crate::entities::conformance::{validate_euid, EntitySchemaConformanceChecker};
 use crate::entities::err::Duplicate;
-use crate::entities::SchemaType;
-use crate::entities::{Dereference, Entities, TCComputation};
+use crate::entities::json::err::TypeMismatchError;
+use crate::entities::{Dereference, Entities, Schema, SchemaType, TCComputation};
+use crate::tpe::err::MismatchedActionAncestorsError;
 use crate::tpe::err::{
     AncestorValidationError, EntitiesConsistencyError, EntitiesError, EntityConsistencyError,
-    EntityValidationError, JsonDeserializationError, MismatchedActionAncestorsError,
-    MismatchedAncestorError, MismatchedAttributeError, MismatchedTagError, MissingEntityError,
-    UnexpectedActionError, UnknownAttributeError, UnknownEntityError, UnknownTagError,
+    EntityValidationError, JsonDeserializationError, MismatchedAncestorError,
+    MismatchedAttributeError, MismatchedTagError, MissingEntityError, UnexpectedActionError,
+    UnknownAttributeError, UnknownEntityError, UnknownTagError,
 };
-use crate::transitive_closure::{enforce_tc_and_dag, TcError};
-use crate::validator::{
-    CoreSchema, EntityTypeDescription as CoreEntityTypeDescription, ValidatorSchema,
-};
-use crate::{
-    ast::PartialValue,
-    entities::{conformance::EntitySchemaConformanceChecker, Schema},
-};
+use crate::tpe::value::{AttrState, PartialRecord};
 use crate::{
     ast::{EntityUID, Value},
     entities::{
         json::{err::JsonDeserializationErrorContext, ValueParser},
-        EntityUidJson,
+        EntityTypeDescription, EntityUidJson,
     },
     evaluator::RestrictedEvaluator,
     extensions::Extensions,
     jsonvalue::JsonValueWithNoDuplicateKeys,
-};
-use crate::{
-    entities::{conformance::validate_euid, EntityTypeDescription},
-    transitive_closure::{compute_tc, repair_tc, TCNode},
+    transitive_closure::{compute_tc, enforce_tc_and_dag, repair_tc, TCNode, TcError},
+    validator::{CoreSchema, ValidatorEntityType, ValidatorSchema},
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -95,43 +91,88 @@ pub struct PartialEntity {
     // The uid of the partial entity
     uid: EntityUID,
     // Optional attributes
-    attrs: Option<BTreeMap<SmolStr, Value>>,
+    attrs: Option<PartialRecord>,
     // Optional ancestors
     ancestors: Option<HashSet<EntityUID>>,
     // Optional tags
-    tags: Option<BTreeMap<SmolStr, Value>>,
+    tags: Option<PartialRecord>,
 }
 
-// An `Entity` without unknowns is a `PartialEntity`
-impl TryFrom<Entity> for PartialEntity {
-    type Error = PartialValueToValueError;
-    fn try_from(value: Entity) -> Result<Self, Self::Error> {
-        let (uid, attrs, ancestors, mut parents, tags) = value.into_inner();
-        parents.extend(ancestors);
-        let attrs = attrs
-            .into_iter()
-            .map(|(a, v)| Ok((a, Value::try_from(v)?)))
-            .collect::<Result<BTreeMap<_, _>, PartialValueToValueError>>()?;
-        let tags = tags
-            .into_iter()
-            .map(|(a, v)| Ok((a, Value::try_from(v)?)))
-            .collect::<Result<BTreeMap<_, _>, PartialValueToValueError>>()?;
-        Ok(Self {
-            uid,
-            attrs: Some(attrs),
-            ancestors: Some(parents),
-            tags: Some(tags),
-        })
-    }
+fn unexpected_attr(uid: EntityUID, attr: SmolStr) -> EntitiesError {
+    EntityValidationError::Concrete(EntitySchemaConformanceError::unexpected_entity_attr(
+        uid, attr,
+    ))
+    .into()
+}
+
+fn unexpected_tag(uid: EntityUID, tag: SmolStr) -> EntitiesError {
+    EntityValidationError::Concrete(EntitySchemaConformanceError::unexpected_entity_tag(
+        uid, tag,
+    ))
+    .into()
 }
 
 impl PartialEntity {
+    fn from_non_action_entity(
+        value: Entity,
+        schema: &ValidatorSchema,
+    ) -> Result<Self, EntitiesError> {
+        let entity_type = lookup_entity_type(schema, value.uid())?;
+        let (uid, attrs, ancestors, mut parents, tags) = value.into_inner();
+        parents.extend(ancestors);
+        let attrs = PartialRecord::from_concrete_record(
+            &attrs
+                .into_iter()
+                .map(|(a, v)| Ok((a, Value::try_from(v)?)))
+                .collect::<Result<BTreeMap<_, _>, EntitiesError>>()?,
+            entity_type.attributes(),
+        );
+        let tags = tags
+            .into_iter()
+            .map(|(a, v)| {
+                if entity_type.tag_type().is_none() {
+                    return Err(unexpected_tag(uid.clone(), a));
+                }
+                Ok((a, Value::try_from(v)?))
+            })
+            .collect::<Result<Vec<_>, EntitiesError>>()?;
+        Self::new(
+            uid,
+            Some(attrs),
+            Some(parents),
+            Some(PartialRecord::from_concrete_tags(tags)),
+            schema,
+        )
+    }
+
+    /// Convert a concrete `Entity` into a `PartialEntity`
+    pub fn from_entity(e: Entity, schema: &ValidatorSchema) -> Result<Self, EntitiesError> {
+        if e.uid().is_action() {
+            // Actions cannot have attribute or tags
+            if let Some(attr) = e.keys().next() {
+                return Err(unexpected_attr(e.uid().clone(), attr.clone()));
+            }
+            if let Some(tag) = e.tag_keys().next() {
+                return Err(unexpected_tag(e.uid().clone(), tag.clone()));
+            }
+            Self::new(
+                e.uid().clone(),
+                Some(PartialRecord::new()),
+                Some(e.ancestors().cloned().collect()),
+                Some(PartialRecord::new()),
+                schema,
+            )
+        } else {
+            Self::from_non_action_entity(e, schema)
+        }
+    }
+
     /// Construct a new [`PartialEntity`]
     pub fn new(
         uid: EntityUID,
-        attrs: Option<BTreeMap<SmolStr, Value>>,
+        attrs: Option<PartialRecord>,
         ancestors: Option<HashSet<EntityUID>>,
-        tags: Option<BTreeMap<SmolStr, Value>>,
+        tags: Option<PartialRecord>,
         schema: &ValidatorSchema,
     ) -> Result<Self, EntitiesError> {
         let e = Self {
@@ -150,7 +191,7 @@ impl PartialEntity {
     }
 
     /// Get the optional attributes of this partial entity
-    pub fn attrs(&self) -> Option<&BTreeMap<SmolStr, Value>> {
+    pub fn attrs(&self) -> Option<&PartialRecord> {
         self.attrs.as_ref()
     }
 
@@ -160,7 +201,7 @@ impl PartialEntity {
     }
 
     /// Get the optional tags of this partial entity
-    pub fn tags(&self) -> Option<&BTreeMap<SmolStr, Value>> {
+    pub fn tags(&self) -> Option<&PartialRecord> {
         self.tags.as_ref()
     }
 
@@ -183,7 +224,7 @@ impl PartialEntity {
                 uid: self.uid.clone(),
                 attr,
             })?;
-            if attrs != &other_attrs {
+            if !attrs.check_consistency(&other_attrs) {
                 return Err(MismatchedAttributeError {
                     uid: self.uid.clone(),
                 }
@@ -204,7 +245,7 @@ impl PartialEntity {
                 uid: self.uid.clone(),
                 tag,
             })?;
-            if tags != &other_tags {
+            if !tags.check_consistency(&other_tags) {
                 return Err(MismatchedTagError {
                     uid: self.uid.clone(),
                 }
@@ -215,7 +256,61 @@ impl PartialEntity {
     }
 }
 
-/// Parse a JSON map of attribute/tag values into concrete [`Value`]s.
+/// Build a `PartialRecord` from restricted expressions
+fn partial_record_from_exprs(
+    exprs: impl IntoIterator<Item = (SmolStr, AttrState<RestrictedExpr>)>,
+) -> Result<PartialRecord, SmolStr> {
+    exprs
+        .into_iter()
+        .map(|(k, attr)| {
+            let state = match attr {
+                AttrState::Value(expr) => {
+                    let eval = RestrictedEvaluator::new(Extensions::all_available());
+                    let value = eval.interpret(expr.as_borrowed()).map_err(|_| k.clone())?;
+                    AttrState::Value(value)
+                }
+                AttrState::PartialRecord(r) => AttrState::PartialRecord(r),
+                AttrState::Present => AttrState::Present,
+                AttrState::Absent => AttrState::Absent,
+                AttrState::Unknown => AttrState::Unknown,
+            };
+            Ok((k, state))
+        })
+        .collect::<Result<PartialRecord, SmolStr>>()
+}
+
+/// Construct a `PartialEntity` from concrete attribute and tag expressions
+pub fn partial_entity_from_exprs(
+    uid: EntityUID,
+    attrs: Option<impl IntoIterator<Item = (SmolStr, AttrState<RestrictedExpr>)>>,
+    ancestors: Option<HashSet<EntityUID>>,
+    tags: Option<impl IntoIterator<Item = (SmolStr, AttrState<RestrictedExpr>)>>,
+    schema: &ValidatorSchema,
+) -> Result<PartialEntity, EntitiesError> {
+    let attrs = attrs
+        .map(|exprs| partial_record_from_exprs(exprs).map_err(|k| unexpected_attr(uid.clone(), k)))
+        .transpose()?;
+    let tags = tags
+        .map(|exprs| partial_record_from_exprs(exprs).map_err(|k| unexpected_tag(uid.clone(), k)))
+        .transpose()?;
+    PartialEntity::new(uid, attrs, ancestors, tags, schema)
+}
+
+/// Look up the `ValidatorEntityType` declaring `uid`'s attributes and tags.
+fn lookup_entity_type<'a>(
+    schema: &'a ValidatorSchema,
+    uid: &EntityUID,
+) -> Result<&'a ValidatorEntityType, EntitiesError> {
+    schema.get_entity_type(uid.entity_type()).ok_or_else(|| {
+        EntityValidationError::Concrete(EntitySchemaConformanceError::unexpected_entity_type(
+            &CoreSchema::new(schema),
+            uid.clone(),
+        ))
+        .into()
+    })
+}
+
+/// Parse a JSON map of attribute/tag values into a [`PartialRecord`]
 ///
 /// `type_of` returns the expected [`SchemaType`] for a given key (tag or attribute). If `uid`'s
 /// entity type is not declared in the schema, an `UnexpectedEntityType` error
@@ -223,29 +318,29 @@ impl PartialEntity {
 fn parse_value_map(
     map: DeduplicatedMap,
     uid: &EntityUID,
-    core_schema: &CoreSchema<'_>,
+    unexpected: impl Fn(SmolStr) -> EntitySchemaConformanceError,
     vparser: &ValueParser<'_>,
-    type_of: impl Fn(&CoreEntityTypeDescription, &str) -> Option<SchemaType>,
-) -> Result<BTreeMap<SmolStr, Value>, JsonDeserializationError> {
-    let eval = RestrictedEvaluator::new(Extensions::all_available());
-    let ty = core_schema.entity_type(uid.entity_type()).ok_or_else(|| {
-        JsonDeserializationError::Concrete(
-            EntitySchemaConformanceError::unexpected_entity_type(core_schema, uid.clone()).into(),
-        )
-    })?;
-    map.map
+    type_of: impl Fn(&str) -> Option<SchemaType>,
+) -> Result<PartialRecord, JsonDeserializationError> {
+    let unexpected = |key: SmolStr| JsonDeserializationError::Concrete(unexpected(key).into());
+    let exprs = map
+        .map
         .into_iter()
         .map(|(k, v)| {
+            let schema_attr_ty = type_of(&k).ok_or_else(|| unexpected(k.clone()))?;
             let expr =
-                vparser.val_into_restricted_expr(v.into(), type_of(&ty, &k).as_ref(), &|| {
+                vparser.val_into_restricted_expr(v.into(), Some(&schema_attr_ty), &|| {
                     JsonDeserializationErrorContext::EntityAttribute {
                         uid: uid.clone(),
                         attr: k.clone(),
                     }
                 })?;
-            Ok((k, eval.interpret(expr.as_borrowed())?))
+            // Concrete entity JSON states a fully known value for every listed attribute or tag.
+            Ok((k, AttrState::Value(expr)))
         })
-        .collect()
+        .collect::<std::result::Result<Vec<_>, JsonDeserializationError>>()?;
+    // Every key above already had to have a declared type, so nothing further to check.
+    partial_record_from_exprs(exprs).map_err(unexpected)
 }
 
 /// Parse an [`EntityJson`] into a [`PartialEntity`] according to `schema`
@@ -262,9 +357,22 @@ pub fn parse_ejson(
         return Err(UnexpectedActionError { action: uid }.into());
     }
     let vparser = ValueParser::new(Extensions::all_available());
+    let schema_ty = core_schema.entity_type(uid.entity_type()).ok_or_else(|| {
+        JsonDeserializationError::Concrete(
+            EntitySchemaConformanceError::unexpected_entity_type(&core_schema, uid.clone()).into(),
+        )
+    })?;
     let attrs = e
         .attrs
-        .map(|m| parse_value_map(m, &uid, &core_schema, &vparser, |ty, k| ty.attr_type(k)))
+        .map(|m| {
+            parse_value_map(
+                m,
+                &uid,
+                |k| EntitySchemaConformanceError::unexpected_entity_attr(uid.clone(), k),
+                &vparser,
+                |k| schema_ty.attr_type(k),
+            )
+        })
         .transpose()?;
 
     let ancestors = e
@@ -285,7 +393,15 @@ pub fn parse_ejson(
 
     let tags = e
         .tags
-        .map(|m| parse_value_map(m, &uid, &core_schema, &vparser, |ty, _| ty.tag_type()))
+        .map(|m| {
+            parse_value_map(
+                m,
+                &uid,
+                |k| EntitySchemaConformanceError::unexpected_entity_tag(uid.clone(), k),
+                &vparser,
+                |_| schema_ty.tag_type(),
+            )
+        })
         .transpose()?;
 
     Ok(PartialEntity {
@@ -343,7 +459,7 @@ impl PartialEntity {
 
         if self.uid.is_action() {
             if let Some(attrs) = &self.attrs {
-                if let Some((attr, _)) = attrs.first_key_value() {
+                if let Some((attr, _)) = attrs.attrs().next() {
                     return Err(EntitySchemaConformanceError::unexpected_entity_attr(
                         uid.clone(),
                         attr.clone(),
@@ -352,7 +468,7 @@ impl PartialEntity {
                 }
             }
             if let Some(tags) = &self.tags {
-                if let Some((tag, _)) = tags.first_key_value() {
+                if let Some((tag, _)) = tags.attrs().next() {
                     return Err(EntitySchemaConformanceError::unexpected_entity_tag(
                         uid.clone(),
                         tag.clone(),
@@ -389,21 +505,186 @@ impl PartialEntity {
             checker.validate_entity_ancestors(uid, ancestors.iter(), &schema_etype)?;
         }
         if let Some(attrs) = &self.attrs {
-            let attrs: BTreeMap<_, PartialValue> = attrs
-                .iter()
-                .map(|(a, v)| (a.clone(), v.clone().into()))
-                .collect();
-            checker.validate_entity_attributes(uid, attrs.iter(), &schema_etype)?;
+            validate_partial_record_as_attrs(attrs, uid, &schema_etype, &core_schema)?;
         }
         if let Some(tags) = &self.tags {
-            let tags: BTreeMap<_, PartialValue> = tags
-                .iter()
-                .map(|(a, v)| (a.clone(), v.clone().into()))
-                .collect();
-            checker.validate_tags(uid, tags.iter(), &schema_etype)?;
+            validate_partial_record_as_tags(tags, uid, &schema_etype, &core_schema)?;
         }
         Ok(())
     }
+}
+
+/// Is the partial attribute state valid for the declared type
+///
+/// This is like normal value typechecking except for partially-known records. If an attribute is
+/// known to exist, then the schema must allow it to exist with some type. If the attribute is fully
+/// unknown, then it needs no validation.
+pub(crate) fn typecheck_attr_state(
+    state: &AttrState,
+    expected_ty: &SchemaType,
+    extensions: &Extensions<'_>,
+) -> Result<(), TypecheckError> {
+    match state {
+        AttrState::Value(v) => {
+            // no partial state, delegate to concrete typechecking
+            typecheck_value_against_schematype(&v.clone().into(), expected_ty, extensions)
+        }
+        AttrState::PartialRecord(rec) => typecheck_partial_record(rec, expected_ty, extensions),
+        // For present/absent, `typecheck_partial_record` is responsible for ensuring the (non-)existence is valid.
+        AttrState::Present | AttrState::Absent | AttrState::Unknown => Ok(()),
+    }
+}
+
+/// Is the partial record `rec` valid as a record of type `expected_ty`?
+pub(crate) fn typecheck_partial_record(
+    rec: &PartialRecord,
+    expected_ty: &SchemaType,
+    extensions: &Extensions<'_>,
+) -> Result<(), TypecheckError> {
+    // TODO: Return a new error type. `TypecheckError` carries a restricted expression, but we want to give it a partial record.
+    let bogus_actual_val = RestrictedExpr::val(false);
+    let SchemaType::Record { attrs, .. } = expected_ty else {
+        return Err(
+            TypeMismatchError::type_mismatch(expected_ty.clone(), None, bogus_actual_val).into(),
+        );
+    };
+
+    for (k, aty) in attrs {
+        match rec.attr(k) {
+            AttrState::Absent if aty.required => {
+                // The attribute is explicitly absent, but the typ requires it.
+                return Err(TypeMismatchError::missing_required_attr(
+                    expected_ty.clone(),
+                    k.clone(),
+                    bogus_actual_val,
+                )
+                .into());
+            }
+            state => typecheck_attr_state(state, &aty.attr_type, extensions)?,
+        }
+    }
+
+    if let Some((k, _)) = rec
+        .attrs()
+        .find(|(k, state)| state.exists() && attrs.get(*k).is_none())
+    {
+        // An attribute exists when the schema doesn't expect it. `.exists()`
+        // filters our absent/unknown attributes.
+        return Err(TypeMismatchError::unexpected_attr(
+            expected_ty.clone(),
+            k.clone(),
+            bogus_actual_val,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn validate_partial_attr<S: Schema>(
+    partial_val: &AttrState,
+    expected_ty: &SchemaType,
+    uid: &EntityUID,
+    key: &SmolStr,
+    kind: AttrOrTag,
+    schema: &S,
+) -> Result<(), EntitySchemaConformanceError> {
+    match typecheck_attr_state(partial_val, expected_ty, Extensions::all_available()) {
+        Ok(()) => {}
+        Err(TypecheckError::TypeMismatch(e)) => {
+            return Err(EntitySchemaConformanceError::type_mismatch(
+                uid.clone(),
+                key.clone(),
+                kind,
+                e,
+            ));
+        }
+        Err(TypecheckError::ExtensionFunctionLookup(e)) => {
+            return Err(EntitySchemaConformanceError::extension_function_lookup(
+                uid.clone(),
+                key.clone(),
+                kind,
+                e,
+            ));
+        }
+    }
+    partial_val.validate_euids(schema)?;
+    Ok(())
+}
+
+/// Validate a `PartialRecord` as entity attributes against the schema.
+fn validate_partial_record_as_attrs<S: Schema>(
+    record: &PartialRecord,
+    uid: &EntityUID,
+    schema_etype: &impl EntityTypeDescription,
+    schema: &S,
+) -> Result<(), EntitySchemaConformanceError> {
+    if let Some(absent) = schema_etype
+        .required_attrs()
+        .find(|attr| matches!(record.attr(&attr), AttrState::Absent))
+    {
+        return Err(EntitySchemaConformanceError::missing_entity_attr(
+            uid.clone(),
+            absent,
+        ));
+    }
+
+    for (attr, partial_val) in record.attrs() {
+        if matches!(partial_val, AttrState::Absent | AttrState::Unknown) {
+            // `Absent` was already checked against the required attributes, and `Unknown` claims
+            // nothing, so neither can conflict with what the schema declares.
+            continue;
+        }
+
+        let Some(expected_ty) = schema_etype.attr_type(attr) else {
+            return Err(EntitySchemaConformanceError::unexpected_entity_attr(
+                uid.clone(),
+                attr.clone(),
+            ));
+        };
+
+        validate_partial_attr(
+            partial_val,
+            &expected_ty,
+            uid,
+            attr,
+            AttrOrTag::Attr,
+            schema,
+        )?
+    }
+    Ok(())
+}
+
+/// Validate a [`PartialRecord`] as entity tags against the schema.
+///
+/// Mirrors [`EntitySchemaConformanceChecker::validate_tags`]:
+/// - If schema says no tags allowed, errors on any present tag
+/// - For each `Value` tag, typechecks against the schema tag type and validates EUIDs
+/// - `Exists` tags are skipped
+fn validate_partial_record_as_tags<S: Schema>(
+    record: &PartialRecord,
+    uid: &EntityUID,
+    schema_etype: &impl EntityTypeDescription,
+    schema: &S,
+) -> Result<(), EntitySchemaConformanceError> {
+    match schema_etype.tag_type() {
+        None => {
+            // No tags allowed, so a tag claimed to exist is an error
+            if let Some((tag, _)) = record.attrs().find(|(_, a)| a.exists()) {
+                return Err(EntitySchemaConformanceError::unexpected_entity_tag(
+                    uid.clone(),
+                    tag.clone(),
+                ));
+            }
+        }
+        // Tags share one declared type and have no fixed key set, so any key is allowed and every
+        // value is checked against the same type.
+        Some(expected_ty) => {
+            for (tag, partial_val) in record.attrs() {
+                validate_partial_attr(partial_val, &expected_ty, uid, tag, AttrOrTag::Tag, schema)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 // Validate if ancestors are well-formed
@@ -478,7 +759,7 @@ impl PartialEntities {
     /// Returns attributes if this entity exists and its attributes are known. TPE treats a missing
     /// entity and unknown attributes identically. If you need to distinguish them, get the full
     /// partial entity (if it exists) using [`PartialEntities::get`].
-    pub fn get_attrs(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {
+    pub fn get_attrs(&self, euid: &EntityUID) -> Option<&PartialRecord> {
         self.get(euid).and_then(|e| e.attrs())
     }
 
@@ -487,7 +768,7 @@ impl PartialEntities {
     /// Returns tags if this entity exists and its tags are known. TPE treats a missing entity and
     /// unknown tags identically. If you need to distinguish them, get the full partial entity (if
     /// it exists) using [`PartialEntities::get`].
-    pub fn get_tags(&self, euid: &EntityUID) -> Option<&BTreeMap<SmolStr, Value>> {
+    pub fn get_tags(&self, euid: &EntityUID) -> Option<&PartialRecord> {
         self.get(euid).and_then(|e| e.tags())
     }
 
@@ -542,7 +823,7 @@ impl PartialEntities {
     ) -> Result<Self, EntitiesError> {
         let entities_map: HashMap<EntityUID, PartialEntity> = entities
             .into_iter()
-            .map(|e| e.try_into().map(|e: PartialEntity| (e.uid.clone(), e)))
+            .map(|e| PartialEntity::from_entity(e, schema).map(|pe| (pe.uid.clone(), pe)))
             .try_collect()?;
         // TC is already computed in the source Entities — the conversion to
         // PartialEntity preserves all ancestors (direct + indirect).
@@ -621,13 +902,15 @@ impl PartialEntities {
     // from schema or be consistent with schema anyways
     fn insert_actions(&mut self, schema: &ValidatorSchema) {
         for (uid, action) in &schema.actions {
+            let ancestors = action.ancestors().cloned().collect();
             self.entities.insert(
                 uid.clone(),
-                #[expect(
-                    clippy::unwrap_used,
-                    reason = "action entities do not contain unknowns"
-                )]
-                action.as_ref().clone().try_into().unwrap(),
+                PartialEntity {
+                    uid: uid.clone(),
+                    attrs: Some(PartialRecord::new()),
+                    ancestors: Some(ancestors),
+                    tags: Some(PartialRecord::new()),
+                },
             );
         }
     }
@@ -665,9 +948,10 @@ impl PartialEntities {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::collections::{HashMap, HashSet};
 
     use crate::tpe::err::AncestorValidationError;
+    use crate::tpe::value::{AttrState, PartialRecord};
     use crate::validator::ValidatorSchema;
     use crate::{
         ast::{EntityUID, Value},
@@ -732,7 +1016,7 @@ mod tests {
         );
         let ejson: EntityJson = serde_json::from_value(json).expect("should parse");
         assert_matches!(parse_ejson(ejson, &schema), Ok(e) => {
-            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: None, ancestors: None, tags: Some(BTreeMap::default()) });
+            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: None, ancestors: None, tags: Some(PartialRecord::new()) });
         });
 
         let schema = basic_schema();
@@ -749,7 +1033,7 @@ mod tests {
         );
         let ejson: EntityJson = serde_json::from_value(json).expect("should parse");
         assert_matches!(parse_ejson(ejson, &schema), Ok(e) => {
-            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: Some(BTreeMap::new()), ancestors: Some(HashSet::default()), tags: Some(BTreeMap::default()) });
+            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: Some(PartialRecord::new()), ancestors: Some(HashSet::default()), tags: Some(PartialRecord::new()) });
         });
 
         let schema = basic_schema();
@@ -769,9 +1053,78 @@ mod tests {
         );
         let ejson: EntityJson = serde_json::from_value(json).expect("should parse");
         assert_matches!(parse_ejson(ejson, &schema), Ok(e) => {
-            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: Some(BTreeMap::from_iter([("b".into(), 1.into()), ("c".into(), Value::record(std::iter::once(("x", false)), None)
-            )])), ancestors: Some(HashSet::default()), tags: Some(BTreeMap::default()) });
+            let expected_attrs = [
+                ("b".into(), AttrState::Value(1.into())),
+                ("c".into(), AttrState::Value(Value::record(std::iter::once(("x", false)), None))),
+            ].into_iter().collect();
+            assert_eq!(e, PartialEntity { uid: r#"A::"""#.parse().unwrap(), attrs: Some(expected_attrs), ancestors: Some(HashSet::default()), tags: Some(PartialRecord::new()) });
         });
+    }
+
+    #[test]
+    fn undescribed_json_keys_rejected() {
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"entity NoTags { a: Long };
+               entity WithTags { a: Long } tags Long;"#,
+            Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+        let parse = |json: serde_json::Value| {
+            PartialEntities::from_json_value(json, &schema).map_err(|e| e.to_string())
+        };
+
+        assert_matches!(
+            parse(serde_json::json!([{ "uid": {"type":"NoTags","id":"x"}, "attrs": {"bogus": 1} }])),
+            Err(e) => assert!(e.contains("attribute `bogus`"), "{e}")
+        );
+        assert_matches!(
+            parse(serde_json::json!([{ "uid": {"type":"NoTags","id":"x"}, "tags": {"t": 1} }])),
+            Err(e) => assert!(e.contains("found a tag `t`"), "{e}")
+        );
+        assert_matches!(
+            parse(serde_json::json!([{ "uid": {"type":"WithTags","id":"x"}, "tags": {"t": 1} }])),
+            Ok(_)
+        );
+        assert_matches!(
+            parse(serde_json::json!([{ "uid": {"type":"NoTags","id":"x"}, "attrs": {"a": 1} }])),
+            Ok(_)
+        );
+    }
+
+    #[test]
+    fn action_entity_attrs_and_tags_rejected() {
+        use crate::ast::Entity;
+
+        let schema = basic_schema();
+        let action: EntityUID = r#"Action::"a""#.parse().unwrap();
+        let mk = |attrs: Vec<(smol_str::SmolStr, Value)>, tags: Vec<(smol_str::SmolStr, Value)>| {
+            Entity::new_with_attr_partial_value(
+                action.clone(),
+                attrs.into_iter().map(|(k, v)| (k, v.into())),
+                HashSet::new(),
+                HashSet::new(),
+                tags.into_iter().map(|(k, v)| (k, v.into())),
+            )
+        };
+
+        assert_matches!(
+            PartialEntity::from_entity(mk(vec![("bogus".into(), 1.into())], vec![]), &schema)
+                .map_err(|e| e.to_string()),
+            Err(e) => assert!(e.contains("attribute `bogus`"), "{e}")
+        );
+        assert_matches!(
+            PartialEntity::from_entity(mk(vec![], vec![("t".into(), 1.into())]), &schema)
+                .map_err(|e| e.to_string()),
+            Err(e) => assert!(e.contains("tag `t`"), "{e}")
+        );
+        assert_matches!(
+            PartialEntity::from_entity(mk(vec![], vec![]), &schema),
+            Ok(e) => {
+                assert_eq!(e.attrs(), Some(&PartialRecord::new()));
+                assert_eq!(e.tags(), Some(&PartialRecord::new()));
+            }
+        );
     }
 
     #[test]
@@ -909,10 +1262,18 @@ mod tests {
 
 #[cfg(test)]
 mod test_validate {
-    use super::*;
+
+    use std::collections::HashSet;
+
+    use crate::ast::{RestrictedExpr, Value};
     use crate::entities::conformance::err::EntitySchemaConformanceError;
-    use crate::tpe::err::{EntityValidationError, MismatchedActionAncestorsError};
+    use crate::extensions::Extensions;
+    use crate::tpe::entities::{partial_entity_from_exprs, PartialEntity};
+    use crate::tpe::err::{EntitiesError, EntityValidationError, MismatchedActionAncestorsError};
+    use crate::tpe::value::{AttrState, PartialRecord};
+    use crate::validator::ValidatorSchema;
     use cool_asserts::assert_matches;
+    use smol_str::SmolStr;
 
     fn test_schema() -> ValidatorSchema {
         ValidatorSchema::from_cedarschema_str(
@@ -939,11 +1300,14 @@ mod test_validate {
         let schema = test_schema();
         let entity = PartialEntity {
             uid: "User::\"alice\"".parse().unwrap(),
-            attrs: Some(BTreeMap::from_iter([("name".into(), Value::from("Alice"))])),
+            attrs: Some(PartialRecord::from_iter([(
+                "name".into(),
+                AttrState::Value(Value::from("Alice")),
+            )])),
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::from_iter([(
+            tags: Some(PartialRecord::from_iter([(
                 "department".into(),
-                Value::from("Engineering"),
+                AttrState::Value(Value::from("Engineering")),
             )])),
         };
 
@@ -955,9 +1319,9 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(action.validate(&schema), Ok(()));
@@ -968,9 +1332,9 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: None,
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(action.validate(&schema), Ok(()));
@@ -981,7 +1345,7 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: Some(HashSet::new()),
             tags: None,
         };
@@ -996,7 +1360,7 @@ mod test_validate {
             uid: "Action::\"view\"".parse().unwrap(),
             attrs: None,
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(action.validate(&schema), Ok(()));
@@ -1007,12 +1371,12 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::from_iter([(
+            attrs: Some(PartialRecord::from_iter([(
                 "unexpected_attr".into(),
-                Value::from("value"),
+                AttrState::Value(Value::from("value")),
             )])),
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(
@@ -1028,11 +1392,11 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::from_iter([(
+            tags: Some(PartialRecord::from_iter([(
                 "unexpected_tag".into(),
-                Value::from("value"),
+                AttrState::Value(Value::from("value")),
             )])),
         };
 
@@ -1049,9 +1413,9 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: Some(HashSet::from_iter(["Action::\"other\"".parse().unwrap()])),
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(
@@ -1067,9 +1431,9 @@ mod test_validate {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"other\"".parse().unwrap(),
-            attrs: Some(BTreeMap::new()),
+            attrs: Some(PartialRecord::new()),
             ancestors: Some(HashSet::new()),
-            tags: Some(BTreeMap::new()),
+            tags: Some(PartialRecord::new()),
         };
 
         assert_matches!(
@@ -1121,7 +1485,10 @@ mod test_validate {
         let schema = test_schema();
         let entity = PartialEntity {
             uid: "User::\"alice\"".parse().unwrap(),
-            attrs: Some(BTreeMap::from_iter([("name".into(), Value::from(42))])),
+            attrs: Some(PartialRecord::from_iter([(
+                "name".into(),
+                AttrState::Value(Value::from(42)),
+            )])),
             ancestors: None,
             tags: None,
         };
@@ -1141,9 +1508,9 @@ mod test_validate {
             uid: "User::\"alice\"".parse().unwrap(),
             attrs: None,
             ancestors: None,
-            tags: Some(BTreeMap::from_iter([(
+            tags: Some(PartialRecord::from_iter([(
                 "department".into(),
-                Value::from(42),
+                AttrState::Value(Value::from(42)),
             )])),
         };
 
@@ -1152,6 +1519,288 @@ mod test_validate {
             Err(EntityValidationError::Concrete(
                 EntitySchemaConformanceError::TypeMismatch(_)
             ))
+        );
+    }
+
+    #[test]
+    fn valid_entity_with_unknown_attrs() {
+        let schema = test_schema();
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: None,
+            ancestors: Some(HashSet::new()),
+            tags: None,
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    #[test]
+    fn valid_entity_with_unknown_individual_attr() {
+        let schema = test_schema();
+        // `Exists` on a required attr passes: it exists, we just don't know its value.
+        let attrs = PartialRecord::from_iter([("name".into(), AttrState::Present)]);
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: Some(attrs),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    #[test]
+    fn valid_entity_with_nested_unknown_in_record_attr() {
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"
+            entity Item {
+                info: { name: String, count: Long },
+            };
+            "#,
+            Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+
+        let inner_record = PartialRecord::from_iter([
+            ("name".into(), AttrState::Value(Value::from("hello"))),
+            ("count".into(), AttrState::Present),
+        ]);
+        let entity = PartialEntity {
+            uid: "Item::\"i1\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([(
+                "info".into(),
+                AttrState::PartialRecord(inner_record),
+            )])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    #[test]
+    fn invalid_entity_with_nested_wrong_type_in_partial_record() {
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"
+            entity Item {
+                info: { name: String, count: Long },
+            };
+            "#,
+            Extensions::all_available(),
+        )
+        .unwrap()
+        .0;
+
+        let inner_record = PartialRecord::from_iter([
+            ("name".into(), AttrState::Value(Value::from(42))),
+            ("count".into(), AttrState::Present),
+        ]);
+        let entity = PartialEntity {
+            uid: "Item::\"i1\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([(
+                "info".into(),
+                AttrState::PartialRecord(inner_record),
+            )])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(
+            entity.validate(&schema),
+            Err(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::TypeMismatch(_)
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_entity_unexpected_unknown_attr() {
+        let schema = test_schema();
+        // Undeclared attr is rejected even as `Exists`: it claims to exist.
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([
+                ("name".into(), AttrState::Value(Value::from("Alice"))),
+                ("bogus".into(), AttrState::Present),
+            ])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(
+            entity.validate(&schema),
+            Err(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::UnexpectedEntityAttr(_)
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_entity_unexpected_unknown_tag() {
+        let schema = test_schema();
+        let entity = PartialEntity {
+            uid: "Resource::\"r1\"".parse().unwrap(),
+            attrs: Some(PartialRecord::new()),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::from_iter([(
+                "sometag".into(),
+                AttrState::Present,
+            )])),
+        };
+
+        assert_matches!(
+            entity.validate(&schema),
+            Err(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::UnexpectedEntityTag(_)
+            ))
+        );
+    }
+
+    #[test]
+    fn invalid_entity_absent_required_attr() {
+        let schema = test_schema();
+        // `Absent` on a required attr is a definitive error, unlike not-in-map.
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([(
+                "name".into(),
+                AttrState::Absent,
+            )])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(
+            entity.validate(&schema),
+            Err(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::MissingRequiredEntityAttr(_)
+            ))
+        );
+    }
+
+    #[test]
+    fn valid_entity_absent_unexpected_attr() {
+        let schema = test_schema();
+        // `Absent` on an undeclared attr is fine: it asserts non-existence.
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([
+                ("name".into(), AttrState::Value(Value::from("Alice"))),
+                ("bogus".into(), AttrState::Absent),
+            ])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    #[test]
+    fn valid_entity_unknown_unexpected_attr() {
+        let schema = test_schema();
+        // `Unknown` on an undeclared attr is fine: it asserts nothing, so it cannot contradict a
+        // schema that says the attribute must not exist. Only `Value`/`Exists` claim existence.
+        let entity = PartialEntity {
+            uid: "User::\"alice\"".parse().unwrap(),
+            attrs: Some(PartialRecord::from_iter([
+                ("name".into(), AttrState::Value(Value::from("Alice"))),
+                ("bogus".into(), AttrState::Unknown),
+            ])),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::new()),
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    #[test]
+    fn valid_entity_unknown_tag_when_no_tags_declared() {
+        let schema = test_schema();
+        // As above, for a type declaring no tags: an `Unknown` tag claims no tag is there.
+        let entity = PartialEntity {
+            uid: "Resource::\"r\"".parse().unwrap(),
+            attrs: Some(PartialRecord::new()),
+            ancestors: Some(HashSet::new()),
+            tags: Some(PartialRecord::from_iter([(
+                "bogus".into(),
+                AttrState::Unknown,
+            )])),
+        };
+
+        assert_matches!(entity.validate(&schema), Ok(()));
+    }
+
+    /// Build a `User::"alice"` from expression-valued attributes, with no tags.
+    fn user_from_exprs(
+        attrs: Vec<(SmolStr, AttrState<RestrictedExpr>)>,
+        schema: &ValidatorSchema,
+    ) -> Result<PartialEntity, EntitiesError> {
+        partial_entity_from_exprs(
+            "User::\"alice\"".parse().unwrap(),
+            Some(attrs),
+            Some(HashSet::new()),
+            Some(Vec::<(SmolStr, AttrState<RestrictedExpr>)>::new()),
+            schema,
+        )
+    }
+
+    fn alice_name() -> (SmolStr, AttrState<RestrictedExpr>) {
+        (
+            "name".into(),
+            AttrState::Value(RestrictedExpr::val("Alice")),
+        )
+    }
+
+    #[test]
+    fn from_exprs_accepts_undeclared_absent_attr() {
+        let e = user_from_exprs(
+            vec![alice_name(), ("bogus".into(), AttrState::Absent)],
+            &test_schema(),
+        );
+        assert_matches!(e, Ok(e) => {
+            assert_eq!(e.attrs().unwrap().attr("bogus"), &AttrState::Absent);
+        });
+    }
+
+    #[test]
+    fn from_exprs_accepts_undeclared_unknown_attr() {
+        let e = user_from_exprs(
+            vec![alice_name(), ("bogus".into(), AttrState::Unknown)],
+            &test_schema(),
+        );
+        assert_matches!(e, Ok(e) => {
+            assert_eq!(e.attrs().unwrap().attr("bogus"), &AttrState::Unknown);
+        });
+    }
+
+    #[test]
+    fn from_exprs_rejects_undeclared_present_attr() {
+        let e = user_from_exprs(vec![("bogus".into(), AttrState::Present)], &test_schema());
+        assert_matches!(
+            e,
+            Err(EntitiesError::Validation(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::UnexpectedEntityAttr(_)
+            )))
+        );
+    }
+
+    #[test]
+    fn from_exprs_rejects_any_attr_on_action() {
+        let schema = test_schema();
+        let e = partial_entity_from_exprs(
+            "Action::\"view\"".parse().unwrap(),
+            Some(vec![("anything".into(), AttrState::Unknown)]),
+            Some(HashSet::new()),
+            Some(Vec::<(SmolStr, AttrState<RestrictedExpr>)>::new()),
+            &schema,
+        );
+        assert_matches!(
+            e,
+            Err(EntitiesError::Validation(EntityValidationError::Concrete(
+                EntitySchemaConformanceError::UnexpectedEntityAttr(_)
+            )))
         );
     }
 }

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -19,7 +19,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
-    ast::{self, BinaryOp, EntityUID, PartialValue, Set, Value, ValueKind, Var},
+    ast::{self, BinaryOp, EntityType, EntityUID, PartialValue, Set, Value, ValueKind, Var},
     evaluator::stack_size_check,
     extensions::Extensions,
 };
@@ -212,14 +212,8 @@ impl Evaluator<'_> {
             }
             ResidualKind::Is { expr, entity_type } => {
                 let expr = self.interpret(expr);
-                if let Some(expr_ety) = expr
-                    .ty()
-                    .as_entity_lub()
-                    .and_then(|ety| ety.get_single_entity())
-                {
-                    if !expr.can_error_assuming_well_formed() {
-                        return mk_concrete((expr_ety == entity_type).into());
-                    }
+                if let Some(v) = try_decide_is_residual(&expr, entity_type) {
+                    return mk_concrete(v);
                 }
                 match &expr {
                     Residual::Concrete { value, .. } => match value.get_as_entity() {
@@ -250,25 +244,8 @@ impl Evaluator<'_> {
             ResidualKind::BinaryApp { op, arg1, arg2 } => {
                 let arg1 = self.interpret(arg1);
                 let arg2 = self.interpret(arg2);
-                let must_be_false = match op {
-                    BinaryOp::HasTag => !Type::may_have_tags(self.schema, arg1.ty()),
-                    BinaryOp::Eq => Type::are_types_disjoint(arg1.ty(), arg2.ty()),
-                    BinaryOp::In => {
-                        match (arg1.ty().as_entity_lub(), arg2.ty().as_set_or_entity_lub()) {
-                            // `in` must be false if `arg1` cannot have an ancestor with type of `arg2`
-                            (Some(lhs_lub), Some(rhs_lub)) => {
-                                !self.schema.any_descendent_of(lhs_lub, rhs_lub)
-                            }
-                            _ => false,
-                        }
-                    }
-                    _ => false,
-                };
-                if must_be_false
-                    && !arg1.can_error_assuming_well_formed()
-                    && !arg2.can_error_assuming_well_formed()
-                {
-                    return mk_concrete(false.into());
+                if let Some(v) = try_decide_binary_residual(self.schema, *op, &arg1, &arg2) {
+                    return mk_concrete(v);
                 }
                 let binapp_residual = |arg1, arg2| {
                     mk_residual(ResidualKind::BinaryApp {
@@ -415,13 +392,8 @@ impl Evaluator<'_> {
             }
             ResidualKind::HasAttr { expr, attr } => {
                 let expr = self.interpret(expr);
-                if !Type::may_have_attr(self.schema, expr.ty(), attr)
-                    && !expr.can_error_assuming_well_formed()
-                {
-                    // The residual can't error and cannot have `attr`, so `has` is always `false`.
-                    // We can't have an analogous reduction to `true` because the concrete semantics
-                    // for `has` is `false` when the entity isn't present.
-                    return mk_concrete(false.into());
+                if let Some(v) = try_decide_has_residual(self.schema, &expr, attr) {
+                    return mk_concrete(v);
                 }
                 match &expr {
                     Residual::Concrete { value, .. } => {
@@ -533,6 +505,68 @@ impl Evaluator<'_> {
             }
         }
     }
+}
+
+/// Given an `is` expression applied to a residual, reduce it to a value if
+/// possible, using the residual's type.
+fn try_decide_is_residual(expr: &Residual, entity_type: &EntityType) -> Option<Value> {
+    if expr.can_error_assuming_well_formed() {
+        return None;
+    }
+    let lub = expr.ty().as_entity_lub()?;
+    if !lub.contains_entity_type(entity_type) {
+        // None of the possible entity types so, `is` is `false`.
+        Some(false.into())
+    } else if lub.get_single_entity() == Some(entity_type) {
+        // The only possible entity type, so `is` is `true`.
+        Some(true.into())
+    } else {
+        // Not possible in strict validation
+        None
+    }
+}
+
+/// Given a binary operation applied to residuals, reduce it to a value if
+/// possible, using the residual types and `schema`.
+fn try_decide_binary_residual(
+    schema: &ValidatorSchema,
+    op: BinaryOp,
+    arg1: &Residual,
+    arg2: &Residual,
+) -> Option<Value> {
+    if arg1.can_error_assuming_well_formed() || arg2.can_error_assuming_well_formed() {
+        return None;
+    }
+    let must_be_false = match (op, arg1.ty(), arg2.ty()) {
+        // `in` must be false if `arg1` cannot have an ancestor with the type of `arg2`
+        (BinaryOp::In, ty1, ty2) => match (ty1.as_entity_lub(), ty2.as_set_or_entity_lub()) {
+            (Some(lhs_lub), Some(rhs_lub)) => !schema.any_descendent_of(lhs_lub, rhs_lub),
+            _ => return None,
+        },
+        (BinaryOp::Eq, ty1, ty2) => Type::are_types_disjoint(ty1, ty2),
+        (BinaryOp::HasTag, ty1, Type::String) => {
+            Type::has_declared_entity_types(schema, ty1) && !Type::may_have_tags(schema, ty1)
+        }
+        _ => return None,
+    };
+    must_be_false.then(|| false.into())
+}
+
+/// Given a `has` expression applied to a residual, reduce it to a value if
+/// possible, using only the residual's type and `schema`.
+fn try_decide_has_residual(schema: &ValidatorSchema, expr: &Residual, attr: &str) -> Option<Value> {
+    if expr.can_error_assuming_well_formed() {
+        return None;
+    }
+    if !matches!(expr.ty(), Type::Record { .. } | Type::Entity(_)) {
+        return None;
+    }
+    // The residual can't error and cannot have `attr`, so `has` is always `false`.
+    // We can't have an analogous reduction to `true` because the concrete semantics
+    // for `has` is `false` when the entity isn't present.
+    (Type::has_declared_entity_types(schema, expr.ty())
+        && !Type::may_have_attr(schema, expr.ty(), attr))
+    .then(|| false.into())
 }
 
 /// If the value is an extension value, rebuild the
@@ -2088,18 +2122,27 @@ mod tests {
             schema: &schema,
             extensions: Extensions::all_available(),
         };
-        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+        let interp = |e| interpret_typed_str_to_str(&eval, e, &schema);
 
-        // Would be decided from concrete data if we used a `PartialEntity` constructor that accept
-        // a schema, but here we show it reduce without concrete information.
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"action has bogus"#),
-            @"false"
-        );
-        assert_snapshot!(
-            interpret_typed_str_to_str(r#"action.hasTag("t")"#),
-            @"false"
-        );
+        // Action operands are not reduced from the schema, since actions are not
+        // declared as entity types. `PartialEntities::new` has no action
+        // entities either, so these stay residuals.
+        assert_snapshot!(interp(r#"action has bogus"#), @r#"App::Action::"view" has bogus"#);
+        assert_snapshot!(interp(r#"action.hasTag("t")"#), @r#"App::Action::"view".hasTag("t")"#);
+
+        // A schema-aware constructor adds the action entities, so the concrete
+        // path decides them.
+        let entities = PartialEntities::from_json_value(serde_json::json!([]), &schema).unwrap();
+        let eval_with_actions = Evaluator {
+            request: &req,
+            entities: &entities,
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interp_with_actions = |e| interpret_typed_str_to_str(&eval_with_actions, e, &schema);
+
+        assert_snapshot!(interp_with_actions(r#"action has bogus"#), @"false");
+        assert_snapshot!(interp_with_actions(r#"action.hasTag("t")"#), @"false");
     }
 
     #[test]

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -24,6 +24,8 @@ use crate::{
     extensions::Extensions,
 };
 
+use crate::validator::types::Type;
+use crate::validator::ValidatorSchema;
 use crate::{
     tpe::entities::PartialEntities,
     tpe::request::PartialRequest,
@@ -35,6 +37,7 @@ use crate::{
 pub struct Evaluator<'e> {
     pub(crate) request: &'e PartialRequest,
     pub(crate) entities: &'e PartialEntities,
+    pub(crate) schema: &'e ValidatorSchema,
     pub(crate) extensions: &'e Extensions<'e>,
 }
 
@@ -209,19 +212,20 @@ impl Evaluator<'_> {
             }
             ResidualKind::Is { expr, entity_type } => {
                 let expr = self.interpret(expr);
+                if let Some(expr_ety) = expr
+                    .ty()
+                    .as_entity_lub()
+                    .and_then(|ety| ety.get_single_entity())
+                {
+                    if !expr.can_error_assuming_well_formed() {
+                        return mk_concrete((expr_ety == entity_type).into());
+                    }
+                }
                 match &expr {
                     Residual::Concrete { value, .. } => match value.get_as_entity() {
                         Ok(uid) => mk_concrete((uid.entity_type() == entity_type).into()),
                         Err(_) => mk_error(), // <error> is <entity_type> => <error>
                     },
-                    Residual::Partial {
-                        kind: ResidualKind::Var(Var::Principal),
-                        ..
-                    } => mk_concrete((entity_type == self.request.principal_type()).into()),
-                    Residual::Partial {
-                        kind: ResidualKind::Var(Var::Resource),
-                        ..
-                    } => mk_concrete((entity_type == self.request.resource_type()).into()),
                     Residual::Partial { .. } => mk_residual(ResidualKind::Is {
                         expr: Arc::new(expr),
                         entity_type: entity_type.clone(),
@@ -246,6 +250,26 @@ impl Evaluator<'_> {
             ResidualKind::BinaryApp { op, arg1, arg2 } => {
                 let arg1 = self.interpret(arg1);
                 let arg2 = self.interpret(arg2);
+                let must_be_false = match op {
+                    BinaryOp::HasTag => !Type::may_have_tags(self.schema, arg1.ty()),
+                    BinaryOp::Eq => Type::are_types_disjoint(arg1.ty(), arg2.ty()),
+                    BinaryOp::In => {
+                        match (arg1.ty().as_entity_lub(), arg2.ty().as_set_or_entity_lub()) {
+                            // `in` must be false if `arg1` cannot have an ancestor with type of `arg2`
+                            (Some(lhs_lub), Some(rhs_lub)) => {
+                                !self.schema.any_descendent_of(lhs_lub, rhs_lub)
+                            }
+                            _ => false,
+                        }
+                    }
+                    _ => false,
+                };
+                if must_be_false
+                    && !arg1.can_error_assuming_well_formed()
+                    && !arg2.can_error_assuming_well_formed()
+                {
+                    return mk_concrete(false.into());
+                }
                 let binapp_residual = |arg1, arg2| {
                     mk_residual(ResidualKind::BinaryApp {
                         op: *op,
@@ -391,6 +415,14 @@ impl Evaluator<'_> {
             }
             ResidualKind::HasAttr { expr, attr } => {
                 let expr = self.interpret(expr);
+                if !Type::may_have_attr(self.schema, expr.ty(), attr)
+                    && !expr.can_error_assuming_well_formed()
+                {
+                    // The residual can't error and cannot have `attr`, so `has` is always `false`.
+                    // We can't have an analogous reduction to `true` because the concrete semantics
+                    // for `has` is `false` when the entity isn't present.
+                    return mk_concrete(false.into());
+                }
                 match &expr {
                     Residual::Concrete { value, .. } => {
                         if let Ok(r) = value.get_as_record() {
@@ -666,6 +698,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -709,6 +742,7 @@ mod tests {
             )
             .unwrap(),
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -732,6 +766,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -804,6 +839,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -876,6 +912,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -888,8 +925,12 @@ mod tests {
             @"2"
         );
         assert_snapshot!(
+            interpret_typed_str_to_str(r#"if (resource == Document::"C") then Document::"A" else Document::"B""#),
+            @r#"if (resource == Document::"C") then Document::"A" else Document::"B""#
+        );
+        assert_snapshot!(
             interpret_typed_str_to_str(r#"if (resource == User::"alice") then Document::"A" else Document::"B""#),
-            @r#"if resource == User::"alice" then Document::"B" else Document::"B""#
+            @r#"Document::"B""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(&r#"if (9223372036854775807 * 2) == 0 then resource else Document::"A""#),
@@ -929,6 +970,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -956,6 +998,14 @@ mod tests {
         assert_snapshot!(
             interpret_typed_str_to_str("principal.baz is Document"),
             @"principal.baz is Document"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if principal == User::"alice" then User::"bob" else User::"jane") is Document"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"(if principal == User::"alice" then User::"bob" else User::"jane") is User"#),
+            @"true"
         );
         assert_snapshot!(
             interpret_typed_str_to_str("User::\"alice\" is User"),
@@ -987,6 +1037,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1029,6 +1080,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1083,6 +1135,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1137,6 +1190,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1204,6 +1258,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1264,6 +1319,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1281,7 +1337,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal has other"#),
-            @"principal has other"
+            @"false"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"f" has s"#),
@@ -1341,6 +1397,7 @@ mod tests {
             request: &req,
             entities: &entities,
             extensions: Extensions::all_available(),
+            schema: &schema,
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
         assert_snapshot!(
@@ -1375,10 +1432,57 @@ mod tests {
     }
 
     #[test]
+    fn test_schema_informed_has_reduction() {
+        let schema = parse_schema(
+            r#"
+            entity User;
+            entity Doc { b: Bool };
+            action get appliesTo { principal: User, resource: Doc, context: {} };
+            "#,
+        );
+        let req = PartialRequest::new(
+            parse_partial_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            parse_partial_euid(r#"Doc"#),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let entities = PartialEntities::from_json_value(
+            serde_json::json!([ { "uid": { "type": "Doc", "id": "mine" } },]),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &entities,
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interp = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(interp(r#"principal has a"#), @"false");
+        assert_snapshot!(interp(r#"principal has a && principal.a"#), @"false");
+        assert_snapshot!(interp(r#"context has a"#), @"false");
+        assert_snapshot!(interp(r#"{} has a"#), @"false");
+        assert_snapshot!(interp(r#"{a: principal} has b"#), @"false");
+        assert_snapshot!(interp(r#"(if principal == User::"alice" then {a: 1} else {a: 2}) has b"#), @"false");
+        assert_snapshot!(interp(r#"(if principal == User::"alice" then User::"bob" else User::"jane") has a"#), @"false");
+
+        // The schema guarantees that `resource` has the attribute, but the entity might not exist,
+        // so we can't reduce to true.
+        assert_snapshot!(interp(r#"resource has b"#), @"resource has b");
+        // Here the partial entities tell us that `Doc::"mine"` does exist, so
+        // we could reduce to `true` in a reasonable future extension.
+        assert_snapshot!(interp(r#"Doc::"mine" has b"#), @r#"Doc::"mine" has b"#);
+    }
+
+    #[test]
     fn test_set() {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
 
@@ -1406,6 +1510,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -1462,6 +1567,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1567,6 +1673,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1604,6 +1711,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -1637,6 +1745,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1654,7 +1763,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal == E::"""#),
-            @r#"principal == E::"""#
+            @"false"
         );
 
         assert_snapshot!(
@@ -1686,6 +1795,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1715,6 +1825,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &PartialEntities::new(),
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1764,6 +1875,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1844,6 +1956,44 @@ mod tests {
     }
 
     #[test]
+    fn test_binary_app_in_unrelated_types() {
+        let schema = parse_schema(
+            r#"
+            entity Org;
+            entity User in Org;
+            entity Unrelated;
+            action get appliesTo {
+                principal: User,
+                resource: Unrelated,
+            };"#,
+        );
+        let req = PartialRequest::new(
+            parse_partial_euid("User"),
+            r#"Action::"get""#.parse().unwrap(),
+            parse_partial_euid("Unrelated"),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal in resource"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal in [resource]"#),
+            @"false"
+        );
+    }
+
+    #[test]
     fn test_binary_app_in_empty_set() {
         let schema = parse_schema(
             r#"entity E in E; entity User in E; action get appliesTo {principal: User, resource: E, context: {empty: Set<E>}};"#,
@@ -1874,6 +2024,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1933,6 +2084,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1967,6 +2119,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -1995,23 +2148,23 @@ mod tests {
             @r#"User::"undefined".hasTag("s") && (User::"undefined".getTag("s") == "bar")"#
         );
 
-        // `E` entities can't have tags, but `hasTag` is still well-typed. These could all reduce to
-        // `false`, but only the explicit empty tag case does atm.
+        // `E` declares no tags in the schema, so `hasTag` on any `E` operand reduces to `false`
+        // regardless of whether concrete tag data is present.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"empty_tags".hasTag("s") && E::"empty_tags".getTag("s") == "bar" "#),
             @"false"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"none_tags".hasTag("s") && E::"none_tags".getTag("s") == "bar" "#),
-            @r#"E::"none_tags".hasTag("s")"#
+            @"false"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"undefined_tags".hasTag("s") && E::"undefined_tags".getTag("s") == "bar" "#),
-            @r#"E::"undefined_tags".hasTag("s")"#
+            @"false"
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"undefined".hasTag("s") && E::"undefined".getTag("s") == "bar" "#),
-            @r#"E::"undefined".hasTag("s")"#
+            @"false"
         );
 
         // Residual on the left prevents eliminating `error()` expression even through it's unreachable
@@ -2027,6 +2180,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -2076,6 +2230,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -2119,6 +2274,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
@@ -2147,6 +2303,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -2173,6 +2330,7 @@ mod tests {
         let eval = Evaluator {
             request: &concrete_user_req(),
             entities: &PartialEntities::new(),
+            schema: &schema(),
             extensions: Extensions::all_available(),
         };
         let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema());
@@ -2237,6 +2395,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
 
@@ -2280,6 +2439,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
 
@@ -2323,6 +2483,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
 
@@ -2368,6 +2529,7 @@ mod tests {
         let eval = Evaluator {
             request: &req,
             entities: &entities,
+            schema: &schema,
             extensions: Extensions::all_available(),
         };
 

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -926,7 +926,7 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"if (resource == Document::"C") then Document::"A" else Document::"B""#),
-            @r#"if (resource == Document::"C") then Document::"A" else Document::"B""#
+            @r#"if resource == Document::"C" then Document::"A" else Document::"B""#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"if (resource == User::"alice") then Document::"A" else Document::"B""#),
@@ -1989,6 +1989,110 @@ mod tests {
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal in [resource]"#),
+            @"false"
+        );
+    }
+
+    #[test]
+    fn test_binary_app_in_action_hierarchy() {
+        let schema = parse_schema(
+            r#"
+            namespace Groups {
+                action all;
+                action unrelated;
+            }
+            namespace App {
+                entity User;
+                entity Doc;
+                action view in [Groups::Action::"all"] appliesTo {
+                    principal: User,
+                    resource: Doc,
+                    context: {},
+                };
+                action edit appliesTo {
+                    principal: User,
+                    resource: Doc,
+                    context: {},
+                };
+            }"#,
+        );
+        let req = PartialRequest::new(
+            parse_partial_euid("App::User"),
+            r#"App::Action::"view""#.parse().unwrap(),
+            parse_partial_euid("App::Doc"),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // We could reduce to a value in these because the schema includes action ancestors, but
+        // calling a constructor other then `PartialEntities::new` will add them and just give us
+        // the concrete evaluation path, so there's no reason to implement that case.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"App::Action::"view" in Groups::Action::"all""#),
+            @r#"App::Action::"view" in Groups::Action::"all""#
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"App::Action::"edit" in Groups::Action::"all""#),
+            @r#"App::Action::"edit" in Groups::Action::"all""#
+        );
+        // Reflexive case is reduced to a value since that never needs ancestors.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"action in action"#),
+            @"true"
+        );
+        // Comparisons with non-actions also reduce since they're decided using only entity types.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"principal in action"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"action in resource"#),
+            @"false"
+        );
+    }
+
+    #[test]
+    fn test_action_operand_reductions() {
+        let schema = parse_schema(
+            r#"
+            namespace App {
+                entity User;
+                entity Doc;
+                action view appliesTo { principal: User, resource: Doc, context: {} };
+            }"#,
+        );
+        let req = PartialRequest::new(
+            parse_partial_euid("App::User"),
+            r#"App::Action::"view""#.parse().unwrap(),
+            parse_partial_euid("App::Doc"),
+            None,
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &PartialEntities::new(),
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interpret_typed_str_to_str = |e| interpret_typed_str_to_str(&eval, e, &schema);
+
+        // Would be decided from concrete data if we used a `PartialEntity` constructor that accept
+        // a schema, but here we show it reduce without concrete information.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"action has bogus"#),
+            @"false"
+        );
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"action.hasTag("t")"#),
             @"false"
         );
     }

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -1997,29 +1997,24 @@ mod tests {
     fn test_binary_app_in_action_hierarchy() {
         let schema = parse_schema(
             r#"
-            namespace Groups {
-                action all;
-                action unrelated;
-            }
+            action unrelated;
+            namespace Groups { action all; }
             namespace App {
-                entity User;
-                entity Doc;
+                entity E;
                 action view in [Groups::Action::"all"] appliesTo {
-                    principal: User,
-                    resource: Doc,
-                    context: {},
+                    principal: E,
+                    resource: E,
                 };
                 action edit appliesTo {
-                    principal: User,
-                    resource: Doc,
-                    context: {},
+                    principal: E,
+                    resource: E,
                 };
             }"#,
         );
         let req = PartialRequest::new(
-            parse_partial_euid("App::User"),
+            parse_partial_euid("App::E"),
             r#"App::Action::"view""#.parse().unwrap(),
-            parse_partial_euid("App::Doc"),
+            parse_partial_euid("App::E"),
             None,
             &schema,
         )
@@ -2034,7 +2029,8 @@ mod tests {
 
         // We could reduce to a value in these because the schema includes action ancestors, but
         // calling a constructor other then `PartialEntities::new` will add them and just give us
-        // the concrete evaluation path, so there's no reason to implement that case.
+        // the concrete evaluation path, so there's no reason to implement that case. Here we show
+        // that it's not decidable at the type level because `App::Action` can be in an `Groups::Action`.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"App::Action::"view" in Groups::Action::"all""#),
             @r#"App::Action::"view" in Groups::Action::"all""#
@@ -2043,12 +2039,21 @@ mod tests {
             interpret_typed_str_to_str(r#"App::Action::"edit" in Groups::Action::"all""#),
             @r#"App::Action::"edit" in Groups::Action::"all""#
         );
-        // Reflexive case is reduced to a value since that never needs ancestors.
+        // This is decidable at the type level because `App::Action` is never in `Action`
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"App::Action::"edit" in Action::"unrelated""#),
+            @"false"
+        );
+        // Reflexive case is reduced to a value since it never needs ancestors
         assert_snapshot!(
             interpret_typed_str_to_str(r#"action in action"#),
             @"true"
         );
-        // Comparisons with non-actions also reduce since they're decided using only entity types.
+        assert_snapshot!(
+            interpret_typed_str_to_str(r#"action in [App::Action::"edit", action]"#),
+            @"true"
+        );
+        // Comparisons with non-actions also reduce
         assert_snapshot!(
             interpret_typed_str_to_str(r#"principal in action"#),
             @"false"

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -30,7 +30,11 @@ use crate::{
     tpe::entities::PartialEntities,
     tpe::request::PartialRequest,
     tpe::residual::{Residual, ResidualKind},
+    tpe::value::AttrState,
 };
+
+#[cfg(test)]
+mod test;
 
 /// The partial evaluator
 #[derive(Debug)]
@@ -91,13 +95,11 @@ impl Evaluator<'_> {
                     mk_residual(ResidualKind::Var(Var::Resource))
                 }
             }
-            ResidualKind::Var(Var::Context) => {
-                if let Some(context) = self.request.context_attrs() {
-                    mk_concrete(Value::record_arc(context.clone(), None))
-                } else {
-                    mk_residual(ResidualKind::Var(Var::Context))
-                }
-            }
+            ResidualKind::Var(Var::Context) => match self.request.context() {
+                Some(context) => AttrState::PartialRecord(context.clone())
+                    .to_residual(r.ty(), || mk_residual(ResidualKind::Var(Var::Context))),
+                None => mk_residual(ResidualKind::Var(Var::Context)),
+            },
             ResidualKind::And { left, right } => {
                 let left = self.interpret(left);
                 match &left {
@@ -316,13 +318,8 @@ impl Evaluator<'_> {
                             let Ok(tag) = v2.get_as_string() else {
                                 return mk_error();
                             };
-                            match self.entities.get_tags(uid) {
-                                Some(tags) => match tags.get(tag) {
-                                    Some(v) => mk_concrete(v.clone()),
-                                    None => mk_error(),
-                                },
-                                None => binapp_residual(arg1, arg2),
-                            }
+                            self.entity_tag(uid, tag)
+                                .to_residual(r.ty(), || binapp_residual(arg1.clone(), arg2.clone()))
                         }
                         BinaryOp::HasTag => {
                             let Ok(uid) = v1.get_as_entity() else {
@@ -331,9 +328,10 @@ impl Evaluator<'_> {
                             let Ok(tag) = v2.get_as_string() else {
                                 return mk_error();
                             };
-                            match self.entities.get_tags(uid) {
-                                Some(tags) => mk_concrete(tags.contains_key(tag).into()),
-                                None => binapp_residual(arg1, arg2),
+                            match self.entity_tag(uid, tag) {
+                                state if state.exists() => mk_concrete(true.into()),
+                                AttrState::Absent => mk_concrete(false.into()),
+                                _ => binapp_residual(arg1, arg2),
                             }
                         }
                         BinaryOp::Contains => match v1.get_as_set() {
@@ -360,62 +358,31 @@ impl Evaluator<'_> {
             }
             ResidualKind::GetAttr { expr, attr } => {
                 let expr = self.interpret(expr);
-                match &expr {
-                    Residual::Concrete { value, .. } => {
-                        if let Ok(r) = value.get_as_record() {
-                            if let Some(val) = r.as_ref().get(attr) {
-                                mk_concrete(val.clone())
-                            } else {
-                                mk_error()
-                            }
-                        } else if let Ok(uid) = value.get_as_entity() {
-                            match self.entities.get_attrs(uid) {
-                                Some(attrs) => match attrs.get(attr) {
-                                    Some(val) => mk_concrete(val.clone()),
-                                    None => mk_error(),
-                                },
-                                None => mk_residual(ResidualKind::GetAttr {
-                                    expr: Arc::new(expr),
-                                    attr: attr.clone(),
-                                }),
-                            }
-                        } else {
-                            mk_error()
-                        }
-                    }
-                    Residual::Partial { .. } => mk_residual(ResidualKind::GetAttr {
-                        expr: Arc::new(expr),
-                        attr: attr.clone(),
-                    }),
-                    Residual::Error(_) => mk_error(),
+                if matches!(expr, Residual::Error(_)) {
+                    return mk_error();
                 }
+                self.attr_state_at(&expr, attr).to_residual(r.ty(), || {
+                    mk_residual(ResidualKind::GetAttr {
+                        expr: Arc::new(expr.clone()),
+                        attr: attr.clone(),
+                    })
+                })
             }
             ResidualKind::HasAttr { expr, attr } => {
                 let expr = self.interpret(expr);
+                if matches!(expr, Residual::Error(_)) {
+                    return mk_error();
+                }
                 if let Some(v) = try_decide_has_residual(self.schema, &expr, attr) {
                     return mk_concrete(v);
                 }
-                match &expr {
-                    Residual::Concrete { value, .. } => {
-                        if let Ok(r) = value.get_as_record() {
-                            mk_concrete(r.as_ref().contains_key(attr).into())
-                        } else if let Ok(uid) = value.get_as_entity() {
-                            match self.entities.get_attrs(uid) {
-                                Some(attrs) => mk_concrete(attrs.contains_key(attr).into()),
-                                None => mk_residual(ResidualKind::HasAttr {
-                                    expr: Arc::new(expr),
-                                    attr: attr.clone(),
-                                }),
-                            }
-                        } else {
-                            mk_error()
-                        }
-                    }
-                    Residual::Partial { .. } => mk_residual(ResidualKind::HasAttr {
+                match self.attr_state_at(&expr, attr) {
+                    state if state.exists() => mk_concrete(true.into()),
+                    AttrState::Absent => mk_concrete(false.into()),
+                    _ => mk_residual(ResidualKind::HasAttr {
                         expr: Arc::new(expr),
                         attr: attr.clone(),
                     }),
-                    Residual::Error(_) => mk_error(),
                 }
             }
             ResidualKind::UnaryApp { op, arg } => {
@@ -505,6 +472,86 @@ impl Evaluator<'_> {
             }
         }
     }
+
+    /// Lookup the partial information available for an entity's attribute, accounting for what is
+    /// known in the entity data and what we can infer from the type.
+    fn entity_attr(&self, uid: &EntityUID, attr: &str) -> AttrState {
+        let Some(attrs) = self.entities.get_attrs(uid) else {
+            return AttrState::Unknown;
+        };
+        let Some(et) = self.schema.get_entity_type(uid.entity_type()) else {
+            return AttrState::Unknown;
+        };
+        attrs.resolve_attr(attr, et.attributes())
+    }
+
+    /// Lookup the partial information available for an entity's tag
+    fn entity_tag(&self, uid: &EntityUID, tag: &str) -> AttrState {
+        match self.entities.get_tags(uid) {
+            Some(tags) => tags.attr(tag).clone(),
+            None => AttrState::Unknown,
+        }
+    }
+
+    /// What we know about an attribute of a residual
+    ///
+    /// Uses r's type to infer what attributes must exist if `r` is partial
+    fn attr_state_at(&self, r: &Residual, attr: &str) -> AttrState {
+        match (self.residual_state(r), r.ty()) {
+            (AttrState::Value(v), _) => {
+                if let Ok(record) = v.get_as_record() {
+                    match record.get(attr) {
+                        Some(v) => AttrState::Value(v.clone()),
+                        None => AttrState::Absent,
+                    }
+                } else if let Ok(uid) = v.get_as_entity() {
+                    // An entity's attributes come from the partial store plus the schema.
+                    self.entity_attr(uid, attr)
+                } else {
+                    AttrState::Unknown
+                }
+            }
+            (AttrState::PartialRecord(rec), Type::Record { attrs, .. }) => {
+                rec.resolve_attr(attr, attrs)
+            }
+            _ => AttrState::Unknown,
+        }
+    }
+
+    /// What we knows about a residual
+    ///
+    /// This functions returns an `AttrState` because we are primarily interested in the case where
+    /// the residual is get-attr expression (`context.foo`) where we want to know what level of
+    /// partial information we know about the attribute.
+    fn residual_state(&self, r: &Residual) -> AttrState {
+        match r {
+            Residual::Concrete { value, .. } => AttrState::Value(value.clone()),
+            Residual::Error(_) => AttrState::Unknown,
+            Residual::Partial { kind, .. } => match kind {
+                ResidualKind::Var(Var::Context) => match self.request.context() {
+                    Some(context) => AttrState::PartialRecord(context.clone()),
+                    None => AttrState::Unknown,
+                },
+                ResidualKind::GetAttr { expr, attr } => self.attr_state_at(expr, attr),
+                ResidualKind::BinaryApp {
+                    op: BinaryOp::GetTag,
+                    arg1,
+                    arg2,
+                } => match (self.residual_state(arg1), self.residual_state(arg2)) {
+                    (AttrState::Value(v1), AttrState::Value(v2)) => {
+                        // Checking for `<entity-lit>.getTag(<tag-lit>)` so that we can get the partial
+                        // attribute information for tag values.
+                        match (v1.get_as_entity(), v2.get_as_string()) {
+                            (Ok(uid), Ok(tag)) => self.entity_tag(uid, tag),
+                            _ => AttrState::Unknown,
+                        }
+                    }
+                    _ => AttrState::Unknown,
+                },
+                _ => AttrState::Unknown,
+            },
+        }
+    }
 }
 
 /// Given an `is` expression applied to a residual, reduce it to a value if
@@ -574,7 +621,7 @@ fn try_decide_has_residual(schema: &ValidatorSchema, expr: &Residual, attr: &str
 /// canonical form given by [`ExtensionValue::canonical_repr`]. This ensures TPE
 /// residuals are deterministic regardless of which constructor originally
 /// created the value.
-fn normalize_ext_value(value: Value) -> Value {
+pub(crate) fn normalize_ext_value(value: Value) -> Value {
     normalize_ext_value_inner(&value).unwrap_or(value)
 }
 
@@ -650,16 +697,14 @@ fn normalize_ext_value_inner(value: &Value) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
-
-    use crate::ast::{Expr, SlotEnv};
+    use crate::ast::{EntityUID, Expr, SlotEnv};
     use crate::tpe::err::ExprToResidualError;
     use crate::tpe::test_utils::{parse_partial_euid, parse_typed_expr};
+    use crate::tpe::value::PartialRecord;
     use crate::validator::types::Type;
     use crate::validator::ValidatorSchema;
     use crate::{
-        ast::{Context, ExprBuilder, Value, Var},
+        ast::{Context, ExprBuilder, Var},
         expr_builder::ExprBuilder as _,
         extensions::Extensions,
     };
@@ -763,15 +808,20 @@ mod tests {
         let schema = parse_schema(
             r#"entity E; action a appliesTo {principal: E, resource: E, context: {l: Long}};"#,
         );
+        let Ok(Context::Value(context)) = Context::from_json_value(serde_json::json!({ "l": 0 }))
+        else {
+            panic!("expected concrete context")
+        };
+        let action: EntityUID = r#"Action::"a""#.parse().unwrap();
         let eval = Evaluator {
             request: &PartialRequest::new(
                 parse_partial_euid(r#"E"#),
-                r#"Action::"a""#.parse().unwrap(),
+                action.clone(),
                 parse_partial_euid("E"),
-                Some(Arc::new(BTreeMap::from([(
-                    "l".parse().unwrap(),
-                    Value::from(0),
-                )]))),
+                Some(
+                    PartialRecord::concrete_context_for_action(context.as_ref(), &action, &schema)
+                        .unwrap(),
+                ),
                 &schema,
             )
             .unwrap(),
@@ -1158,11 +1208,15 @@ mod tests {
         else {
             panic!("expected concrete context")
         };
+        let action: EntityUID = r#"Action::"a""#.parse().unwrap();
         let req = PartialRequest::new(
             parse_partial_euid(r#"E::"foo""#),
-            r#"Action::"a""#.parse().unwrap(),
+            action.clone(),
             parse_partial_euid("E"),
-            Some(context),
+            Some(
+                PartialRecord::concrete_context_for_action(context.as_ref(), &action, &schema)
+                    .unwrap(),
+            ),
             &schema,
         )
         .unwrap();
@@ -1446,14 +1500,14 @@ mod tests {
             interpret_typed_str_to_str(r#"(resource.b && E::"0" has s) && E::"0".s == context.x"#),
             @r#"resource.b && ("foo" == context.x)"#
         );
+        // `E::"1"` has empty attrs, but TPE treats anything that's not explicitly absent as unknown
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"1" has s && E::"1".s == context.x"#),
-            @"false"
+            @r#"(E::"1" has s) && (E::"1".s == context.x)"#
         );
-        // Residual `resource.b` means we can't eliminate `error` expression even though it's unreachable
         assert_snapshot!(
             interpret_typed_str_to_str(r#"(resource.b && E::"1" has s) && E::"1".s == context.x"#),
-            @"resource.b && false && error()"
+            @r#"resource.b && (E::"1" has s) && (E::"1".s == context.x)"#
         );
         assert_snapshot!(
             interpret_typed_str_to_str(r#"E::"2" has s && E::"2".s == context.x"#),
@@ -1589,12 +1643,16 @@ mod tests {
         else {
             panic!("expected concrete context")
         };
+        let action: EntityUID = r#"Action::"get""#.parse().unwrap();
 
         let req = PartialRequest::new(
             parse_partial_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
+            action.clone(),
             parse_partial_euid(r#"E::"""#),
-            Some(context),
+            Some(
+                PartialRecord::concrete_context_for_action(context.as_ref(), &action, &schema)
+                    .unwrap(),
+            ),
             &schema,
         )
         .unwrap();
@@ -2141,8 +2199,8 @@ mod tests {
         };
         let interp_with_actions = |e| interpret_typed_str_to_str(&eval_with_actions, e, &schema);
 
-        assert_snapshot!(interp_with_actions(r#"action has bogus"#), @"false");
-        assert_snapshot!(interp_with_actions(r#"action.hasTag("t")"#), @"false");
+        assert_snapshot!(interp_with_actions(r#"action has bogus"#), @r#"App::Action::"view" has bogus"#);
+        assert_snapshot!(interp_with_actions(r#"action.hasTag("t")"#), @r#"App::Action::"view".hasTag("t")"#);
     }
 
     #[test]
@@ -2155,11 +2213,16 @@ mod tests {
         else {
             panic!("expected concrete context")
         };
+
+        let action: EntityUID = r#"Action::"get""#.parse().unwrap();
         let req = PartialRequest::new(
             parse_partial_euid("User"),
-            r#"Action::"get""#.parse().unwrap(),
+            action.clone(),
             parse_partial_euid("E"),
-            Some(context),
+            Some(
+                PartialRecord::concrete_context_for_action(context.as_ref(), &action, &schema)
+                    .unwrap(),
+            ),
             &schema,
         )
         .unwrap();
@@ -2246,9 +2309,11 @@ mod tests {
             interpret_typed_str_to_str(r#"User::"some_tags".hasTag("s")"#),
             @"true"
         );
+        // A tag missing from the map stays a residual: tag not-in-map means
+        // unknown existence, so we cannot reduce to `false`.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"some_tags".hasTag("bogus")"#),
-            @"false"
+            @r#"User::"some_tags".hasTag("bogus")"#
         );
         // Unknown entity uid, unknown tags, or absent entity: `hasTag` stays a residual.
         assert_snapshot!(
@@ -2281,10 +2346,11 @@ mod tests {
             interpret_typed_str_to_str(r#"User::"some_tags".hasTag("s") && User::"some_tags".getTag("s") == "bar" "#),
             @"true"
         );
-        // Known tags, missing key: `hasTag` is false and short-circuits.
+        // A tag missing from the map stays a residual: tag not-in-map means
+        // unknown existence, so we cannot reduce to `false`.
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"some_tags".hasTag("bogus") && User::"some_tags".getTag("bogus") == "bar" "#),
-            @"false"
+            @r#"User::"some_tags".hasTag("bogus") && (User::"some_tags".getTag("bogus") == "bar")"#
         );
         // Unknown cases
         assert_snapshot!(
@@ -2319,10 +2385,10 @@ mod tests {
             @"false"
         );
 
-        // Residual on the left prevents eliminating `error()` expression even through it's unreachable
+        // same issue tag not-in-map issue
         assert_snapshot!(
             interpret_typed_str_to_str(r#"User::"none_tags".hasTag("tag") && User::"none_tags".getTag("tag") == "foo" && User::"some_tags".hasTag("bogus") && User::"some_tags".getTag("bogus") == "bar" "#),
-            @r#"User::"none_tags".hasTag("tag") && (User::"none_tags".getTag("tag") == "foo") && false && error()"#
+            @r#"User::"none_tags".hasTag("tag") && (User::"none_tags".getTag("tag") == "foo") && User::"some_tags".hasTag("bogus") && (User::"some_tags".getTag("bogus") == "bar")"#
         );
     }
 

--- a/cedar-policy-core/src/tpe/evaluator/test.rs
+++ b/cedar-policy-core/src/tpe/evaluator/test.rs
@@ -1,0 +1,1221 @@
+use super::super::test_utils::*;
+use crate::{
+    ast::{Eid, EntityUID, Expr, Literal, Value},
+    parser::parse_policyset,
+    tpe::{
+        self,
+        entities::{PartialEntities, PartialEntity},
+        request::PartialRequest,
+        value::{AttrState as PA, AttrState, PartialRecord},
+    },
+    validator::ValidatorSchema,
+};
+use insta::assert_snapshot;
+use smol_str::SmolStr;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Give a test module its schema, request, and entity builders.
+///
+/// Defines `schema()`, `setup()` (schema plus a request for the given principal/action/resource),
+/// and `entity`/`empty_entity` bound to that schema — so every fixture is validated against the
+/// schema it will be evaluated with.
+macro_rules! test_env {
+    ($src:expr, $principal:expr, $action:expr, $resource:expr) => {
+        #[track_caller]
+        #[allow(dead_code, reason = "not every test module names the schema directly")]
+        pub(crate) fn schema() -> ValidatorSchema {
+            ValidatorSchema::from_cedarschema_str(
+                $src,
+                &crate::extensions::Extensions::all_available(),
+            )
+            .unwrap()
+            .0
+        }
+
+        #[track_caller]
+        #[allow(dead_code, reason = "not every test module needs the request")]
+        pub(crate) fn setup() -> (ValidatorSchema, PartialRequest) {
+            let schema = schema();
+            let req = request_with_context(
+                $principal,
+                $action,
+                $resource,
+                Some(PartialRecord::new()),
+                &schema,
+            );
+            (schema, req)
+        }
+
+        #[track_caller]
+        #[allow(dead_code, reason = "not every test module builds a non-empty entity")]
+        pub(crate) fn entity(
+            ty: &str,
+            id: &str,
+            attrs: Option<PartialRecord>,
+            tags: Option<PartialRecord>,
+        ) -> PartialEntity {
+            PartialEntity::new(uid(ty, id), attrs, Some(HashSet::new()), tags, &schema())
+                .expect("entity should conform to the schema")
+        }
+
+        #[track_caller]
+        #[allow(dead_code, reason = "not every test module builds an empty entity")]
+        pub(crate) fn empty_entity(ty: &str, id: &str) -> PartialEntity {
+            entity(
+                ty,
+                id,
+                Some(PartialRecord::new()),
+                Some(PartialRecord::new()),
+            )
+        }
+    };
+}
+
+/// Build an [`EntityUID`] from a type and id.
+pub(crate) fn uid(ty: &str, id: &str) -> EntityUID {
+    EntityUID::from_components(ty.parse().unwrap(), Eid::new(id), None)
+}
+
+/// As [`request`], but with the given context.
+#[track_caller]
+pub(crate) fn request_with_context(
+    principal: &str,
+    action_id: &str,
+    resource: &str,
+    context: Option<PartialRecord>,
+    schema: &ValidatorSchema,
+) -> PartialRequest {
+    PartialRequest::new(
+        parse_partial_euid(principal),
+        uid("Action", action_id),
+        parse_partial_euid(resource),
+        context,
+        schema,
+    )
+    .expect("request should conform to the schema")
+}
+
+/// Partially evaluate `policy` and pretty-print the residual as Cedar text.
+#[track_caller]
+pub(crate) fn eval_to_cedar(
+    schema: &ValidatorSchema,
+    req: &PartialRequest,
+    entities: impl IntoIterator<Item = PartialEntity>,
+    policy: &str,
+) -> String {
+    let policies = parse_policyset(policy).unwrap();
+    let ents = PartialEntities::from_entities(entities.into_iter(), schema).unwrap();
+    let response = tpe::is_authorized(&policies, req, &ents, schema).unwrap();
+    let id = policies.static_policies().next().unwrap().id().clone();
+    let r = Arc::unwrap_or_clone(response.get_residual_policy(&id).unwrap().get_residual());
+    Expr::from(r.clone()).to_string()
+}
+
+/// Wrap a condition in a `permit` policy with id `p`.
+pub(crate) fn permit_when(cond: &str) -> String {
+    format!(r#"permit(principal, action, resource) when {{ {cond} }};"#)
+}
+
+/// A known-value literal attribute (`AttrState::Value`).
+pub(crate) fn present(v: impl Into<Literal>) -> AttrState {
+    AttrState::Value(Value::new(v.into(), None))
+}
+
+/// A known-value entity-uid attribute (`AttrState::Value`).
+pub(crate) fn present_uid(ty: &str, id: &str) -> AttrState {
+    AttrState::Value(Value::new(Literal::EntityUID(Arc::new(uid(ty, id))), None))
+}
+
+/// A known-value record attribute (`AttrState::Value`).
+pub(crate) fn record(
+    fields: impl IntoIterator<Item = (impl Into<SmolStr>, AttrState)>,
+) -> AttrState {
+    AttrState::PartialRecord(rec(fields))
+}
+
+/// A [`PartialRecord`] from (key, attribute) pairs.
+pub(crate) fn rec(
+    fields: impl IntoIterator<Item = (impl Into<SmolStr>, AttrState)>,
+) -> PartialRecord {
+    fields.into_iter().map(|(k, v)| (k.into(), v)).collect()
+}
+
+mod partial_attr_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User { name: String, level: Long } tags String;
+        entity Document { owner: User, public: Bool };
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn doc(public: PA) -> PartialEntity {
+        entity(
+            "Document",
+            "doc",
+            Some(rec([
+                ("owner", present_uid("User", "alice")),
+                ("public", public),
+            ])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    fn alice() -> PartialEntity {
+        entity(
+            "User",
+            "alice",
+            Some(rec([("name", present("Alice")), ("level", present(5))])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    fn eval(public: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        eval_to_cedar(&schema, &req, [doc(public), alice()], &permit_when(cond))
+    }
+
+    fn eval_no_public(cond: &str) -> String {
+        let (schema, req) = setup();
+        let doc = entity(
+            "Document",
+            "doc",
+            Some(rec([("owner", present_uid("User", "alice"))])),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(&schema, &req, [doc, alice()], &permit_when(cond))
+    }
+
+    fn eval_tag(role: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec([("name", present("Alice")), ("level", present(5))])),
+            Some(rec([("role", role)])),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [doc(present(true)), alice],
+            &permit_when(cond),
+        )
+    }
+
+    fn eval_no_tags(cond: &str) -> String {
+        let (schema, req) = setup();
+        eval_to_cedar(
+            &schema,
+            &req,
+            [doc(present(true)), alice()],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_get_attr() {
+        let cond = "resource.public";
+        assert_snapshot!(eval(present(true), cond), @"true");
+        assert_snapshot!(eval(PA::Present, cond), @r#"Document::"doc".public"#);
+        assert_snapshot!(eval_no_public(cond), @r#"Document::"doc".public"#);
+    }
+
+    #[test]
+    fn test_has_attr() {
+        let cond = "resource has public";
+        assert_snapshot!(eval(PA::Present, cond), @"true");
+        // `public` omitted from the known attrs, yet `has` is true: required, so
+        // the schema guarantees existence.
+        assert_snapshot!(eval_no_public(cond), @"true");
+    }
+
+    #[test]
+    fn test_tag_has_and_get() {
+        let cond = r#"principal.hasTag("role") && principal.getTag("role") == "admin""#;
+        assert_snapshot!(eval_tag(present("admin"), cond), @"true");
+        assert_snapshot!(
+            eval_tag(PA::Present, cond),
+            @r#"User::"alice".getTag("role") == "admin""#
+        );
+        assert_snapshot!(eval_tag(PA::Absent, cond), @"false");
+        assert_snapshot!(
+            eval_no_tags(cond),
+            @r#"User::"alice".hasTag("role") && (User::"alice".getTag("role") == "admin")"#
+        );
+    }
+}
+
+mod nested_partial_attr_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User;
+        entity Document { meta: { title: String, rating: Long }, public: Bool };
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn doc(meta: PA) -> PartialEntity {
+        entity(
+            "Document",
+            "doc",
+            Some(rec([("meta", meta), ("public", present(true))])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    fn eval(meta: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        eval_to_cedar(
+            &schema,
+            &req,
+            [doc(meta), empty_entity("User", "alice")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_record_value_is_error_free() {
+        let meta = record([("title", PA::Present), ("rating", present(5))]);
+        // Error freedom here is conservative: the record read is treated as possibly erroring, so
+        // the comparison is not folded away by `&& 1 == 2`. Deciding error freedom from the
+        // resolved attribute state (which would fold this to `false`) is deferred.
+        assert_snapshot!(
+            eval(meta.clone(), r#"resource.meta == {title: "x", rating: 5} && 1 == 2"#),
+            @r#"(Document::"doc".meta == {rating: 5, title: "x"}) && false"#
+        );
+    }
+
+    #[test]
+    fn test_title_eq() {
+        let cond = r#"resource.meta.title == "My Doc""#;
+        assert_snapshot!(
+            eval(record([("title", present("My Doc")), ("rating", present(5))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("title", PA::Present), ("rating", present(5))]), cond),
+            @r#"Document::"doc".meta.title == "My Doc""#
+        );
+    }
+
+    #[test]
+    fn test_has_title() {
+        let cond = "resource.meta has title";
+        assert_snapshot!(
+            eval(record([("title", PA::Present), ("rating", present(5))]), cond),
+            @"true"
+        );
+        assert_snapshot!(eval(record([("rating", present(5))]), cond), @"true");
+        assert_snapshot!(eval(PA::Present, cond), @r#"Document::"doc".meta has title"#);
+    }
+
+    #[test]
+    fn test_mixed_known_and_unknown_fields() {
+        assert_snapshot!(
+            eval(
+                record([("title", PA::Present), ("rating", present(5))]),
+                r#"resource.meta.rating < 10 && resource.meta.title == "My Doc""#,
+            ),
+            @r#"Document::"doc".meta.title == "My Doc""#
+        );
+    }
+
+    #[test]
+    fn test_record_equality() {
+        let cond = r#"resource.meta == {title: "My Doc", rating: 5}"#;
+        assert_snapshot!(
+            eval(record([("title", present("My Doc")), ("rating", present(5))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Other")), ("rating", present(5))]), cond),
+            @"false"
+        );
+        // `rating` is 6 here, not 5, but the residual re-emits `resource.meta`
+        // rather than a rebuilt literal, so the compared value reads `rating: 5`.
+        assert_snapshot!(
+            eval(record([("title", PA::Present), ("rating", present(6))]), cond),
+            @r#"Document::"doc".meta == {rating: 5, title: "My Doc"}"#
+        );
+    }
+}
+
+mod partial_record_tag_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User tags { role: String, level: Long };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval(val: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(PartialRecord::new()),
+            Some(rec([("info", val)])),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_get_role() {
+        let cond = r#"principal.hasTag("info") && principal.getTag("info").role == "admin""#;
+        assert_snapshot!(
+            eval(record([("role", present("admin")), ("level", present(5))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("role", PA::Present), ("level", present(5))]), cond),
+            @r#"User::"alice".getTag("info").role == "admin""#
+        );
+        assert_snapshot!(
+            eval(record([("level", present(5))]), cond),
+            @r#"User::"alice".getTag("info").role == "admin""#
+        );
+    }
+
+    #[test]
+    fn test_known_sibling_resolves() {
+        assert_snapshot!(
+            eval(
+                record([("role", PA::Present), ("level", present(5))]),
+                r#"principal.hasTag("info") && principal.getTag("info").level < 10"#,
+            ),
+            @"true"
+        );
+    }
+}
+
+mod optional_attr_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User { name: String, nickname?: String };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval(nickname: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec([("name", present("Alice")), ("nickname", nickname)])),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    fn eval_no_nickname(cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec([("name", present("Alice"))])),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_has() {
+        let cond = "principal has nickname";
+        assert_snapshot!(eval(present("Ali"), cond), @"true");
+        assert_snapshot!(eval(PA::Present, cond), @"true");
+        assert_snapshot!(eval(PA::Absent, cond), @"false");
+        assert_snapshot!(eval_no_nickname(cond), @r#"User::"alice" has nickname"#);
+    }
+
+    #[test]
+    fn test_guarded() {
+        let cond = r#"principal has nickname && principal.nickname == "Ali""#;
+        assert_snapshot!(eval(present("Ali"), cond), @"true");
+        assert_snapshot!(eval(PA::Present, cond), @r#"User::"alice".nickname == "Ali""#);
+        assert_snapshot!(eval(PA::Absent, cond), @"false");
+        assert_snapshot!(
+            eval_no_nickname(cond),
+            @r#"(User::"alice" has nickname) && (User::"alice".nickname == "Ali")"#
+        );
+    }
+}
+
+mod nested_optional_attr_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User;
+        entity Document { meta: { title: String, subtitle?: String } };
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval(meta: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        let doc = entity(
+            "Document",
+            "doc",
+            Some(rec([("meta", meta)])),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [doc, empty_entity("User", "alice")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_has_subtitle() {
+        let cond = "resource.meta has subtitle";
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", present("Sub"))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", PA::Present)]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", PA::Absent)]), cond),
+            @"false"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc"))]), cond),
+            @r#"Document::"doc".meta has subtitle"#
+        );
+    }
+
+    #[test]
+    fn test_guarded_subtitle() {
+        let cond = r#"resource.meta has subtitle && resource.meta.subtitle == "Sub""#;
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", present("Sub"))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", PA::Present)]), cond),
+            @r#"Document::"doc".meta.subtitle == "Sub""#
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc")), ("subtitle", PA::Absent)]), cond),
+            @"false"
+        );
+        assert_snapshot!(
+            eval(record([("title", present("Doc"))]), cond),
+            @r#"(Document::"doc".meta has subtitle) && (Document::"doc".meta.subtitle == "Sub")"#
+        );
+    }
+}
+
+mod context_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User;
+        entity Document;
+        action Read appliesTo {
+            principal: User,
+            resource: Document,
+            context: { level: Long, tag?: String }
+        };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval_ctx(context: Option<PartialRecord>, cond: &str) -> String {
+        let schema = schema();
+        let req = request_with_context(
+            r#"User::"alice""#,
+            "Read",
+            r#"Document::"doc""#,
+            context,
+            &schema,
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [
+                empty_entity("User", "alice"),
+                empty_entity("Document", "doc"),
+            ],
+            &permit_when(cond),
+        )
+    }
+
+    fn ctx(fields: impl IntoIterator<Item = (&'static str, PA)>) -> Option<PartialRecord> {
+        Some(rec(fields))
+    }
+
+    #[test]
+    fn test_context_level() {
+        let cond = "context.level < 10";
+        assert_snapshot!(eval_ctx(ctx([("level", present(5))]), cond), @"true");
+        assert_snapshot!(eval_ctx(None, cond), @"context.level < 10");
+        assert_snapshot!(
+            eval_ctx(ctx([("level", PA::Present)]), cond),
+            @"context.level < 10"
+        );
+    }
+
+    #[test]
+    fn test_context_optional_tag() {
+        let cond = r#"context has tag && context.tag == "admin""#;
+        assert_snapshot!(
+            eval_ctx(ctx([("level", present(5)), ("tag", present("admin"))]), cond),
+            @"true"
+        );
+        assert_snapshot!(
+            eval_ctx(ctx([("level", present(5)), ("tag", PA::Absent)]), cond),
+            @"false"
+        );
+        assert_snapshot!(
+            eval_ctx(ctx([("level", present(5)), ("tag", PA::Present)]), cond),
+            @r#"context.tag == "admin""#
+        );
+        assert_snapshot!(
+            eval_ctx(ctx([("level", present(5))]), cond),
+            @r#"(context has tag) && (context.tag == "admin")"#
+        );
+        assert_snapshot!(
+            eval_ctx(None, cond),
+            @r#"(context has tag) && (context.tag == "admin")"#
+        );
+    }
+}
+
+mod required_attr_not_in_map_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User { name: String, nickname?: String };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval_with_attrs(attrs: impl IntoIterator<Item = (&'static str, PA)>, cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec(attrs)),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_required_not_in_map() {
+        assert_snapshot!(eval_with_attrs([], "principal has name"), @"true");
+        assert_snapshot!(
+            eval_with_attrs([], r#"principal.name == "Alice""#),
+            @r#"User::"alice".name == "Alice""#
+        );
+        assert_snapshot!(
+            eval_with_attrs([], r#"principal has name && principal.name == "Alice""#),
+            @r#"User::"alice".name == "Alice""#
+        );
+    }
+
+    #[test]
+    fn test_optional_not_in_map() {
+        let name = [("name", present("Alice"))];
+        assert_snapshot!(
+            eval_with_attrs(name.clone(), "principal has nickname"),
+            @r#"User::"alice" has nickname"#
+        );
+        assert_snapshot!(
+            eval_with_attrs(
+                name,
+                r#"principal has nickname && principal.nickname == "Ali""#,
+            ),
+            @r#"(User::"alice" has nickname) && (User::"alice".nickname == "Ali")"#
+        );
+    }
+
+    #[test]
+    fn test_required_in_map() {
+        let cond = "principal has name";
+        assert_snapshot!(eval_with_attrs([("name", present("Alice"))], cond), @"true");
+        assert_snapshot!(eval_with_attrs([("name", PA::Present)], cond), @"true");
+    }
+}
+
+/// Unknown attrs/tags (`None`) differ from a known-but-partial map: even a
+/// required attr's access stays residual (contrast `required_not_in_map`).
+mod unknown_entity_data_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User { name: String } tags String;
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval(cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity("User", "alice", None, None);
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_attrs() {
+        assert_snapshot!(eval("principal has name"), @r#"User::"alice" has name"#);
+        assert_snapshot!(
+            eval(r#"principal.name == "Alice""#),
+            @r#"User::"alice".name == "Alice""#
+        );
+        assert_snapshot!(
+            eval(r#"principal has name && principal.name == "Alice""#),
+            @r#"(User::"alice" has name) && (User::"alice".name == "Alice")"#
+        );
+    }
+
+    #[test]
+    fn test_tags() {
+        assert_snapshot!(eval(r#"principal.hasTag("t")"#), @r#"User::"alice".hasTag("t")"#);
+        assert_snapshot!(
+            eval(r#"principal.hasTag("t") && principal.getTag("t") == "x""#),
+            @r#"User::"alice".hasTag("t") && (User::"alice".getTag("t") == "x")"#
+        );
+    }
+}
+
+/// Record *literals*: Cedar evaluates every field, so an erroring sibling
+/// poisons the whole record and field extraction must not bypass it.
+mod record_literal_tests {
+    use super::*;
+
+    test_env!(
+        r#"
+        entity User { level: Long };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn eval(level: PA, cond: &str) -> String {
+        let (schema, req) = setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec([("level", level)])),
+            Some(PartialRecord::new()),
+        );
+        eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when(cond),
+        )
+    }
+
+    #[test]
+    fn test_all_concrete() {
+        assert_snapshot!(eval(present(5), "{a: 1, b: 2}.a == 1"), @"true");
+        assert_snapshot!(eval(present(5), "{a: 1, b: 2} has a"), @"true");
+        assert_snapshot!(eval(present(5), "{a: 1, b: 2} has c"), @"false");
+        assert_snapshot!(eval(present(5), "{a: 1} == {a: 1}"), @"true");
+        assert_snapshot!(eval(present(5), "{a: 1} == {a: 2}"), @"false");
+        assert_snapshot!(
+            eval(present(5), "{a: {b: {c: 3}}}.a.b.c == 3"),
+            @"true"
+        );
+    }
+
+    #[test]
+    fn test_sibling_error_poisons_literal() {
+        // Overflow in `e` errors the record, so reading `l` errors too.
+        let overflow = "{e: 9223372036854775807 + 1, l: 0}";
+        assert_snapshot!(eval(present(5), &format!("{overflow}.l == 0")), @"error()");
+        assert_snapshot!(eval(present(5), &format!("{overflow} has l")), @"error()");
+        assert_snapshot!(
+            eval(present(5), "{outer: {e: 9223372036854775807 + 1, l: 0}}.outer.l == 0"),
+            @"error()"
+        );
+    }
+
+    // The residual field may error once known, so a concrete sibling can't
+    // be extracted.
+    #[test]
+    fn test_residual_sibling_blocks_extraction() {
+        assert_snapshot!(
+            eval(PA::Present, "{e: principal.level + 1, l: 0}.l == 0"),
+            @r#"{e: User::"alice".level + 1, l: 0}.l == 0"#
+        );
+        assert_snapshot!(
+            eval(PA::Present, "{e: principal.level + 1, l: 0} has l"),
+            @r#"{e: User::"alice".level + 1, l: 0} has l"#
+        );
+        // `has` is likewise unanswered: if the sibling errors, so does `has`.
+        assert_snapshot!(
+            eval(PA::Present, "{e: principal.level + 1, l: 0} has missing"),
+            @r#"{e: User::"alice".level + 1, l: 0} has missing"#
+        );
+        assert_snapshot!(
+            eval(PA::Present, "{e: principal.level + 1, l: 0}.e < 10"),
+            @r#"{e: User::"alice".level + 1, l: 0}.e < 10"#
+        );
+    }
+
+    #[test]
+    fn test_error_branch_eliminated_by_known_guard() {
+        assert_snapshot!(
+            eval(
+                present(5),
+                "{e: if principal.level < 10 then 1 else 9223372036854775807 + 1, l: 0}.l == 0"
+            ),
+            @"true"
+        );
+        assert_snapshot!(
+            eval(
+                PA::Present,
+                "{e: if principal.level < 10 then 1 else 9223372036854775807 + 1, l: 0}.l == 0"
+            ),
+            @r#"{e: if User::"alice".level < 10 then 1 else error(), l: 0}.l == 0"#
+        );
+    }
+
+    #[test]
+    fn test_nested_literal_error_propagates_outward() {
+        assert_snapshot!(
+            eval(present(5), "{outer: {e: 9223372036854775807 + 1}, l: 0}.l == 0"),
+            @"error()"
+        );
+    }
+
+    // `principal` provably cannot error, yet still blocks extraction under the
+    // current conservative rule. A precision gap, not unsoundness; pinned so an
+    // improvement shows up as a snapshot change.
+    #[test]
+    fn test_non_erroring_residual_sibling_still_blocks() {
+        // An unknown principal, so its own schema and request rather than the module's.
+        mod unknown_principal {
+            use super::super::*;
+            test_env!(
+                r#"
+                entity User;
+                entity Document;
+                action Read appliesTo { principal: User, resource: Document, context: {} };
+                "#,
+                "User",
+                "Read",
+                r#"Document::"doc""#
+            );
+        }
+        let (schema, req) = unknown_principal::setup();
+        let out = eval_to_cedar(
+            &schema,
+            &req,
+            [unknown_principal::empty_entity("Document", "doc")],
+            &permit_when("{p: principal, l: 0}.l == 0"),
+        );
+        assert_snapshot!(out, @"{l: 0, p: principal}.l == 0");
+    }
+
+    // Contrast: the same shape from entity *data* does allow extraction.
+    #[test]
+    fn test_record_value_contrast_extraction_allowed() {
+        // A record-valued attribute, so its own schema rather than the module's.
+        mod record_attr {
+            use super::super::*;
+            test_env!(
+                r#"
+                entity User { meta: { e: Long, l: Long } };
+                entity Document;
+                action Read appliesTo { principal: User, resource: Document, context: {} };
+                "#,
+                r#"User::"alice""#,
+                "Read",
+                r#"Document::"doc""#
+            );
+        }
+        use record_attr::{empty_entity, entity};
+        let (schema, req) = record_attr::setup();
+        let alice = entity(
+            "User",
+            "alice",
+            Some(rec([(
+                "meta",
+                record([("e", PA::Present), ("l", present(0))]),
+            )])),
+            Some(PartialRecord::new()),
+        );
+        let out = eval_to_cedar(
+            &schema,
+            &req,
+            [alice, empty_entity("Document", "doc")],
+            &permit_when("principal.meta.l == 0"),
+        );
+        assert_snapshot!(out, @"true");
+    }
+}
+
+/// Interpreting a residual again with more entity data, as `is_authorized_batched` does.
+mod iterated_eval_tests {
+    use super::*;
+    use crate::extensions::Extensions;
+    use crate::parser::parse_policyset;
+    use crate::tpe::entities::PartialEntities;
+    use crate::tpe::residual::Residual;
+    use crate::tpe::Evaluator;
+
+    test_env!(
+        r#"
+        entity Other { data: Long };
+        entity User { meta: { other: Other, level: Long } };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn alice() -> PartialEntity {
+        entity(
+            "User",
+            "alice",
+            Some(rec([(
+                "meta",
+                record([("other", present_uid("Other", "o")), ("level", present(1))]),
+            )])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    /// As [`alice`], but `meta.level` is only known to exist, so `meta` cannot
+    /// fold to a concrete record.
+    fn alice_partial_meta() -> PartialEntity {
+        entity(
+            "User",
+            "alice",
+            Some(rec([(
+                "meta",
+                record([("other", present_uid("Other", "o")), ("level", PA::Present)]),
+            )])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    fn other() -> PartialEntity {
+        entity(
+            "Other",
+            "o",
+            Some(rec([("data", present(42))])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    /// Interpret `cond` against `round1` entities, then interpret the resulting
+    /// residual again against `round2`.
+    #[track_caller]
+    fn eval_twice(
+        round1: impl IntoIterator<Item = PartialEntity>,
+        round2: impl IntoIterator<Item = PartialEntity>,
+        cond: &str,
+    ) -> (String, String) {
+        let schema = schema();
+        let req = request_with_context(
+            r#"User::"alice""#,
+            "Read",
+            r#"Document::"doc""#,
+            Some(PartialRecord::new()),
+            &schema,
+        );
+        let policies = parse_policyset(&permit_when(cond)).unwrap();
+
+        let render = |r: &Residual| Expr::from(r.clone()).to_string();
+
+        let ents1 = PartialEntities::from_entities(round1.into_iter(), &schema).unwrap();
+        let residuals = tpe::policy_residual_map(&req, &policies, &schema).unwrap();
+        let expr = residuals.into_values().next().unwrap();
+        let first = Evaluator {
+            request: &req,
+            entities: &ents1,
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        }
+        .interpret(&expr);
+
+        let ents2 = PartialEntities::from_entities(round2.into_iter(), &schema).unwrap();
+        let second = Evaluator {
+            request: &req,
+            entities: &ents2,
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        }
+        .interpret(&first);
+
+        (render(&first), render(&second))
+    }
+
+    #[test]
+    fn test_access_through_record_value_reduces_on_later_round() {
+        let (first, second) = eval_twice(
+            [alice(), empty_entity("Document", "doc")],
+            [alice(), other(), empty_entity("Document", "doc")],
+            "principal.meta.other.data == 42",
+        );
+        assert_snapshot!(first, @r#"Other::"o".data == 42"#);
+        assert_snapshot!(second, @"true");
+    }
+
+    #[test]
+    fn test_record_value_base_arriving_late() {
+        let (first, second) = eval_twice(
+            [empty_entity("Document", "doc")],
+            [alice(), empty_entity("Document", "doc")],
+            r#"principal.meta == {other: Other::"o", level: 1}"#,
+        );
+        assert_snapshot!(first, @r#"User::"alice".meta == {level: 1, other: Other::"o"}"#);
+        assert_snapshot!(second, @"true");
+    }
+
+    #[test]
+    fn test_record_value_snapshot_is_refreshed_with_fuller_data() {
+        // Round 1 knows only that `meta.level` exists; round 2 knows its value.
+        let (first, second) = eval_twice(
+            [alice_partial_meta(), empty_entity("Document", "doc")],
+            [alice(), other(), empty_entity("Document", "doc")],
+            r#"principal.meta == {other: Other::"o", level: 1}"#,
+        );
+        assert_snapshot!(first, @r#"User::"alice".meta == {level: 1, other: Other::"o"}"#);
+        assert_snapshot!(second, @"true");
+    }
+}
+/// Residual export is lossless now that a partly-known record has no cached form: what a caller
+/// sees from `residual_policies()` is exactly the engine's own state, and re-interpreting it
+/// reaches the same answer.
+mod export_tests {
+    use super::*;
+    use crate::extensions::Extensions;
+    use crate::tpe::Evaluator;
+
+    test_env!(
+        r#"
+        entity User { meta: { title: String, rating: Long } };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    fn alice() -> PartialEntity {
+        entity(
+            "User",
+            "alice",
+            Some(rec([(
+                "meta",
+                record([("title", PA::Present), ("rating", present(5))]),
+            )])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    /// Interpreting an already-interpreted residual changes nothing: exporting the source
+    /// expression preserves every simplification represented by the evaluator state.
+    #[test]
+    fn export_is_idempotent() {
+        let (schema, req) = setup();
+        let ents = PartialEntities::from_entities(
+            [alice(), empty_entity("Document", "doc")].into_iter(),
+            &schema,
+        )
+        .unwrap();
+        let eval = Evaluator {
+            request: &req,
+            entities: &ents,
+            schema: &schema,
+            extensions: Extensions::all_available(),
+        };
+        let interp = |cond: &str| {
+            let policies = parse_policyset(&permit_when(cond)).unwrap();
+            let residuals = tpe::policy_residual_map(&req, &policies, &schema).unwrap();
+            let expr = residuals.into_values().next().unwrap();
+            let first = eval.interpret(&expr);
+            let second = eval.interpret(&first);
+            (
+                Expr::from(first).to_string(),
+                Expr::from(second).to_string(),
+            )
+        };
+
+        // A known field folds, and the fold survives export.
+        let (first, second) = interp("principal.meta.rating == 5");
+        assert_snapshot!(first, @"true");
+        assert_eq!(first, second);
+
+        // An unknown field exports as the access itself, and re-reading it resolves identically.
+        let (first, second) = interp(r#"principal.meta.title == "x""#);
+        assert_snapshot!(first, @r#"User::"alice".meta.title == "x""#);
+        assert_eq!(first, second);
+    }
+}
+
+/// A record can be partly known at one level and fully known at the next. The inner record must
+/// still fold to a concrete value, which needs its declared type — so the resolved state has to
+/// carry the type alongside a record-valued attribute, not just the record.
+mod nested_concrete_record_tests {
+    use super::*;
+    use crate::tpe::residual::Residual;
+
+    test_env!(
+        r#"
+        entity Other { data: Long };
+        entity User { meta: { inner: { a: Long, b: Long }, other: Other, tag: String } };
+        entity Document;
+        action Read appliesTo { principal: User, resource: Document, context: {} };
+        "#,
+        r#"User::"alice""#,
+        "Read",
+        r#"Document::"doc""#
+    );
+
+    /// `meta` is partly known — `tag` only exists — but `meta.inner` is fully known.
+    fn alice() -> PartialEntity {
+        entity(
+            "User",
+            "alice",
+            Some(rec([(
+                "meta",
+                record([
+                    ("inner", record([("a", present(1)), ("b", present(2))])),
+                    ("other", present_uid("Other", "hidden")),
+                    ("tag", PA::Present),
+                ]),
+            )])),
+            Some(PartialRecord::new()),
+        )
+    }
+
+    #[track_caller]
+    fn residual(cond: &str) -> Residual {
+        let (schema, req) = setup();
+        let policies = parse_policyset(&permit_when(cond)).unwrap();
+        let ents = PartialEntities::from_entities(
+            [alice(), empty_entity("Document", "doc")].into_iter(),
+            &schema,
+        )
+        .unwrap();
+        let response = tpe::is_authorized(&policies, &req, &ents, &schema).unwrap();
+        let id = policies.static_policies().next().unwrap().id().clone();
+        Arc::unwrap_or_clone(response.get_residual_policy(&id).unwrap().get_residual())
+    }
+
+    #[track_caller]
+    fn eval(cond: &str) -> String {
+        Expr::from(residual(cond)).to_string()
+    }
+
+    #[test]
+    fn inner_record_folds_through_a_partial_outer_record() {
+        assert_snapshot!(eval("principal.meta.inner == {a: 1, b: 2}"), @"true");
+        assert_snapshot!(eval("principal.meta.inner.a == 1"), @"true");
+        // The unknown sibling blocks nothing but itself.
+        assert_snapshot!(
+            eval(r#"principal.meta.tag == "x""#),
+            @r#"User::"alice".meta.tag == "x""#
+        );
+    }
+
+    /// `all_literal_uids` drives which entities the batched loop requests. A uid the residual
+    /// actually reads is reported; a uid that was only reachable through the cached fields of a
+    /// partly-known record is not, now that there is no cache to walk. That narrowing is safe: such
+    /// an entity is never dereferenced, so nothing needs it loaded.
+    #[test]
+    fn literal_uids() {
+        let uids = |cond: &str| {
+            let mut v: Vec<String> = residual(cond)
+                .all_literal_uids()
+                .iter()
+                .map(|u| u.to_string())
+                .collect();
+            v.sort();
+            v
+        };
+        // Read through the entity-valued field: its uid is in the residual itself.
+        assert_eq!(
+            uids("principal.meta.other.data == 1"),
+            vec![r#"Other::"hidden""#]
+        );
+        // Comparing the whole record leaves the access in the residual. `Other::"visible"` is in the
+        // expression so it is reported; `Other::"hidden"` was only ever reachable through the cached
+        // fields, and the residual never dereferences it.
+        assert_eq!(
+            uids(r#"principal.meta == {inner: {a: 1, b: 2}, other: Other::"visible", tag: "x"}"#),
+            vec![r#"Other::"visible""#, r#"User::"alice""#]
+        );
+    }
+}

--- a/cedar-policy-core/src/tpe/request.rs
+++ b/cedar-policy-core/src/tpe/request.rs
@@ -18,26 +18,30 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::ast::{EntityUIDEntry, RequestSchema};
+use crate::ast::EntityUIDEntry;
 use crate::entities::conformance::err::InvalidEnumEntityError;
+use crate::entities::conformance::ValidateEuidError;
+use crate::entities::SchemaType;
+use crate::tpe::entities::typecheck_partial_record;
 use crate::tpe::err::{
     InconsistentActionError, InconsistentPrincipalEidError, InconsistentPrincipalTypeError,
     InconsistentResourceEidError, InconsistentResourceTypeError, NoMatchingReqEnvError,
     RequestConsistencyError,
 };
+use crate::tpe::value::PartialRecord;
 use crate::validator::request_validation_errors::{
-    UndeclaredActionError, UndeclaredPrincipalTypeError, UndeclaredResourceTypeError,
+    InvalidContextError, UndeclaredActionError, UndeclaredPrincipalTypeError,
+    UndeclaredResourceTypeError,
 };
 use crate::validator::{
-    types::RequestEnv, RequestValidationError, ValidationMode, ValidatorEntityTypeKind,
-    ValidatorSchema,
+    types::{RequestEnv, Type},
+    CoreSchema, RequestValidationError, ValidationMode, ValidatorEntityTypeKind, ValidatorSchema,
 };
 use crate::{
-    ast::{Context, Eid, EntityType, EntityUID, Request, Value},
+    ast::{Context, Eid, EntityType, EntityUID, Request},
     entities::conformance::is_valid_enumerated_entity,
     extensions::Extensions,
 };
-use smol_str::SmolStr;
 
 /// Partial EntityUID
 #[derive(Debug, Clone)]
@@ -183,8 +187,9 @@ pub struct PartialRequest {
     resource: PartialEntityUID,
 
     /// Context associated with the request.
-    /// `None` means that variable will result in a residual for partial evaluation.
-    context: Option<Arc<BTreeMap<SmolStr, Value>>>,
+    /// `None` means the entire context is unknown and will result in a residual.
+    /// `Some(record)` allows per-field partial information.
+    context: Option<PartialRecord>,
 }
 
 impl PartialRequest {
@@ -193,7 +198,7 @@ impl PartialRequest {
         principal: PartialEntityUID,
         action: EntityUID,
         resource: PartialEntityUID,
-        context: Option<Arc<BTreeMap<SmolStr, Value>>>,
+        context: Option<PartialRecord>,
         schema: &ValidatorSchema,
     ) -> Result<Self, RequestValidationError> {
         let req = Self {
@@ -236,12 +241,8 @@ impl PartialRequest {
             self.resource
                 .validate(schema)
                 .map_err(|e| e.into_resource_error())?;
-            if let Some(m) = &self.context {
-                schema.validate_context(
-                    &Context::Value(m.clone()),
-                    &self.action,
-                    Extensions::all_available(),
-                )?;
+            if let Some(context) = &self.context {
+                self.validate_context(context, action_id.context_type(), schema)?;
             }
             Ok(())
         } else {
@@ -250,6 +251,43 @@ impl PartialRequest {
             }
             .into())
         }
+    }
+
+    /// Validate a partial context against the action's declared context type.
+    fn validate_context(
+        &self,
+        context: &PartialRecord,
+        expected_ty: &Type,
+        schema: &ValidatorSchema,
+    ) -> Result<(), RequestValidationError> {
+        let schema_ty =
+            SchemaType::try_from(expected_ty.clone()).map_err(|_| self.invalid_context_error())?;
+        typecheck_partial_record(context, &schema_ty, Extensions::all_available())
+            .map_err(|_| self.invalid_context_error())?;
+
+        // Validate entity UIDs in the known parts of the context
+        context
+            .validate_euids(&CoreSchema::new(schema))
+            .map_err(|e| match e {
+                ValidateEuidError::InvalidEnumEntity(e) => {
+                    RequestValidationError::InvalidEnumEntity(e)
+                }
+                ValidateEuidError::UndeclaredAction(e) => UndeclaredActionError {
+                    action: Arc::new(e.uid),
+                }
+                .into(),
+            })?;
+        Ok(())
+    }
+
+    /// Build an [`InvalidContextError`] naming this request's action.
+    fn invalid_context_error(&self) -> RequestValidationError {
+        // TODO: error can't hold partial values, replacing with empty map fro now
+        InvalidContextError {
+            context: Context::Value(Arc::new(BTreeMap::new())),
+            action: Arc::new(self.action.clone()),
+        }
+        .into()
     }
 
     /// Check consistency between a [`PartialRequest`] and a [`Request`]
@@ -278,8 +316,8 @@ impl PartialRequest {
 
         match &request.context {
             Some(Context::Value(c)) => {
-                if let Some(m) = &self.context {
-                    if c != m {
+                if let Some(ctx) = &self.context {
+                    if !ctx.check_consistency(c.as_ref()) {
                         return Err(RequestConsistencyError::InconsistentContext);
                     }
                 }
@@ -319,8 +357,8 @@ impl PartialRequest {
         &self.action
     }
 
-    /// Get the `context` attributes
-    pub fn context_attrs(&self) -> Option<&Arc<BTreeMap<SmolStr, Value>>> {
+    /// Get the `context`
+    pub fn context(&self) -> Option<&PartialRecord> {
         self.context.as_ref()
     }
 }
@@ -330,11 +368,10 @@ mod invalid_requests {
     use std::{collections::BTreeMap, sync::Arc};
 
     use crate::{
-        ast::Value,
+        ast::{EntityUID, Value},
         extensions::Extensions,
         test_utils::{expect_err, ExpectedErrorMessage, ExpectedErrorMessageBuilder},
-        tpe::request::PartialRequest,
-        tpe::test_utils::parse_partial_euid,
+        tpe::{request::PartialRequest, test_utils::parse_partial_euid, value::PartialRecord},
         validator::ValidatorSchema,
     };
 
@@ -371,12 +408,16 @@ mod invalid_requests {
         context: Option<Arc<BTreeMap<smol_str::SmolStr, Value>>>,
         msg: &ExpectedErrorMessage<'_>,
     ) {
+        let action: EntityUID = action.parse().unwrap();
+        let schema = schema();
         let err = PartialRequest::new(
             parse_partial_euid(principal),
-            action.parse().unwrap(),
+            action.clone(),
             parse_partial_euid(resource),
-            context,
-            &schema(),
+            context.and_then(|c| {
+                PartialRecord::concrete_context_for_action(c.as_ref(), &action, &schema)
+            }),
+            &schema,
         )
         .expect_err("should fail to validate");
         expect_err("", &miette::Report::new(err), msg);
@@ -500,10 +541,8 @@ mod invalid_requests {
             r#"Action::"a""#,
             "B",
             Some(Arc::new(BTreeMap::from_iter([("".into(), 1.into())]))),
-            &ExpectedErrorMessageBuilder::error(
-                r#"context `{"": 1}` is not valid for `Action::"a"`"#,
-            )
-            .build(),
+            &ExpectedErrorMessageBuilder::error(r#"context `{}` is not valid for `Action::"a"`"#)
+                .build(),
         );
     }
 }
@@ -513,10 +552,10 @@ mod inconsistent_requests {
     use std::{collections::BTreeMap, sync::Arc};
 
     use crate::{
-        ast::{Context, EntityUIDEntry, Request, Value},
+        ast::{Context, EntityUID, EntityUIDEntry, Request, Value},
         extensions::Extensions,
         test_utils::{expect_err, ExpectedErrorMessageBuilder},
-        tpe::{request::PartialRequest, test_utils::parse_partial_euid},
+        tpe::{request::PartialRequest, test_utils::parse_partial_euid, value::PartialRecord},
         validator::ValidatorSchema,
     };
 
@@ -548,12 +587,21 @@ mod inconsistent_requests {
     /// concrete resource `B::"r"`, and context `{foo: 0}`.
     #[track_caller]
     fn request() -> PartialRequest {
+        let Ok(Context::Value(context)) = Context::from_json_value(serde_json::json!({ "foo": 0 }))
+        else {
+            panic!("expected concrete context")
+        };
+        let schema = schema();
+        let action: EntityUID = r#"Action::"a""#.parse().unwrap();
         PartialRequest::new(
             parse_partial_euid(r#"A::"p""#),
-            r#"Action::"a""#.parse().unwrap(),
+            action.clone(),
             parse_partial_euid(r#"B::"r""#),
-            Some(Arc::new(BTreeMap::from_iter([("foo".into(), 0.into())]))),
-            &schema(),
+            Some(
+                PartialRecord::concrete_context_for_action(context.as_ref(), &action, &schema)
+                    .unwrap(),
+            ),
+            &schema,
         )
         .unwrap()
     }
@@ -719,6 +767,110 @@ mod inconsistent_requests {
         expect_inconsistency(
             &concrete,
             "the concrete request's context contains unknowns",
+        );
+    }
+}
+
+#[cfg(test)]
+mod partial_context_euids {
+    use crate::ast::EntityUID;
+    use crate::ast::Value;
+    use crate::extensions::Extensions;
+    use crate::tpe::request::PartialRequest;
+    use crate::tpe::test_utils::parse_partial_euid;
+    use crate::tpe::value::{AttrState, PartialRecord};
+    use crate::validator::ValidatorSchema;
+    use cool_asserts::assert_matches;
+
+    fn schema() -> ValidatorSchema {
+        ValidatorSchema::from_cedarschema_str(
+            r#"
+            entity Color enum ["red", "blue"];
+            entity User;
+            entity Doc;
+            action Read appliesTo { principal: User, resource: Doc,
+                                    context: { c: Color, nested: { c: Color } } };
+            "#,
+            Extensions::all_available(),
+        )
+        .unwrap()
+        .0
+    }
+
+    fn bad_color() -> AttrState {
+        let euid: EntityUID = r#"Color::"green""#.parse().unwrap();
+        AttrState::Value(Value::from(euid))
+    }
+
+    fn validate(context: PartialRecord) -> Result<(), String> {
+        let action: EntityUID = r#"Action::"Read""#.parse().unwrap();
+        PartialRequest::new(
+            parse_partial_euid(r#"User::"a""#),
+            action,
+            parse_partial_euid(r#"Doc::"d""#),
+            Some(context),
+            &schema(),
+        )
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+    }
+
+    /// Euids are validated wherever they are known, including under a record
+    /// whose sibling fields are unknown — an unknown field elsewhere must not
+    /// stop the rest of the context being checked.
+    #[test]
+    fn invalid_enum_eid_is_rejected() {
+        assert_matches!(
+            validate(PartialRecord::from_iter([
+                ("c".into(), bad_color()),
+                ("nested".into(), AttrState::Present),
+            ])),
+            Err(e) => assert!(e.contains(r#"not declared as a valid eid"#), "{e}")
+        );
+
+        let inner = PartialRecord::from_iter([("c".into(), bad_color())]);
+        assert_matches!(
+            validate(PartialRecord::from_iter([
+                ("c".into(), AttrState::Present),
+                (
+                    "nested".into(),
+                    AttrState::PartialRecord(inner)
+                ),
+            ])),
+            Err(e) => assert!(e.contains(r#"not declared as a valid eid"#), "{e}")
+        );
+    }
+
+    /// A type error under a record that isn't fully concrete must be reported,
+    /// not panicked on: the error carries a `RestrictedExpr`, which a partial
+    /// value has no lossless rendering as.
+    #[test]
+    fn type_error_in_non_concrete_record_is_reported() {
+        // Undeclared attr nested under a record, with an unknown sibling so the
+        // record cannot be rendered concretely.
+        let inner = PartialRecord::from_iter([
+            ("c".into(), AttrState::Present),
+            ("bogus".into(), AttrState::Value(Value::from(1))),
+        ]);
+        assert_matches!(
+            validate(PartialRecord::from_iter([
+                ("c".into(), AttrState::Present),
+                (
+                    "nested".into(),
+                    AttrState::PartialRecord(inner)
+                ),
+            ])),
+            Err(e) => assert!(e.contains("is not valid for"), "{e}")
+        );
+
+        // A record value where the schema declares a non-record type.
+        let rec = PartialRecord::from_iter([("x".into(), AttrState::Value(Value::from(1)))]);
+        assert_matches!(
+            validate(PartialRecord::from_iter([
+                ("c".into(), AttrState::PartialRecord(rec)),
+                ("nested".into(), AttrState::Present),
+            ])),
+            Err(e) => assert!(e.contains("is not valid for"), "{e}")
         );
     }
 }

--- a/cedar-policy-core/src/tpe/response.rs
+++ b/cedar-policy-core/src/tpe/response.rs
@@ -382,9 +382,6 @@ impl<'a> Response<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
-
     use crate::ast::{
         ActionConstraint, Policy, PolicySet, PrincipalConstraint, ResourceConstraint,
     };
@@ -394,6 +391,7 @@ mod tests {
     use crate::tpe::is_authorized;
     use crate::tpe::request::PartialRequest;
     use crate::tpe::test_utils::parse_partial_euid;
+    use crate::tpe::value::PartialRecord;
     use crate::validator::ValidatorSchema;
 
     fn schema() -> ValidatorSchema {
@@ -432,7 +430,7 @@ mod tests {
             parse_partial_euid(r#"Auth::User::"1""#),
             parse_euid(r#"Auth::Action::"AssumeRole""#).unwrap(),
             parse_partial_euid("Auth::Role"),
-            Some(Arc::new(BTreeMap::new())),
+            Some(PartialRecord::new()),
             &schema(),
         )
         .unwrap()

--- a/cedar-policy-core/src/tpe/value.rs
+++ b/cedar-policy-core/src/tpe/value.rs
@@ -1,0 +1,420 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Defines partial values, values where individual record attributes may be partially known.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use smol_str::SmolStr;
+
+use crate::ast::{self, EntityUID, Value};
+use crate::entities::conformance::{validate_euids_in_partial_value, ValidateEuidError};
+use crate::entities::Schema;
+use crate::tpe::evaluator::normalize_ext_value;
+use crate::tpe::residual::Residual;
+use crate::validator::types::{AttributeType, Attributes, Type};
+use crate::validator::ValidatorSchema;
+
+/// Possibly-partial information about an attribute (or tag).
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum AttrState<V = Value> {
+    /// The attribute exists and its value is fully known
+    Value(V),
+    /// The attribute exists and is a record, of which only part is known
+    ///
+    /// We might like to have the invariant that a partial record is not fully known, but this is
+    /// not the case. E.g., a fully known context record is represented as sa partial record.
+    PartialRecord(PartialRecord),
+    /// The attribute exists but its value is unknown
+    Present,
+    /// The attribute is known not to exist
+    Absent,
+    /// Whether the attribute exists at all is unknown
+    Unknown,
+}
+
+impl<V> AttrState<V> {
+    /// Does this state assert that the attribute exists?
+    pub(crate) fn exists(&self) -> bool {
+        match self {
+            AttrState::Value(_) | AttrState::PartialRecord(_) | AttrState::Present => true,
+            AttrState::Absent | AttrState::Unknown => false,
+        }
+    }
+
+    /// The partial information about an attribute implied by its declared type.
+    ///
+    /// Note that for an attribute of an entity, we need to know that the entity exists before we
+    /// can trust the `Present` truly the attribute is there.
+    pub(crate) fn from_declared(declared: Option<&AttributeType>) -> Self {
+        match declared {
+            // Declared as required, so we can assume it exists
+            Some(at) if at.is_required => AttrState::Present,
+            // Declared as optional, so we can't assume anything
+            Some(_) => AttrState::Unknown,
+            // Not declared, so we can assume it doesn't exist
+            None => AttrState::Absent,
+        }
+    }
+}
+
+impl AttrState {
+    /// Validate every entity UID appearing in the known parts of this attribute
+    pub(crate) fn validate_euids(&self, schema: &impl Schema) -> Result<(), ValidateEuidError> {
+        match self {
+            AttrState::Value(v) => {
+                validate_euids_in_partial_value(schema, &ast::PartialValue::from(v.clone()))
+            }
+            AttrState::PartialRecord(r) => r.validate_euids(schema),
+            AttrState::Present | AttrState::Absent | AttrState::Unknown => Ok(()),
+        }
+    }
+
+    /// Is this state consistent with the concrete (possibly absent) attribute value `other`?
+    fn check_consistency(&self, other: Option<&Value>) -> bool {
+        match (self, other) {
+            (AttrState::Value(v), Some(c)) => v == c,
+            (AttrState::PartialRecord(r), Some(c)) => match c.get_as_record() {
+                Ok(m) => r.check_consistency(m),
+                Err(_) => false,
+            },
+            (AttrState::Present, Some(_)) => true,
+            (AttrState::Absent, None) => true,
+            (AttrState::Unknown, _) => true,
+            _ => false,
+        }
+    }
+
+    /// Get `self` a value, if it is fully known
+    fn as_value_at(&self, declared: Option<&AttributeType>) -> Option<Value> {
+        match self {
+            AttrState::Value(v) => Some(v.clone()),
+            AttrState::PartialRecord(r) => match declared.map(|at| at.attr_type.as_ref()) {
+                Some(Type::Record { attrs, .. }) => {
+                    r.as_values(attrs).map(|m| Value::record(m, None))
+                }
+                _ => None,
+            },
+            AttrState::Present | AttrState::Absent | AttrState::Unknown => None,
+        }
+    }
+
+    /// Reduce a resolved attribute state to a residual of type `ty`.
+    ///
+    /// If we have a fully known value, return this as a concrete residual. Otherwise, `self_` use
+    /// self to build a residual, assuming it is semantically equivalent.
+    pub(crate) fn to_residual(&self, ty: &Type, self_: impl FnOnce() -> Residual) -> Residual {
+        let concrete = |value: Value| Residual::Concrete {
+            value: normalize_ext_value(value),
+            ty: ty.clone(),
+        };
+        match self {
+            AttrState::Value(v) => concrete(v.clone()),
+            AttrState::Absent => Residual::Error(ty.clone()),
+            AttrState::PartialRecord(r) => match ty {
+                Type::Record { attrs, .. } => match r.as_values(attrs) {
+                    Some(m) => concrete(Value::record(m, None)),
+                    None => self_(),
+                },
+                _ => self_(),
+            },
+            AttrState::Present | AttrState::Unknown => self_(),
+        }
+    }
+}
+
+/// A record in which individual attributes may be unknown.
+///
+/// Attributes that the map does not mention are assumed to be [`AttrState::Unknown`].
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PartialRecord(Arc<BTreeMap<SmolStr, AttrState>>);
+
+impl FromIterator<(SmolStr, AttrState)> for PartialRecord {
+    fn from_iter<T: IntoIterator<Item = (SmolStr, AttrState)>>(iter: T) -> Self {
+        PartialRecord(Arc::new(iter.into_iter().collect()))
+    }
+}
+
+impl PartialRecord {
+    /// Construct an empty `PartialRecord`
+    pub(crate) fn new() -> Self {
+        PartialRecord(Arc::new(BTreeMap::new()))
+    }
+
+    /// The state of `attr` in this record.
+    ///
+    /// Any attribute the record does not list is `Unknown`.
+    pub(crate) fn attr(&self, attr: &str) -> &AttrState {
+        self.0.get(attr).unwrap_or(&AttrState::Unknown)
+    }
+
+    /// The attributes this record explicitly states
+    pub(crate) fn attrs(&self) -> impl Iterator<Item = (&SmolStr, &AttrState)> {
+        self.0.iter()
+    }
+
+    /// The state of `attr`, informed by the record's declared attribute types
+    ///
+    /// An attribute not explicitly in the record has partial information based on what we can infer
+    /// from the attribute types.
+    pub(crate) fn resolve_attr(&self, attr: &str, attr_tys: &Attributes) -> AttrState {
+        match self.attr(attr) {
+            // The record says nothing, so recover what the declared type implies.
+            AttrState::Unknown => AttrState::from_declared(attr_tys.get_attr(attr)),
+            state => state.clone(),
+        }
+    }
+
+    /// Is this record fully concrete at `attrs_ty`
+    ///
+    /// Every declared attribute must be explicitly defined.
+    fn is_concrete_at(&self, attr_tys: &Attributes) -> bool {
+        if attr_tys.keys().any(|k| !self.0.contains_key(k)) {
+            return false;
+        }
+        self.attrs().all(|(k, state)| match state {
+            AttrState::Value(_) => attr_tys.get_attr(k).is_some(),
+            AttrState::Absent => true,
+            AttrState::PartialRecord(r) => {
+                match attr_tys.get_attr(k).map(|at| at.attr_type.as_ref()) {
+                    Some(Type::Record { attrs, .. }) => r.is_concrete_at(attrs),
+                    _ => false,
+                }
+            }
+            AttrState::Present | AttrState::Unknown => false,
+        })
+    }
+
+    /// Convert to a concrete record, if this record is concrete at `attr_tys`
+    fn as_values(&self, attr_tys: &Attributes) -> Option<BTreeMap<SmolStr, Value>> {
+        if !self.is_concrete_at(attr_tys) {
+            return None;
+        }
+        self.attrs()
+            .filter_map(|(k, state)| {
+                // `Absent` is concrete but contributes no attribute. It might be invalid
+                // according to the type, but this function assumes well-typed values.
+                state
+                    .as_value_at(attr_tys.get_attr(k))
+                    .map(|v| (k.clone(), v))
+            })
+            .collect::<BTreeMap<_, _>>()
+            .into()
+    }
+
+    /// Build a partial record from a fully concrete record of type `attr_tys`.
+    ///
+    /// Concrete records are closed, so a declared attribute the record lacks is `Absent`. Present
+    /// attributes are `Value`. This uses `attr_tys` to populate absent attributes; it does not typecheck the values.
+    pub(crate) fn from_concrete_record(
+        attrs: &BTreeMap<SmolStr, Value>,
+        attr_tys: &Attributes,
+    ) -> Self {
+        attrs
+            .iter()
+            .map(|(k, v)| (k.clone(), AttrState::Value(v.clone())))
+            .chain(
+                attr_tys
+                    .iter()
+                    .filter(|(k, _)| !attrs.contains_key(*k))
+                    .map(|(k, _)| (k.clone(), AttrState::Absent)),
+            )
+            .collect()
+    }
+
+    /// Build a partial record from a fully concrete set of entity tags.
+    ///
+    /// Unlike in `from_concrete_record`, we cannot infer that any missing tag is absent because
+    /// there is not declared set of tags.
+    pub(crate) fn from_concrete_tags(tags: impl IntoIterator<Item = (SmolStr, Value)>) -> Self {
+        tags.into_iter()
+            .map(|(k, v)| (k, AttrState::Value(v)))
+            .collect()
+    }
+
+    /// The concrete context for a specific action represented as a partial record
+    pub fn concrete_context_for_action(
+        attrs: &BTreeMap<SmolStr, Value>,
+        action: &EntityUID,
+        schema: &ValidatorSchema,
+    ) -> Option<Self> {
+        let Some(Type::Record { attrs: atys, .. }) =
+            schema.get_action_id(action).map(|a| a.context_type())
+        else {
+            return None;
+        };
+        Some(Self::from_concrete_record(attrs, atys))
+    }
+
+    pub(crate) fn validate_euids(&self, schema: &impl Schema) -> Result<(), ValidateEuidError> {
+        self.attrs()
+            .try_for_each(|(_, attr)| attr.validate_euids(schema))
+    }
+
+    /// Check whether this partial record is consistent with a concrete record.
+    ///
+    /// This is checking consistency, not validity. To guarantee TPE soundness we must also check
+    /// that `other` is valid with respect to its expected type.
+    pub(crate) fn check_consistency(&self, other: &BTreeMap<SmolStr, Value>) -> bool {
+        self.attrs()
+            .all(|(k, attr)| attr.check_consistency(other.get(k)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validator::types::{AttributeType, Attributes, OpenTag};
+
+    fn long_attrs(required: impl IntoIterator<Item = &'static str>) -> Attributes {
+        Attributes::with_attributes(required.into_iter().map(|k| {
+            (
+                k.into(),
+                AttributeType::required_attribute(Arc::new(Type::primitive_long())),
+            )
+        }))
+    }
+
+    #[test]
+    fn from_concrete_map_marks_missing_declared_absent() {
+        let map = BTreeMap::from_iter([("a".into(), Value::from(1))]);
+        let rec = PartialRecord::from_concrete_record(&map, &long_attrs(["a", "b"]));
+        assert_eq!(rec.attr("a"), &AttrState::Value(Value::from(1)));
+        assert_eq!(rec.attr("b"), &AttrState::Absent);
+    }
+
+    #[test]
+    fn from_concrete_map_keeps_undeclared_attr() {
+        let map = BTreeMap::from_iter([
+            ("declared".into(), Value::from(1)),
+            ("undeclared".into(), Value::from(2)),
+        ]);
+        let rec = PartialRecord::from_concrete_record(&map, &long_attrs(["declared"]));
+        assert_eq!(rec.attr("undeclared"), &AttrState::Value(Value::from(2)));
+        // ... and it is exactly what stops the record determining a concrete one.
+        assert_eq!(rec.as_values(&long_attrs(["declared"])), None);
+    }
+
+    #[test]
+    fn from_concrete_map_does_not_split_nested_record() {
+        let inner = Value::record([("inner", Value::from(1))], None);
+        let map = BTreeMap::from_iter([("outer".into(), inner.clone())]);
+        let attrs = Attributes::with_attributes([(
+            "outer".into(),
+            AttributeType::required_attribute(Arc::new(Type::record_with_required_attributes(
+                [("inner".into(), Arc::new(Type::primitive_long()))],
+                OpenTag::ClosedAttributes,
+            ))),
+        )]);
+        let rec = PartialRecord::from_concrete_record(&map, &attrs);
+        assert_eq!(rec.attr("outer"), &AttrState::Value(inner));
+    }
+
+    #[test]
+    fn as_values_requires_every_declared_attr_decided() {
+        let attrs = long_attrs(["a", "b"]);
+        let rec = PartialRecord::from_iter([("a".into(), AttrState::Value(Value::from(1)))]);
+        assert_eq!(rec.as_values(&attrs), None);
+
+        let rec = PartialRecord::from_iter([
+            ("a".into(), AttrState::Value(Value::from(1))),
+            ("b".into(), AttrState::Absent),
+        ]);
+        assert_eq!(
+            rec.as_values(&attrs),
+            Some(BTreeMap::from_iter([("a".into(), Value::from(1))]))
+        );
+    }
+
+    #[test]
+    fn as_values_folds_nested_partial_record() {
+        let inner_ty = Type::record_with_required_attributes(
+            [("inner".into(), Arc::new(Type::primitive_long()))],
+            OpenTag::ClosedAttributes,
+        );
+        let attrs = Attributes::with_attributes([(
+            "outer".into(),
+            AttributeType::required_attribute(Arc::new(inner_ty)),
+        )]);
+        let inner = PartialRecord::from_iter([("inner".into(), AttrState::Value(Value::from(1)))]);
+        let rec = PartialRecord::from_iter([("outer".into(), AttrState::PartialRecord(inner))]);
+        assert_eq!(
+            rec.as_values(&attrs),
+            Some(BTreeMap::from_iter([(
+                "outer".into(),
+                Value::record([("inner", Value::from(1))], None)
+            )]))
+        );
+    }
+
+    #[test]
+    fn check_consistency_per_state() {
+        let concrete = BTreeMap::from_iter([("a".into(), Value::from(1))]);
+        let cases: [(AttrState, bool); 5] = [
+            (AttrState::Value(Value::from(1)), true),
+            (AttrState::Value(Value::from(2)), false),
+            (AttrState::Present, true),
+            (AttrState::Absent, false),
+            (AttrState::Unknown, true),
+        ];
+        for (state, expected) in cases {
+            let rec = PartialRecord::from_iter([("a".into(), state.clone())]);
+            assert_eq!(
+                rec.check_consistency(&concrete),
+                expected,
+                "state {state:?} against {concrete:?}"
+            );
+        }
+        let rec = PartialRecord::from_iter([("b".into(), AttrState::Absent)]);
+        assert!(rec.check_consistency(&concrete));
+        let rec = PartialRecord::from_iter([("b".into(), AttrState::Present)]);
+        assert!(!rec.check_consistency(&concrete));
+    }
+
+    #[test]
+    fn check_consistency_value_record_is_exact() {
+        let concrete = BTreeMap::from_iter([(
+            "a".into(),
+            Value::record([("x", Value::from(1)), ("y", Value::from(2))], None),
+        )]);
+        let rec = PartialRecord::from_iter([(
+            "a".into(),
+            AttrState::Value(Value::record([("x", Value::from(1))], None)),
+        )]);
+        assert!(!rec.check_consistency(&concrete));
+
+        // The same partial knowledge stated as a `PartialRecord` *is* consistent.
+        let rec = PartialRecord::from_iter([(
+            "a".into(),
+            AttrState::PartialRecord(PartialRecord::from_iter([(
+                "x".into(),
+                AttrState::Value(Value::from(1)),
+            )])),
+        )]);
+        assert!(rec.check_consistency(&concrete));
+    }
+
+    #[test]
+    fn resolve_attr_recovers_omitted_attr_from_type() {
+        let attrs = Attributes::with_required_attributes([(
+            "req".into(),
+            Arc::new(Type::primitive_long()),
+        )]);
+        let rec = PartialRecord::new();
+        assert_eq!(rec.resolve_attr("req", &attrs), AttrState::Present,);
+        assert_eq!(rec.resolve_attr("undeclared", &attrs), AttrState::Absent,);
+    }
+}

--- a/cedar-policy-core/src/validator/coreschema.rs
+++ b/cedar-policy-core/src/validator/coreschema.rs
@@ -625,6 +625,14 @@ pub mod request_validation_errors {
         pub fn action(&self) -> &ast::EntityUID {
             &self.action
         }
+
+        /// Build an `InvalidContextError`
+        pub fn new(context: ast::Context, action: ast::EntityUID) -> InvalidContextError {
+            InvalidContextError {
+                context,
+                action: Arc::new(action),
+            }
+        }
     }
 }
 

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -42,7 +42,10 @@ use crate::validator::{
     cedar_schema::SchemaWarning,
     json_schema,
     partition_nonempty::PartitionNonEmpty,
-    types::{Attributes, EntityKind, OpenTag, RequestEnv, Type, TypeIterator, UnlinkedRequestEnv},
+    types::{
+        Attributes, EntityKind, EntityLUB, OpenTag, RequestEnv, Type, TypeIterator,
+        UnlinkedRequestEnv,
+    },
     ValidationMode,
 };
 
@@ -1052,6 +1055,37 @@ impl ValidatorSchema {
             .unwrap_or_default();
         descendants.push(ety);
         descendants
+    }
+
+    /// Checks if an action of entity type `lhs_ety` may be a descendant of an
+    /// action of entity type `rhs_ety` in the action hierarchy.
+    /// Lean counterpart: <https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L202>
+    fn maybe_action_descendent_of(&self, lhs_ety: &EntityType, rhs_ety: &EntityType) -> bool {
+        self.action_ids().any(|action| {
+            action.name().entity_type() == rhs_ety
+                && action
+                    .descendants()
+                    .any(|desc| desc.entity_type() == lhs_ety)
+        })
+    }
+
+    /// Checks if `lhs_ety` may be a descendant of `rhs_ety`, either in the
+    /// entity or action hierarchy. If this function returns `false`, then
+    /// `lhs in rhs` cannot possibly evaluate to `true` for entities of these
+    /// types.
+    /// Lean counterpart: <https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L205>
+    fn descendent_of(&self, lhs_ety: &EntityType, rhs_ety: &EntityType) -> bool {
+        self.get_entity_types_in(rhs_ety).contains(&lhs_ety)
+            || self.maybe_action_descendent_of(lhs_ety, rhs_ety)
+    }
+
+    /// Check if some entity type in `lhs` may be a descendant of some entity
+    /// type in `rhs`, either in the entity or action hierarchy. If this
+    /// function returns `false`, then `lhs in rhs` cannot possibly evaluate to
+    /// `true`.
+    pub(crate) fn any_descendent_of(&self, lhs: &EntityLUB, rhs: &EntityLUB) -> bool {
+        lhs.iter()
+            .any(|lhs| rhs.iter().any(|rhs| self.descendent_of(lhs, rhs)))
     }
 
     /// Get all action entities in the schema where `action in euids` evaluates

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use std::{borrow::Cow, collections::HashSet};
 
 use crate::ast::UnwrapInfallible;
-use crate::validator::types::{BoolType, EntityLUB};
+use crate::validator::types::BoolType;
 use crate::validator::{
     extension_schema::ExtensionFunctionType,
     extensions::ExtensionSchemas,
@@ -1740,32 +1740,6 @@ impl<'a> SingleEnvTypechecker<'a> {
         }
     }
 
-    /// Checks if `lhs_ety` may be a descendant of `rhs_ety` in the action hierarchy.
-    /// We assume that `lhs_ety` is an action entity type, but `rhs_ety` can be any entity type.
-    /// Lean counterpart: <https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L202>
-    fn check_action_in_entity_type(&self, lhs_ety: &EntityType, rhs_ety: &EntityType) -> bool {
-        lhs_ety == rhs_ety
-            || self.schema.action_ids().any(|action| {
-                action.name().entity_type() == rhs_ety
-                    && action
-                        .descendants()
-                        .any(|desc| desc.entity_type() == lhs_ety)
-            })
-    }
-
-    /// Check if an entity type in `lhs` may be a descendant of some entity type
-    /// in rhs, either in the entity or action hierarchy. If this function
-    /// returns `false`, then `lhs in rhs` cannot possibly evaluate to `true`,
-    /// meaning that the expression can have type `False`.
-    fn any_entity_type_decedent_of(&self, lhs: &EntityLUB, rhs: &EntityLUB) -> bool {
-        lhs.iter().any(|lhs| {
-            rhs.iter().any(|rhs| {
-                self.schema.get_entity_types_in(rhs).contains(&lhs)
-                    || self.check_action_in_entity_type(lhs, rhs)
-            })
-        })
-    }
-
     /// Handles typechecking of `in` expressions. This is complicated because it
     /// requires searching the schema to determine if an `in` expression
     /// consisting of variables and literals can ever be true. When we find that
@@ -1833,23 +1807,14 @@ impl<'a> SingleEnvTypechecker<'a> {
                             rhs_expr,
                         ),
                     _ => {
-                        let lhs_etys = match lhs_expr.data() {
-                            Some(Type::Entity(EntityKind::Entity(lhs_etys))) => Some(lhs_etys),
-                            _ => None,
-                        };
-                        let rhs_etys = match rhs_expr.data() {
-                            Some(Type::Entity(EntityKind::Entity(rhs_etys))) => Some(rhs_etys),
-                            Some(Type::Set {
-                                element_type: Some(element_type),
-                            }) => match element_type.as_ref() {
-                                Type::Entity(EntityKind::Entity(rhs_etys)) => Some(rhs_etys),
-                                _ => None,
-                            },
-                            _ => None,
-                        };
+                        let lhs_etys = lhs_expr.data().as_ref().and_then(Type::as_entity_lub);
+                        let rhs_etys = rhs_expr
+                            .data()
+                            .as_ref()
+                            .and_then(Type::as_set_or_entity_lub);
                         match (lhs_etys, rhs_etys) {
                             (Some(lhs_etys), Some(rhs_etys))
-                                if !self.any_entity_type_decedent_of(lhs_etys, rhs_etys) =>
+                                if !self.schema.any_descendent_of(lhs_etys, rhs_etys) =>
                             {
                                 TypecheckAnswer::success(
                                     ExprBuilder::with_data(Some(Type::Bool(BoolType::False)))

--- a/cedar-policy-core/src/validator/types.rs
+++ b/cedar-policy-core/src/validator/types.rs
@@ -485,10 +485,28 @@ impl Type {
         }
     }
 
+    /// Are all entity types that a value of type `ty` could have declared as
+    /// entity types in `schema`? Returns `true` for non-entity types.
+    ///
+    /// This is `false` for action entity types, which are declared as actions
+    /// rather than as entity types, so `may_have_attr` and `may_have_tags`
+    /// report them as having no attributes and no tags.
+    #[cfg(feature = "tpe")]
+    pub(crate) fn has_declared_entity_types(schema: &ValidatorSchema, ty: &Type) -> bool {
+        match ty {
+            Type::Entity(EntityKind::Entity(entity_lub)) => entity_lub
+                .iter()
+                .all(|entity| schema.get_entity_type(entity).is_some()),
+            _ => true,
+        }
+    }
+
     /// Could a value of type `ty` have any tags, according to `schema`?
     ///
-    /// Returns `false` only when `ty` is an entity type without tags declared
-    /// in the schema.
+    /// Returns `false` only when `ty` is an entity type and none of the entity
+    /// types it could be declare tags in the schema. Entity types missing from
+    /// the schema count as declaring no tags, so callers that don't want to
+    /// rely on that should also check [`Type::has_declared_entity_types`].
     #[cfg(feature = "tpe")]
     pub(crate) fn may_have_tags(schema: &ValidatorSchema, ty: &Type) -> bool {
         match ty {

--- a/cedar-policy-core/src/validator/types.rs
+++ b/cedar-policy-core/src/validator/types.rs
@@ -372,7 +372,7 @@ impl Type {
                     // common, are disjoint types.
                     // Entity types least-upper-bounds that have entity types in
                     // common, are not disjoint types.
-                    lub1.is_disjoint(&lub2)
+                    lub1.is_disjoint(lub2)
                 } else {
                     false // conservatively false, not promising disjointness; see notes on this function
                 }
@@ -461,6 +461,48 @@ impl Type {
             // `AnyEntity` is handled by the open-attribute match case.
             // No other types may have attributes.
             _ => false,
+        }
+    }
+
+    /// Get `self` as a specific entity type (or set of types in permissive
+    /// validation). Returns `None` for non-entity types and for `AnyEntity`.
+    pub(crate) fn as_entity_lub(&self) -> Option<&EntityLUB> {
+        match &self {
+            Type::Entity(entity_kind) => entity_kind.as_entity_lub(),
+            _ => None,
+        }
+    }
+
+    /// Get `self` as a specific entity type, or, if `self` is a set, then the
+    /// element type as an entity type.  Returns `None` if `self` is neither an
+    /// entity or set of entity, and for `AnyEntity`.
+    pub(crate) fn as_set_or_entity_lub(&self) -> Option<&EntityLUB> {
+        match self {
+            Type::Set {
+                element_type: Some(element_type),
+            } => element_type.as_entity_lub(),
+            _ => self.as_entity_lub(),
+        }
+    }
+
+    /// Could a value of type `ty` have any tags, according to `schema`?
+    ///
+    /// Returns `false` only when `ty` is an entity type without tags declared
+    /// in the schema.
+    #[cfg(feature = "tpe")]
+    pub(crate) fn may_have_tags(schema: &ValidatorSchema, ty: &Type) -> bool {
+        match ty {
+            Type::Entity(EntityKind::Entity(entity_lub)) => {
+                entity_lub.lub_elements.iter().any(|entity| {
+                    schema
+                        .get_entity_type(entity)
+                        .is_some_and(|entity_type| entity_type.tag_type().is_some())
+                })
+            }
+            // Non-entity types cannot have tags, but `hasTag` is only
+            // well-typed on entities, so this case is not expected. The safe
+            // behavior is to assume they might have tags.
+            _ => true,
         }
     }
 
@@ -1096,10 +1138,10 @@ pub enum EntityKind {
 }
 
 impl EntityKind {
-    pub(crate) fn as_entity_lub(&self) -> Option<EntityLUB> {
+    pub(crate) fn as_entity_lub(&self) -> Option<&EntityLUB> {
         match self {
             EntityKind::AnyEntity => None,
-            EntityKind::Entity(lub) => Some(lub.clone()),
+            EntityKind::Entity(lub) => Some(lub),
         }
     }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -34,6 +34,10 @@ Cedar Language Version: TBD
 - For the experimental `tpe` feature, fixed `TpeResponse::policy_set` to return the residual policies, matching `TpeResponse::policies` as documented. Previously it returned the original policies (#2540).
 - For the experimental `tpe` feature, partial entity validation now accept action entities with unknown components. The `UnknownActionComponent` is now never returned and is deleted.
 
+### Added
+
+- For the experimental `tpe` feature, TPE now reduces `has`, `hasTag`, `in` and `==` applied to non-erroring but unknown expressions when the schema provides enough information to determine the concrete value of the operation.
+
 ## [4.12.0] - 2026-07-28
 
 Cedar Language Version: 4.5

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -17,15 +17,16 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
-use cedar_policy_core::ast::{self, Value};
+use cedar_policy_core::ast::{self, RestrictedExpr, Value};
 use cedar_policy_core::authorizer::Decision;
 use cedar_policy_core::batched_evaluator::is_authorized_batched;
 use cedar_policy_core::batched_evaluator::{
     err::BatchedEvalError, EntityLoader as EntityLoaderInternal,
 };
-use cedar_policy_core::evaluator::{EvaluationError, RestrictedEvaluator};
-use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::tpe;
+use cedar_policy_core::tpe::entities::partial_entity_from_exprs;
+use cedar_policy_core::tpe::value::{AttrState, PartialRecord};
+use cedar_policy_core::validator::request_validation_errors::InvalidContextError;
 use itertools::Itertools;
 use ref_cast::RefCast;
 use smol_str::SmolStr;
@@ -91,17 +92,32 @@ impl PartialRequest {
         context: Option<Context>,
         schema: &Schema,
     ) -> Result<Self, PartialRequestCreationError> {
-        let context = context
-            .map(|c| match c.0 {
-                ast::Context::RestrictedResidual(_) => {
-                    Err(PartialRequestCreationError::ContextContainsUnknowns)
-                }
-                ast::Context::Value(m) => Ok(m),
-            })
-            .transpose()?;
+        let context = Self::context_to_partial_record(context, &action, schema)?;
         tpe::request::PartialRequest::new(principal.0, action.0, resource.0, context, &schema.0)
             .map(Self)
             .map_err(|e| PartialRequestCreationError::Validation(e.into()))
+    }
+
+    /// Converts the concrete context to a partial record. We have this for the moment to keep the
+    /// current public TPE API. Future change will update `PartialRequest::new` to take a partial
+    /// context.
+    fn context_to_partial_record(
+        context: Option<Context>,
+        action: &EntityUid,
+        schema: &Schema,
+    ) -> Result<Option<PartialRecord>, PartialRequestCreationError> {
+        let Some(context) = context else {
+            return Ok(None);
+        };
+        let map = match context.0 {
+            ast::Context::RestrictedResidual(_) => {
+                return Err(PartialRequestCreationError::ContextContainsUnknowns)
+            }
+            ast::Context::Value(m) => m,
+        };
+        PartialRecord::concrete_context_for_action(map.as_ref(), action.as_ref(), &schema.0)
+            .map(Some)
+            .ok_or(PartialRequestCreationError::ContextContainsUnknowns)
     }
 }
 
@@ -109,9 +125,13 @@ impl PartialRequest {
 ///
 /// Intended for use with [`PolicySet::query_resource`].
 #[doc = include_str!("../../experimental_warning.md")]
-#[repr(transparent)]
-#[derive(Debug, Clone, RefCast)]
-pub struct ResourceQueryRequest(pub(crate) PartialRequest);
+#[derive(Debug, Clone)]
+pub struct ResourceQueryRequest {
+    request: PartialRequest,
+    /// The concrete context this was constructed with. Kept so `to_request` returns what the caller
+    /// supplied rather than reconstructing it from the internal partial representation.
+    context: Context,
+}
 
 impl ResourceQueryRequest {
     /// Construct a valid [`ResourceQueryRequest`] according to a [`Schema`]
@@ -126,10 +146,10 @@ impl ResourceQueryRequest {
             PartialEntityUid(principal.0.into()),
             action,
             PartialEntityUid::new(resource, None),
-            Some(context),
+            Some(context.clone()),
             schema,
         )
-        .map(Self)
+        .map(|request| Self { request, context })
     }
 
     fn principal(&self) -> EntityUid {
@@ -137,22 +157,7 @@ impl ResourceQueryRequest {
             clippy::unwrap_used,
             reason = "constructor requires concrete principal"
         )]
-        EntityUid(self.0 .0.principal().clone().try_into().unwrap())
-    }
-
-    fn context(&self) -> Context {
-        #[expect(clippy::unwrap_used, reason = "constructor requires concrete context")]
-        let context_attrs = self.0 .0.context_attrs().unwrap();
-        #[expect(
-            clippy::unwrap_used,
-            reason = "building context from BTreeMap iter, so no duplicates are possible"
-        )]
-        Context::from_pairs(
-            context_attrs
-                .iter()
-                .map(|(a, v)| (a.to_string(), RestrictedExpression(v.clone().into()))),
-        )
-        .unwrap()
+        EntityUid(self.request.0.principal().clone().try_into().unwrap())
     }
 
     /// Convert this to a [`Request`] by providing the resource [`EntityId`]
@@ -168,12 +173,12 @@ impl ResourceQueryRequest {
     ) -> Result<Request, RequestValidationError> {
         Request::new(
             self.principal(),
-            EntityUid(self.0 .0.action().clone()),
+            EntityUid(self.request.0.action().clone()),
             EntityUid::from_type_name_and_id(
-                EntityTypeName(self.0 .0.resource_type().clone()),
+                EntityTypeName(self.request.0.resource_type().clone()),
                 resource_id,
             ),
-            self.context(),
+            self.context.clone(),
             schema,
         )
     }
@@ -183,9 +188,13 @@ impl ResourceQueryRequest {
 ///
 /// Intended for use with [`PolicySet::query_principal`].
 #[doc = include_str!("../../experimental_warning.md")]
-#[repr(transparent)]
-#[derive(Debug, Clone, RefCast)]
-pub struct PrincipalQueryRequest(pub(crate) PartialRequest);
+#[derive(Debug, Clone)]
+pub struct PrincipalQueryRequest {
+    request: PartialRequest,
+    /// The concrete context this was constructed with. Kept so `to_request` returns what the caller
+    /// supplied rather than reconstructing it from the internal partial representation.
+    context: Context,
+}
 
 impl PrincipalQueryRequest {
     /// Construct a valid [`PrincipalQueryRequest`] according to a [`Schema`]
@@ -200,30 +209,15 @@ impl PrincipalQueryRequest {
             PartialEntityUid::new(principal, None),
             action,
             PartialEntityUid(resource.0.into()),
-            Some(context),
+            Some(context.clone()),
             schema,
         )
-        .map(Self)
+        .map(|request| Self { request, context })
     }
 
     fn resource(&self) -> EntityUid {
         #[expect(clippy::unwrap_used, reason = "constructor requires concrete resource")]
-        EntityUid(self.0 .0.resource().clone().try_into().unwrap())
-    }
-
-    fn context(&self) -> Context {
-        #[expect(clippy::unwrap_used, reason = "constructor requires concrete context")]
-        let context_attrs = self.0 .0.context_attrs().unwrap();
-        #[expect(
-            clippy::unwrap_used,
-            reason = "building context from BTreeMap iter, so no duplicates are possible"
-        )]
-        Context::from_pairs(
-            context_attrs
-                .iter()
-                .map(|(a, v)| (a.to_string(), RestrictedExpression(v.clone().into()))),
-        )
-        .unwrap()
+        EntityUid(self.request.0.resource().clone().try_into().unwrap())
     }
 
     /// Convert this to a [`Request`] by providing the principal [`EntityId`]
@@ -239,12 +233,12 @@ impl PrincipalQueryRequest {
     ) -> Result<Request, RequestValidationError> {
         Request::new(
             EntityUid::from_type_name_and_id(
-                EntityTypeName(self.0 .0.principal_type().clone()),
+                EntityTypeName(self.request.0.principal_type().clone()),
                 principal_id,
             ),
-            EntityUid(self.0 .0.action().clone()),
+            EntityUid(self.request.0.action().clone()),
             self.resource(),
-            self.context(),
+            self.context.clone(),
             schema,
         )
     }
@@ -298,11 +292,25 @@ impl ActionQueryRequest {
         &self,
         action: EntityUid,
     ) -> Result<PartialRequest, cedar_policy_core::validator::RequestValidationError> {
+        let context = self
+            .context
+            .as_ref()
+            .map(|map| {
+                PartialRecord::concrete_context_for_action(
+                    map.as_ref(),
+                    action.as_ref(),
+                    &self.schema.0,
+                )
+                .ok_or_else(|| {
+                    InvalidContextError::new(ast::Context::Value(Arc::clone(map)), action.0.clone())
+                })
+            })
+            .transpose()?;
         tpe::request::PartialRequest::new(
             self.principal.0.clone(),
             action.0,
             self.resource.0.clone(),
-            self.context.clone(),
+            context,
             &self.schema.0,
         )
         .map(PartialRequest)
@@ -324,36 +332,24 @@ impl PartialEntity {
         tags: Option<BTreeMap<SmolStr, RestrictedExpression>>,
         schema: &Schema,
     ) -> Result<Self, PartialEntityError> {
-        Ok(Self(tpe::entities::PartialEntity::new(
+        Ok(Self(partial_entity_from_exprs(
             uid.0,
-            attrs
-                .map(|ps| {
-                    ps.into_iter()
-                        .map(|(k, v)| {
-                            Ok((
-                                k,
-                                RestrictedEvaluator::new(Extensions::all_available())
-                                    .interpret(v.0.as_borrowed())?,
-                            ))
-                        })
-                        .collect::<Result<BTreeMap<_, _>, EvaluationError>>()
-                })
-                .transpose()?,
+            attrs.map(Self::concrete_attr_map_to_partial),
             ancestors.map(|s| s.into_iter().map(|e| e.0).collect()),
-            tags.map(|ps| {
-                ps.into_iter()
-                    .map(|(k, v)| {
-                        Ok((
-                            k,
-                            RestrictedEvaluator::new(Extensions::all_available())
-                                .interpret(v.0.as_borrowed())?,
-                        ))
-                    })
-                    .collect::<Result<BTreeMap<_, _>, EvaluationError>>()
-            })
-            .transpose()?,
+            tags.map(Self::concrete_attr_map_to_partial),
             &schema.0,
         )?))
+    }
+
+    /// Converts the concrete attributes (or tags) to a partial record. We have this for the moment
+    /// to keep the current public TPE API. Future change will update `PartialEntity::new` to take a
+    /// partial attributes and tags.
+    fn concrete_attr_map_to_partial(
+        map: BTreeMap<SmolStr, RestrictedExpression>,
+    ) -> Vec<(SmolStr, AttrState<RestrictedExpr>)> {
+        map.into_iter()
+            .map(|(k, v)| (k, AttrState::Value(v.0)))
+            .collect()
     }
 }
 
@@ -781,19 +777,19 @@ impl PolicySet {
         schema: &Schema,
     ) -> Result<impl Iterator<Item = EntityUid>, PermissionQueryError> {
         let partial_entities = PartialEntities::from_concrete(entities.clone(), schema)?;
-        let tpe_response = self.tpe(&request.0, &partial_entities, schema)?;
+        let tpe_response = self.tpe(&request.request, &partial_entities, schema)?;
         let policies = tpe_response.policy_set();
         match tpe_response.decision() {
             Some(Decision::Allow) => Ok(entities
                 .iter()
-                .filter(|entity| entity.0.uid().entity_type() == request.0.0.resource_type())
+                .filter(|entity| entity.0.uid().entity_type() == request.request.0.resource_type())
                 .map(Entity::uid)
                 .collect_vec()
                 .into_iter()),
             Some(Decision::Deny) => Ok(vec![].into_iter()),
             None => Ok(entities
                 .iter()
-                .filter(|entity| entity.0.uid().entity_type() == request.0.0.resource_type())
+                .filter(|entity| entity.0.uid().entity_type() == request.request.0.resource_type())
                 .filter(|entity| {
                     #[expect(
                         clippy::unwrap_used, reason = "`to_request` cannot panic because we do not pass a schema. However, the correctness of the authorization
@@ -827,19 +823,19 @@ impl PolicySet {
         schema: &Schema,
     ) -> Result<impl Iterator<Item = EntityUid>, PermissionQueryError> {
         let partial_entities = PartialEntities::from_concrete(entities.clone(), schema)?;
-        let tpe_response = self.tpe(&request.0, &partial_entities, schema)?;
+        let tpe_response = self.tpe(&request.request, &partial_entities, schema)?;
         let policies = tpe_response.policy_set();
         match tpe_response.decision() {
             Some(Decision::Allow) => Ok(entities
                 .iter()
-                .filter(|entity| entity.0.uid().entity_type() == request.0.0.principal_type())
+                .filter(|entity| entity.0.uid().entity_type() == request.request.0.principal_type())
                 .map(Entity::uid)
                 .collect_vec()
                 .into_iter()),
             Some(Decision::Deny) => Ok(vec![].into_iter()),
             None => Ok(entities
                 .iter()
-                .filter(|entity| entity.0.uid().entity_type() == request.0.0.principal_type())
+                .filter(|entity| entity.0.uid().entity_type() == request.request.0.principal_type())
                 .filter(|entity| {
                     #[expect(
                         clippy::unwrap_used, reason = "`to_request` cannot panic because we do not pass a schema. However, the correctness of the authorization
@@ -1033,8 +1029,8 @@ mod tpe_tests {
 
         use crate::{
             ActionConstraint, ActionQueryRequest, Context, Entities, EntityId, EntityUid,
-            PartialEntities, PartialEntity, PartialEntityError, PartialEntityUid, PartialRequest,
-            PolicySet, PrincipalConstraint, PrincipalQueryRequest, Request, ResourceConstraint,
+            PartialEntities, PartialEntity, PartialEntityUid, PartialRequest, PolicySet,
+            PrincipalConstraint, PrincipalQueryRequest, Request, ResourceConstraint,
             ResourceQueryRequest, RestrictedExpression, Schema,
         };
 
@@ -1068,6 +1064,7 @@ mod tpe_tests {
             )
             .unwrap();
 
+            // Omitting a declared attribute is now fine, it's just unknown
             assert_matches!(
                 PartialEntity::new(
                     r#"Show::"foo""#.parse().unwrap(),
@@ -1082,7 +1079,7 @@ mod tpe_tests {
                     None,
                     &schema
                 ),
-                Err(PartialEntityError::Entities(EntitiesError::Validation(_)))
+                Ok(_)
             );
 
             let e1 = PartialEntity::new(
@@ -2368,7 +2365,7 @@ when { principal in resource.admins };
             let mut loader = PartialEntityLoader;
             let result = pset.is_authorized_batched(&request, &schema, &mut loader, 10);
 
-            assert_matches!(result, Err(BatchedEvalError::PartialValueToValue(_)));
+            assert_matches!(result, Err(BatchedEvalError::Entities(_)));
         }
 
         #[test]


### PR DESCRIPTION
## Description of changes

This is the core implementation of "TPE infinity" extension. It adds the internal implementation details required to support partial evaluation with attribute level partial information.

It doesn't include the public API, which will come in a PR on top of this for separate review. 

The internal representation of partial values now supports the following states for attributes.

1. A known value
2. An attribute known to exist, but with an unknown value
3. An entirely unknown attribute which may or may not exist
4. An attribute which does not exist

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
