### PR TITLE
Allow valid partial action entities to leave components unknown

### DIFF
--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -25,8 +25,7 @@ use crate::tpe::err::{
     AncestorValidationError, EntitiesConsistencyError, EntitiesError, EntityConsistencyError,
     EntityValidationError, JsonDeserializationError, MismatchedActionAncestorsError,
     MismatchedAncestorError, MismatchedAttributeError, MismatchedTagError, MissingEntityError,
-    UnexpectedActionError, UnknownActionComponentError, UnknownAttributeError, UnknownEntityError,
-    UnknownTagError,
+    UnexpectedActionError, UnknownAttributeError, UnknownEntityError, UnknownTagError,
 };
 use crate::transitive_closure::{enforce_tc_and_dag, TcError};
 use crate::validator::{
@@ -343,12 +342,6 @@ impl PartialEntity {
         let etype = uid.entity_type();
 
         if self.uid.is_action() {
-            if self.attrs.is_none() || self.tags.is_none() {
-                return Err(UnknownActionComponentError {
-                    action: uid.clone(),
-                }
-                .into());
-            }
             if let Some(attrs) = &self.attrs {
                 if let Some((attr, _)) = attrs.first_key_value() {
                     return Err(EntitySchemaConformanceError::unexpected_entity_attr(
@@ -377,11 +370,6 @@ impl PartialEntity {
                         }
                         .into());
                     }
-                } else {
-                    return Err(UnknownActionComponentError {
-                        action: uid.clone(),
-                    }
-                    .into());
                 }
             } else {
                 return Err(EntitySchemaConformanceError::UndeclaredAction(
@@ -923,9 +911,7 @@ mod tests {
 mod test_validate {
     use super::*;
     use crate::entities::conformance::err::EntitySchemaConformanceError;
-    use crate::tpe::err::{
-        EntityValidationError, MismatchedActionAncestorsError, UnknownActionComponentError,
-    };
+    use crate::tpe::err::{EntityValidationError, MismatchedActionAncestorsError};
     use cool_asserts::assert_matches;
 
     fn test_schema() -> ValidatorSchema {
@@ -978,7 +964,7 @@ mod test_validate {
     }
 
     #[test]
-    fn invalid_action_with_unknown_ancestors() {
+    fn valid_action_with_unknown_ancestors() {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
@@ -987,16 +973,11 @@ mod test_validate {
             tags: Some(BTreeMap::new()),
         };
 
-        assert_matches!(
-            action.validate(&schema),
-            Err(EntityValidationError::UnknownActionComponent(
-                UnknownActionComponentError { .. }
-            ))
-        );
+        assert_matches!(action.validate(&schema), Ok(()));
     }
 
     #[test]
-    fn invalid_action_with_unknown_tags() {
+    fn valid_action_with_unknown_tags() {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
@@ -1005,16 +986,11 @@ mod test_validate {
             tags: None,
         };
 
-        assert_matches!(
-            action.validate(&schema),
-            Err(EntityValidationError::UnknownActionComponent(
-                UnknownActionComponentError { .. }
-            ))
-        );
+        assert_matches!(action.validate(&schema), Ok(()));
     }
 
     #[test]
-    fn invalid_action_with_unknown_attrs() {
+    fn valid_action_with_unknown_attrs() {
         let schema = test_schema();
         let action = PartialEntity {
             uid: "Action::\"view\"".parse().unwrap(),
@@ -1023,12 +999,7 @@ mod test_validate {
             tags: Some(BTreeMap::new()),
         };
 
-        assert_matches!(
-            action.validate(&schema),
-            Err(EntityValidationError::UnknownActionComponent(
-                UnknownActionComponentError { .. }
-            ))
-        );
+        assert_matches!(action.validate(&schema), Ok(()));
     }
 
     #[test]

--- a/cedar-policy-core/src/tpe/err.rs
+++ b/cedar-policy-core/src/tpe/err.rs
@@ -61,21 +61,10 @@ pub enum EntityValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Concrete(#[from] EntitySchemaConformanceError),
-    /// Error thrown when an action component is unknown
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    UnknownActionComponent(#[from] UnknownActionComponentError),
     /// Error thrown when an action's ancestors do not match the schema
     #[error(transparent)]
     #[diagnostic(transparent)]
     MismatchedActionAncestors(#[from] MismatchedActionAncestorsError),
-}
-
-/// Error thrown when an action has unknown ancestors/attrs/tags
-#[derive(Debug, Error, Diagnostic)]
-#[error("action `{}` has unknown ancestors/attrs/tags", .action)]
-pub struct UnknownActionComponentError {
-    pub(super) action: EntityUID,
 }
 
 /// Error thrown when an action's ancestors do not match the schema

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -28,6 +28,7 @@ Cedar Language Version: TBD
 - Fixed `Policy::try_into_pst()` and `Template::try_into_pst()` to preserve policy IDs for text- and JSON-backed values, restoring `PolicySet::try_into_pst()` / `PolicySet::from_pst()` round trips.
 - In the experimental `protobufs` feature, the `Schema::decode` function now accepts schemas that reference `Action` entity types not defined in the schema. This was previously  rejected (#2491).
 - For the experimental `tpe` feature, fixed `TpeResponse::policy_set` to return the residual policies, matching `TpeResponse::policies` as documented. Previously it returned the original policies (#2540).
+- For the experimental `tpe` feature, partial entity validation now accept action entities with unknown components. The `UnknownActionComponent` is now never returned and is deleted.
 
 ## [4.12.0] - 2026-07-28
 


### PR DESCRIPTION
Fixes Rust to match the behavior of `actionEntityIsValid` in the Lean model

`UnknownActionComponentError` is now never returned, so this error variant is deleted.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
