### PR TITLE
Optimize TPE by evaluating residual policies as they are constructed

### DIFF
--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -28,8 +28,8 @@ use crate::batched_evaluator::err::{BatchedEvalError, InsufficientIterationsErro
 use crate::entities::TCComputation;
 use crate::tpe::entities::PartialEntity;
 use crate::tpe::err::PartialRequestError;
-use crate::tpe::policy_residual_map;
 use crate::tpe::request::{PartialEntityUID, PartialRequest};
+use crate::tpe::residual_policies;
 use crate::tpe::response::{decision_from_residuals, ResidualPolicy, Response};
 use crate::validator::ValidatorSchema;
 use crate::{ast::PolicySet, extensions::Extensions};
@@ -98,17 +98,7 @@ pub fn is_authorized_batched(
         entities: &entities,
         extensions: Extensions::all_available(),
     };
-    let mut residuals: Vec<ResidualPolicy> = policy_residual_map(&request, ps, schema)?
-        .into_iter()
-        .map(|(id, expr)| {
-            let residual = initial_evaluator.interpret(&expr);
-            #[expect(
-                clippy::unwrap_used,
-                reason = "exprs and policy set contain the same policy ids"
-            )]
-            ResidualPolicy::new(Arc::new(residual), Arc::new(ps.get(id).unwrap().clone()))
-        })
-        .collect();
+    let mut residuals = residual_policies(&request, ps, schema, &initial_evaluator)?;
 
     for _i in 0..max_iters {
         if decision_from_residuals(&residuals).is_some() {

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -26,9 +26,8 @@ pub mod response;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
-use crate::ast::PolicyID;
 use crate::tpe::err::{PolicyValidationError, TpeError};
 use crate::tpe::residual::Residual;
 use crate::tpe::response::{ResidualPolicy, Response};
@@ -38,12 +37,14 @@ use crate::{ast::PolicySet, extensions::Extensions};
 
 use crate::tpe::{entities::PartialEntities, evaluator::Evaluator, request::PartialRequest};
 
-pub(crate) fn policy_residual_map<'a>(
-    request: &'a PartialRequest,
-    ps: &'a PolicySet,
+/// Typecheck each policy in `ps` and partially evaluate it against `request`
+pub(crate) fn residual_policies(
+    request: &PartialRequest,
+    ps: &PolicySet,
     schema: &ValidatorSchema,
-) -> std::result::Result<HashMap<&'a PolicyID, Residual>, TpeError> {
-    let mut residuals = HashMap::new();
+    evaluator: &Evaluator<'_>,
+) -> std::result::Result<Vec<ResidualPolicy>, TpeError> {
+    let mut residuals = Vec::new();
     let tc = Typechecker::new(schema, crate::validator::ValidationMode::Strict);
     let env = request.find_request_env(schema)?;
     for p in ps.policies() {
@@ -57,21 +58,15 @@ pub(crate) fn policy_residual_map<'a>(
         // Get an environment using the actual types of the entities linked with
         // this template. If static, the slot env is empty and this is a no-op.
         let env = env.clone().link_slot_env(p.env());
-        match tc.typecheck_by_single_request_env(t, &env) {
-            PolicyCheck::Success(expr) => {
-                residuals.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
-            }
-            PolicyCheck::Fail(errs) => {
+        let expr = match tc.typecheck_by_single_request_env(t, &env) {
+            PolicyCheck::Success(expr) => expr,
+            PolicyCheck::Irrelevant(errs, expr) if errs.is_empty() => expr,
+            PolicyCheck::Fail(errs) | PolicyCheck::Irrelevant(errs, _) => {
                 return Err(PolicyValidationError::new(errs).into());
             }
-            PolicyCheck::Irrelevant(errs, expr) => {
-                if errs.is_empty() {
-                    residuals.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
-                } else {
-                    return Err(PolicyValidationError::new(errs).into());
-                }
-            }
-        }
+        };
+        let residual = evaluator.interpret(&Residual::try_from_typed_expr(&expr, p.env())?);
+        residuals.push(ResidualPolicy::new(Arc::new(residual), Arc::new(p.clone())));
     }
     Ok(residuals)
 }
@@ -91,18 +86,14 @@ pub fn is_authorized<'a>(
         entities,
         extensions: Extensions::all_available(),
     };
-    let residuals = policy_residual_map(request, ps, schema)?
-        .into_iter()
-        .map(|(id, residual)| {
-            let residual = evaluator.interpret(&residual);
-            #[expect(
-                clippy::unwrap_used,
-                reason = "exprs and policy set contain the same policy ids"
-            )]
-            ResidualPolicy::new(Arc::new(residual), Arc::new(ps.get(id).unwrap().clone()))
-        });
+    let residuals = residual_policies(request, ps, schema, &evaluator)?;
 
-    Ok(Response::new(residuals, request, entities, schema))
+    Ok(Response::new(
+        residuals.into_iter(),
+        request,
+        entities,
+        schema,
+    ))
 }
 
 #[cfg(test)]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -26,6 +26,8 @@ Cedar Language Version: TBD
   entities from the schema, and will now return immediately on reaching a concrete authorization decision.
 - For the `tpe` experimental feature, removed the `BatchedEvalError::MissingEntities` error variant
   which was never constructed.
+- For the `tpe` experimental feature, `PolicySet::tpe` is faster on large policy sets
+  (~1.4x on a 25,000-policy set).
 
 
 ### Fixed


### PR DESCRIPTION
The current implementation first builds a map containing the residual representations of all policies, and only then evaluates each policy. For a large policy set this could mean allocating a very large intermediate collection which we avoid with the change in this PR. Roughly measured as a ~1.4x speed up on very large policy sets. 

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
