### PR TITLE
Fix batched TPE action seeding and loop exit

### DIFF
--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -30,8 +30,7 @@ use crate::tpe::entities::PartialEntity;
 use crate::tpe::err::PartialRequestError;
 use crate::tpe::policy_residual_map;
 use crate::tpe::request::{PartialEntityUID, PartialRequest};
-use crate::tpe::residual::Residual;
-use crate::tpe::response::{ResidualPolicy, Response};
+use crate::tpe::response::{decision_from_residuals, ResidualPolicy, Response};
 use crate::validator::ValidatorSchema;
 use crate::{ast::PolicySet, extensions::Extensions};
 
@@ -92,7 +91,8 @@ pub fn is_authorized_batched(
     max_iters: u32,
 ) -> Result<Decision, BatchedEvalError> {
     let request = concrete_request_to_partial(request, schema)?;
-    let mut entities = PartialEntities::default();
+    // Actions comes from the schema, so batched eval can start with them
+    let mut entities = PartialEntities::from_entities(iter::empty(), schema)?;
     let initial_evaluator = Evaluator {
         request: &request,
         entities: &entities,
@@ -111,6 +111,11 @@ pub fn is_authorized_batched(
         .collect();
 
     for _i in 0..max_iters {
+        if decision_from_residuals(&residuals).is_some() {
+            // Exit before `max_iters` if we reach a decision
+            break;
+        }
+
         let ids = residuals.iter().flat_map(|r| r.all_literal_uids());
         let mut to_load = HashSet::new();
         // filter to_load for already loaded entities
@@ -162,14 +167,6 @@ pub fn is_authorized_batched(
                 )
             })
             .collect();
-
-        // if all the residuals are done, exit
-        if residuals
-            .iter()
-            .all(|r| !matches!(*(r.get_residual()), Residual::Partial { .. }))
-        {
-            break;
-        }
     }
 
     let response = Response::new(residuals.into_iter(), &request, &entities, schema);
@@ -177,5 +174,78 @@ pub fn is_authorized_batched(
     match response.decision() {
         Some(decision) => Ok(decision),
         None => Err(InsufficientIterationsError {}.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Context, RequestSchemaAllPass};
+    use crate::extensions::Extensions;
+    use crate::parser::parse_policyset;
+
+    struct Loader {
+        requested: Vec<EntityUID>,
+    }
+
+    impl EntityLoader for Loader {
+        fn load_entities(
+            &mut self,
+            uids: &HashSet<EntityUID>,
+        ) -> HashMap<EntityUID, Option<Entity>> {
+            self.requested.extend(uids.iter().cloned());
+            uids.iter().map(|u| (u.clone(), None)).collect()
+        }
+    }
+
+    #[track_caller]
+    fn run(policies: &str) -> (Decision, Loader) {
+        let schema = ValidatorSchema::from_cedarschema_str(
+            r#"
+            entity User { level: Long };
+            entity Document;
+            action all;
+            action read in [all] appliesTo { principal: [User], resource: [Document] };
+            "#,
+            Extensions::all_available(),
+        )
+        .expect("schema should parse")
+        .0;
+        let request = Request::new(
+            (r#"User::"alice""#.parse().expect("uid should parse"), None),
+            (r#"Action::"read""#.parse().expect("uid should parse"), None),
+            (
+                r#"Document::"doc""#.parse().expect("uid should parse"),
+                None,
+            ),
+            Context::empty(),
+            Some(&RequestSchemaAllPass {}),
+            Extensions::all_available(),
+        )
+        .expect("request should be valid");
+        let ps = parse_policyset(policies).expect("policies should parse");
+        let mut loader = Loader {
+            requested: Vec::new(),
+        };
+        let decision = is_authorized_batched(&request, &ps, &schema, &mut loader, 3)
+            .expect("should reach a decision");
+        (decision, loader)
+    }
+
+    #[test]
+    fn actions_are_seeded_from_the_schema() {
+        let (decision, loader) = run(r#"permit(principal, action in Action::"all", resource);"#);
+        assert_eq!(decision, Decision::Allow);
+        assert_eq!(loader.requested, vec![]);
+    }
+
+    #[test]
+    fn nothing_is_loaded_once_the_decision_is_determined() {
+        let (decision, loader) = run(r#"
+            forbid(principal, action, resource);
+            permit(principal, action, resource) when { principal.level > 5 };
+            "#);
+        assert_eq!(decision, Decision::Deny);
+        assert_eq!(loader.requested, vec![]);
     }
 }

--- a/cedar-policy-core/src/batched_evaluator/err.rs
+++ b/cedar-policy-core/src/batched_evaluator/err.rs
@@ -19,7 +19,7 @@
 use thiserror::Error;
 
 use crate::ast::PartialValueToValueError;
-use crate::tpe::err::{EntitiesError, MissingEntitiesError, PartialRequestError, TpeError};
+use crate::tpe::err::{EntitiesError, PartialRequestError, TpeError};
 use crate::validator::RequestValidationError;
 
 /// Errors for Batched Evaluation
@@ -41,9 +41,6 @@ pub enum BatchedEvalError {
     /// Error thrown when a entity loader provided entity was partial instead of fully concrete
     #[error(transparent)]
     PartialValueToValue(#[from] PartialValueToValueError),
-    /// Error the entity loader failed to load all requested entities
-    #[error(transparent)]
-    MissingEntities(#[from] MissingEntitiesError),
     /// Error when batched evaluation did not converge due to the iteration limit
     #[error(transparent)]
     InsufficientIterations(#[from] InsufficientIterationsError),

--- a/cedar-policy-core/src/tpe/err.rs
+++ b/cedar-policy-core/src/tpe/err.rs
@@ -377,20 +377,6 @@ pub struct UnknownEntityError {
     pub(super) uid: EntityUID,
 }
 
-/// Error thrown when some requested entities were not loaded
-#[derive(Debug, Error, Diagnostic)]
-#[error("failed to load entities: {}", .missing_entities.iter().map(|uid| uid.to_string()).collect::<Vec<_>>().join(", "))]
-pub struct MissingEntitiesError {
-    pub(super) missing_entities: Vec<EntityUID>,
-}
-
-impl MissingEntitiesError {
-    /// Construct a new [`MissingEntitiesError`]
-    pub fn new(missing_entities: Vec<EntityUID>) -> Self {
-        Self { missing_entities }
-    }
-}
-
 /// Error thrown when a [`crate::tpe::request::PartialRequest`] is inconsistent with a [`crate::ast::Request`]
 #[derive(Debug, Error, Diagnostic)]
 pub enum RequestConsistencyError {

--- a/cedar-policy-core/src/tpe/response.rs
+++ b/cedar-policy-core/src/tpe/response.rs
@@ -58,6 +58,11 @@ impl ResidualPolicy {
         self.residual.clone()
     }
 
+    /// Get a reference to the [`Residual`]
+    pub fn as_residual(&self) -> &Residual {
+        &self.residual
+    }
+
     /// Get the [`PolicyID`]
     pub fn get_policy_id(&self) -> &PolicyID {
         self.policy.id()
@@ -79,6 +84,52 @@ impl From<ResidualPolicy> for Policy {
             value.policy.annotations_arc().clone(),
         )
     }
+}
+
+fn decide(
+    true_forbids: bool,
+    true_permits: bool,
+    residual_permits: bool,
+    residual_forbids: bool,
+) -> Option<Decision> {
+    match (
+        true_forbids,
+        true_permits,
+        residual_permits,
+        residual_forbids,
+    ) {
+        // Any true forbids means we will deny
+        (true, _, _, _) => Some(Decision::Deny),
+        // No potentially or trivially true permits, means we default deny
+        (_, false, false, _) => Some(Decision::Deny),
+        // Potentially true forbids, means we can't know (as that forbid may evaluate to true, overriding any permits)
+        (false, _, _, true) => None,
+        // No true permits, but some potentially true permits + no true/potentially true forbids means we don't know
+        (false, false, true, false) => None,
+        // At least one trivially true permit, and no trivially or possible true forbids, means we allow
+        (false, true, _, false) => Some(Decision::Allow),
+    }
+}
+
+/// The decision a set of residuals determines, if any, without building a whole [`Response`].
+pub(crate) fn decision_from_residuals(residuals: &[ResidualPolicy]) -> Option<Decision> {
+    let mut true_forbid = false;
+    let mut true_permit = false;
+    let mut residual_forbid = false;
+    let mut residual_permit = false;
+    for rp in residuals {
+        match rp.get_effect() {
+            Effect::Forbid => {
+                true_forbid = true_forbid || rp.as_residual().is_true();
+                residual_forbid = residual_forbid || rp.as_residual().is_partial();
+            }
+            Effect::Permit => {
+                true_permit = true_permit || rp.as_residual().is_true();
+                residual_permit = residual_permit || rp.as_residual().is_partial();
+            }
+        }
+    }
+    decide(true_forbid, true_permit, residual_permit, residual_forbid)
 }
 
 /// The result of partial authorization.
@@ -159,23 +210,12 @@ impl<'a> Response<'a> {
             }
         }
 
-        let decision = match (
+        let decision = decide(
             !true_forbids.is_empty(),
             !true_permits.is_empty(),
             !residual_permits.is_empty(),
             !residual_forbids.is_empty(),
-        ) {
-            // Any true forbids means we will deny
-            (true, _, _, _) => Some(Decision::Deny),
-            // No potentially or trivially true permits, means we default deny
-            (_, false, false, _) => Some(Decision::Deny),
-            // Potentially true forbids, means we can't know (as that forbid may evaluate to true, overriding any permits)
-            (false, _, _, true) => None,
-            // No true permits, but some potentially true permits + no true/potentially true forbids means we don't know
-            (false, false, true, false) => None,
-            // At least one trivially true permit, and no trivially or possible true forbids, means we allow
-            (false, true, _, false) => Some(Decision::Allow),
-        };
+        );
 
         Self {
             decision,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,10 @@ Cedar Language Version: TBD
   cannot apply to any request. This change makes it possible to remove entries from an `appliesTo` list
   without introducing validation errors. Callers that want to keep rejecting these policies should check
   `ValidationResult::validation_warnings` for `ValidationWarning::InvalidActionApplication`.
+- For the `tpe` experimental feature,  `is_authorized_batched` now automatically loads actions
+  entities from the schema, and will now return immediately on reaching a concrete authorization decision.
+- For the `tpe` experimental feature, removed the `BatchedEvalError::MissingEntities` error variant
+  which was never constructed.
 
 
 ### Fixed


### PR DESCRIPTION
- Start batched evaluation from the schema's action entities, matching the behavior added to the Lean model in https://github.com/cedar-policy/cedar-spec/pull/1017
- Stop the loop once a decision is determined, fixing Rust to match the current behavior of the Lean model. Rust previously stopped when all policies reached concrete value, so, e.g., it would continue looping and loading entities even if it immediately satisfied a forbid policy. 
- Delete `MissingEntitiesError`, which was never constructed.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
