### PR TITLE
Add unchecked `Entities` constructors that skip transitive closure

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,6 +14,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 Cedar Language Version: TBD
 
+### Added
+
+- `Entities::from_entities_unchecked` and `Entities::upsert_entities_unchecked`, which construct or extend an `Entities` without computing or checking the transitive closure of the entity hierarchy. Callers are responsible for providing a transitively closed, acyclic hierarchy. Intended for callers that already maintain the transitive closure and want to avoid the cost of recomputing it (#2378).
+
 ### Changed
 
 - Invalid action application errors ("Unable to find an applicable action given the policy scope constraints")

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -508,6 +508,69 @@ impl Entities {
         .map(Entities)
     }
 
+    /// Create an `Entities` object with the given entities, without computing
+    /// or checking the transitive closure of the entity hierarchy.
+    ///
+    /// The caller is responsible for ensuring that the entities already form a
+    /// DAG and are transitively closed; that is, each entity's `parents` must
+    /// already contain all of its transitive ancestors. Nothing is verified, and
+    /// violating this yields an `Entities` whose `in` and ancestor queries are
+    /// incorrect. This is useful for performance if you already maintain the
+    /// transitive closure yourself; otherwise prefer
+    /// [`Entities::from_entities`], which computes it.
+    ///
+    /// `schema` represents a source of `Action` entities, which will be added
+    /// to the entities provided.
+    /// (If any `Action` entities are present in the provided entities, and a
+    /// `schema` is also provided, each `Action` entity in the provided entities
+    /// must exactly match its definition in the schema or an error is
+    /// returned.)
+    ///
+    /// If a `schema` is present, this function will also ensure that the
+    /// produced entities fully conform to the `schema` -- for instance, it will
+    /// error if attributes have the wrong types (e.g., string instead of
+    /// integer), or if required attributes are missing or superfluous
+    /// attributes are provided.
+    /// ## Errors
+    /// - [`EntitiesError::Duplicate`] if there are any duplicate entities in `entities`
+    /// - [`EntitiesError::InvalidEntity`] if `schema` is not none and any entities do not conform
+    ///   to the schema
+    ///
+    /// ```
+    /// # use cedar_policy::{Entities, Entity, EntityUid};
+    /// # use std::collections::HashSet;
+    /// # use std::str::FromStr;
+    /// let alice = EntityUid::from_str(r#"User::"alice""#).unwrap();
+    /// let admins = EntityUid::from_str(r#"Group::"admins""#).unwrap();
+    /// let acme = EntityUid::from_str(r#"Org::"acme""#).unwrap();
+    /// // `alice` lists both her direct parent and its parent, so the
+    /// // transitive closure is already present in the input.
+    /// let entities = Entities::from_entities_unchecked(
+    ///     [
+    ///         Entity::new_no_attrs(alice.clone(), HashSet::from([admins.clone(), acme.clone()])),
+    ///         Entity::new_no_attrs(admins.clone(), HashSet::from([acme.clone()])),
+    ///         Entity::new_no_attrs(acme.clone(), HashSet::new()),
+    ///     ],
+    ///     None,
+    /// )
+    /// .unwrap();
+    /// assert!(entities.is_ancestor_of(&acme, &alice));
+    /// ```
+    pub fn from_entities_unchecked(
+        entities: impl IntoIterator<Item = Entity>,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        cedar_policy_core::entities::Entities::from_entities(
+            entities.into_iter().map(|e| e.0),
+            schema
+                .map(|s| cedar_policy_core::validator::CoreSchema::new(&s.0))
+                .as_ref(),
+            cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
+            Extensions::all_available(),
+        )
+        .map(Entities)
+    }
+
     /// Add all of the [`Entity`]s in the collection to this [`Entities`]
     /// structure, re-computing the transitive closure.
     ///
@@ -583,6 +646,46 @@ impl Entities {
                     .map(|s| cedar_policy_core::validator::CoreSchema::new(&s.0))
                     .as_ref(),
                 cedar_policy_core::entities::TCComputation::ComputeNow,
+                Extensions::all_available(),
+            )?,
+        ))
+    }
+
+    /// Updates or adds all of the [`Entity`]s in the collection to this [`Entities`]
+    /// structure, without re-computing the transitive closure.
+    ///
+    /// The caller is responsible for ensuring that the resulting entities still
+    /// form a DAG and are transitively closed; that is, each added entity's
+    /// `parents` must already contain all of its transitive ancestors. Nothing
+    /// is verified, and violating this yields an `Entities` whose `in` and
+    /// ancestor queries are incorrect. This method is only safe on an
+    /// `Entities` whose transitive closure was supplied entirely by the caller
+    /// (for instance, one built with [`Entities::from_entities_unchecked`]):
+    /// when it replaces an existing entity, ancestors that were previously
+    /// computed for that entity's descendants are dropped and not re-computed.
+    /// If you do not maintain the transitive closure yourself, prefer
+    /// [`Entities::upsert_entities`], which re-computes it.
+    ///
+    /// If a `schema` is provided, this method will ensure that the added
+    /// entities fully conform to the schema -- for instance, it will error if
+    /// attributes have the wrong types (e.g., string instead of integer), or if
+    /// required attributes are missing or superfluous attributes are provided.
+    /// (This method will not add action entities from the `schema`.)
+    /// ## Errors
+    /// - [`EntitiesError::InvalidEntity`] if `schema` is not none and any entities do not conform
+    ///   to the schema
+    pub fn upsert_entities_unchecked(
+        self,
+        entities: impl IntoIterator<Item = Entity>,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        Ok(Self(
+            self.0.upsert_entities(
+                entities.into_iter().map(|e| Arc::new(e.0)),
+                schema
+                    .map(|s| cedar_policy_core::validator::CoreSchema::new(&s.0))
+                    .as_ref(),
+                cedar_policy_core::entities::TCComputation::AssumeAlreadyComputed,
                 Extensions::all_available(),
             )?,
         ))

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -9413,9 +9413,13 @@ mod to_json {
 mod test_entities_api {
     use std::collections::HashSet;
 
+    use cool_asserts::assert_matches;
+
+    use super::entities::err::EntitiesError;
     use super::Entities;
     use super::Entity;
     use super::EntityUid;
+    use super::{Authorizer, Context, Decision, PolicySet, Request, Schema};
 
     #[test]
     fn test_upsert_entities() {
@@ -9437,6 +9441,152 @@ mod test_entities_api {
         entities = entities.upsert_entities(vec![e1_updated], None).unwrap();
         assert_eq!(entities.len(), 2);
         assert!(entities.is_ancestor_of(&e2_uid, &e1_uid));
+    }
+
+    /// Three-level hierarchy `alice -> admins -> acme`. `closed` lists `acme`
+    /// directly on `alice`, as a caller maintaining its own transitive closure
+    /// would; `direct` lists only immediate parents.
+    fn hierarchy(closed: bool) -> Vec<Entity> {
+        let alice_parents = if closed {
+            HashSet::from([admins(), acme()])
+        } else {
+            HashSet::from([admins()])
+        };
+        vec![
+            Entity::new_no_attrs(alice(), alice_parents),
+            Entity::new_no_attrs(admins(), HashSet::from([acme()])),
+            Entity::new_no_attrs(acme(), HashSet::new()),
+        ]
+    }
+
+    fn alice() -> EntityUid {
+        EntityUid::from_strs("User", "alice")
+    }
+
+    fn admins() -> EntityUid {
+        EntityUid::from_strs("Group", "admins")
+    }
+
+    fn acme() -> EntityUid {
+        EntityUid::from_strs("Org", "acme")
+    }
+
+    fn alice_in_acme(entities: &Entities) -> Decision {
+        let pset: PolicySet =
+            r#"permit(principal, action, resource) when { principal in Org::"acme" };"#
+                .parse()
+                .unwrap();
+        let request = Request::new(
+            alice(),
+            EntityUid::from_strs("Action", "view"),
+            EntityUid::from_strs("Doc", "readme"),
+            Context::empty(),
+            None,
+        )
+        .unwrap();
+        Authorizer::new()
+            .is_authorized(&request, &pset, entities)
+            .decision()
+    }
+
+    /// The unchecked constructor trusts whatever ancestors the caller supplies:
+    /// a pre-closed hierarchy authorizes exactly like the checked one, while a
+    /// parents-only hierarchy is left non-closed rather than repaired.
+    #[test]
+    fn from_entities_unchecked_uses_provided_closure() {
+        let closed = Entities::from_entities_unchecked(hierarchy(true), None).unwrap();
+        assert!(closed.is_ancestor_of(&acme(), &alice()));
+        assert_eq!(alice_in_acme(&closed), Decision::Allow);
+        assert!(closed.deep_eq(&Entities::from_entities(hierarchy(true), None).unwrap()));
+
+        let direct = Entities::from_entities_unchecked(hierarchy(false), None).unwrap();
+        assert!(direct.is_ancestor_of(&admins(), &alice()));
+        assert!(!direct.is_ancestor_of(&acme(), &alice()));
+        assert_eq!(alice_in_acme(&direct), Decision::Deny);
+
+        let checked = Entities::from_entities(hierarchy(false), None).unwrap();
+        assert!(checked.is_ancestor_of(&acme(), &alice()));
+        assert_eq!(alice_in_acme(&checked), Decision::Allow);
+    }
+
+    #[test]
+    fn from_entities_unchecked_skips_cycle_detection() {
+        let cycle = || {
+            vec![
+                Entity::new_no_attrs(alice(), HashSet::from([admins()])),
+                Entity::new_no_attrs(admins(), HashSet::from([alice()])),
+            ]
+        };
+        assert_matches!(
+            Entities::from_entities(cycle(), None),
+            Err(EntitiesError::TransitiveClosureError(_))
+        );
+        assert_matches!(Entities::from_entities_unchecked(cycle(), None), Ok(_));
+    }
+
+    #[test]
+    fn from_entities_unchecked_still_rejects_duplicates() {
+        let duplicates = vec![
+            Entity::new_no_attrs(alice(), HashSet::new()),
+            Entity::new_no_attrs(alice(), HashSet::from([admins()])),
+        ];
+        assert_matches!(
+            Entities::from_entities_unchecked(duplicates, None),
+            Err(EntitiesError::Duplicate(_))
+        );
+    }
+
+    #[test]
+    fn from_entities_unchecked_still_applies_schema() {
+        let (schema, _) = Schema::from_cedarschema_str(
+            r#"
+            entity User;
+            action view appliesTo { principal: [User], resource: [User] };
+            "#,
+        )
+        .unwrap();
+        let entities = Entities::from_entities_unchecked(
+            [Entity::new_no_attrs(alice(), HashSet::new())],
+            Some(&schema),
+        )
+        .unwrap();
+        assert!(entities
+            .get(&EntityUid::from_strs("Action", "view"))
+            .is_some());
+
+        let undeclared =
+            Entity::new_no_attrs(EntityUid::from_strs("Manager", "jane"), HashSet::new());
+        assert_matches!(
+            Entities::from_entities_unchecked([undeclared], Some(&schema)),
+            Err(EntitiesError::InvalidEntity(_))
+        );
+    }
+
+    #[test]
+    fn upsert_entities_unchecked_skips_tc() {
+        let entities = Entities::from_entities(
+            [
+                Entity::new_no_attrs(alice(), HashSet::new()),
+                Entity::new_no_attrs(admins(), HashSet::from([acme()])),
+                Entity::new_no_attrs(acme(), HashSet::new()),
+            ],
+            None,
+        )
+        .unwrap();
+        assert!(!entities.is_ancestor_of(&admins(), &alice()));
+
+        // Moving `alice` under `admins` without the closure leaves `acme` unreachable.
+        let moved = Entity::new_no_attrs(alice(), HashSet::from([admins()]));
+        let unchecked = entities
+            .clone()
+            .upsert_entities_unchecked([moved.clone()], None)
+            .unwrap();
+        assert_eq!(unchecked.len(), 3);
+        assert!(unchecked.is_ancestor_of(&admins(), &alice()));
+        assert!(!unchecked.is_ancestor_of(&acme(), &alice()));
+
+        let checked = entities.upsert_entities([moved], None).unwrap();
+        assert!(checked.is_ancestor_of(&acme(), &alice()));
     }
 }
 


### PR DESCRIPTION
## Description of changes

Motivation: callers that keep a large pre-loaded entity graph in memory and already maintain its closure themselves can avoid paying to recompute it on every construction or update. This follows the `Entities::decode_unchecked` precedent from #2387. No changes to `cedar-policy-core`; the `AssumeAlreadyComputed` mode already existed there.

Adds `Entities::from_entities_unchecked` and `Entities::upsert_entities_unchecked` to the `cedar-policy` crate. They mirror `from_entities` and `upsert_entities` exactly, except that they pass `TCComputation::AssumeAlreadyComputed` to the core layer instead of `ComputeNow`, so the transitive closure of the entity hierarchy is neither computed nor checked. The caller must supply a hierarchy that is already acyclic and transitively closed (every ancestor listed in each entity's `parents`).

Everything else the checked constructors do still applies: duplicate detection, schema conformance checking, and adding `Action` entities from the schema in `from_entities_unchecked`. Only transitive closure computation and cycle detection are skipped.

## Issue #, if available

Resolves #2378

## Checklist for requesting a review

The change in this PR is:

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/):

- [x] Does not require updates because my change does not impact the Cedar language specification.
