### PR TITLE
Making sure variadic ipaddr rejects isInRange with no arguments before typechecking

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -156,7 +156,7 @@ pub struct ExtensionFunction {
     /// The argument types that this function expects, as `SchemaType`s.
     arg_types: Vec<SchemaType>,
     /// Whether this is a variadic function or not. If it is a variadic function it can accept 1 or more arguments
-    /// of the last argument type.
+    /// of the last argument type, in addition to the first argument, for a total of 2 or more arguments.
     is_variadic: bool,
 }
 
@@ -324,8 +324,11 @@ impl ExtensionFunction {
             name.clone(),
             style,
             Box::new(move |args: &[Value]| match &args {
+                // A variadic function takes two or more arguments, so `rest` must be
+                // non-empty. This keeps the evaluator in agreement with the validator,
+                // which requires `args.len() >= arg_types.len()`, i.e. at least 2.
                 #[cfg(feature = "variadic-is-in-range")]
-                &[first, rest @ ..] => func(first, rest),
+                &[first, rest @ ..] if !rest.is_empty() => func(first, rest),
                 #[cfg(not(feature = "variadic-is-in-range"))]
                 &[first, second] => func(first, std::slice::from_ref(second)),
                 _ => Err(evaluator::EvaluationError::wrong_num_arguments(

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -1187,11 +1187,31 @@ mod tests {
             ],
         )));
 
-        // Requires at least one argument.
+        // Requires at least two arguments: the target plus at least one range.
         assert_ipaddr_wrong_num_args_err(
             eval.interpret_inline_policy(&Expr::call_extension_fn(
                 Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
                 vec![],
+            )),
+            "isInRange",
+        );
+
+        // A target with no ranges is an arity error, not `false`. `x.isInRange()` parses,
+        // so this is reachable when evaluating a policy that has not been validated.
+        assert_ipaddr_wrong_num_args_err(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![ip("192.168.0.1")],
+            )),
+            "isInRange",
+        );
+
+        // The arity check happens before the arguments are converted, so a single
+        // non-ipaddr argument is still an arity error rather than a type error.
+        assert_ipaddr_wrong_num_args_err(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![Expr::val("192.168.0.1")],
             )),
             "isInRange",
         );

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -1471,4 +1471,21 @@ mod datetime_tests {
             false,
         );
     }
+
+    // `isInRange` needs a target plus at least one range. Fewer arguments than that
+    // must not compile, matching the arity error the evaluator raises.
+    #[test]
+    #[cfg(feature = "variadic-is-in-range")]
+    fn test_ipaddr_variadic_is_in_range_requires_a_range() {
+        let is_in_range =
+            Name::parse_unqualified_name("isInRange").expect("should be a valid identifier");
+        for args in [vec![], vec![parse_expr(r#"ip("192.168.0.1")"#)]] {
+            let expr = Expr::call_extension_fn(is_in_range.clone(), args);
+            assert_matches!(
+                compile(&expr, &datetime_sym_env()),
+                Err(CompileError::TypeError),
+                "{expr}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Description of changes

Before this commit if the `variadic-is-in-range` feature flag was enabled only typechecking would detect calls to `isInRange()` without any arguments. This means that if we evaluated `ip.isInRange()` without validation it would just fold to `false`. This change ensures consistent behavior with the non-variadic version.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
